### PR TITLE
AFHMM+SAC: prevent disaggregation thread from failing when the CVX solver does not find any constraint

### DIFF
--- a/nilmtk_contrib/disaggregate/afhmm_sac.py
+++ b/nilmtk_contrib/disaggregate/afhmm_sac.py
@@ -256,7 +256,11 @@ class AFHMM_SAC(Disaggregator):
                 prob = cvx.Problem(expression, constraints)
 
                 prob.solve(solver=cvx.SCS,verbose=False, warm_start=True)
-                s_ = [i.value for i in cvx_state_vectors]
+                s_ = [
+                    np.zeros((len(test_mains), self.default_num_states)) if i.value is None
+                    else i.value
+                    for i in cvx_state_vectors
+                ]
 
         prediction_dict = {}
         for appliance_id in range(self.num_appliances):


### PR DESCRIPTION
Fixes: https://github.com/nilmtk/nilmtk-contrib/issues/40