### PR TITLE
Enforce shared model runtime contracts

### DIFF
--- a/nilmtk_contrib/torch/TCN.py
+++ b/nilmtk_contrib/torch/TCN.py
@@ -6,6 +6,7 @@ import torch.nn as nn
 from torch.utils.data import TensorDataset, DataLoader
 from nilmtk.disaggregate import Disaggregator
 
+from nilmtk_contrib.utils.checkpoints import load_torch_state
 from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
 
 logger = module_logger(__name__)
@@ -105,10 +106,10 @@ class TemporalBlock(nn.Module):
         self.relu = nn.ReLU()
         
         # Weight normalization for stability
-        self.conv1 = nn.utils.weight_norm(self.conv1)
-        self.conv2 = nn.utils.weight_norm(self.conv2)
+        self.conv1 = nn.utils.parametrizations.weight_norm(self.conv1)
+        self.conv2 = nn.utils.parametrizations.weight_norm(self.conv2)
         if self.downsample is not None:
-            self.downsample = nn.utils.weight_norm(self.downsample)
+            self.downsample = nn.utils.parametrizations.weight_norm(self.downsample)
         
         self.init_weights()
     
@@ -380,7 +381,7 @@ class TCN(Disaggregator):
                             _log_print(f"Validation loss improved, saving model to {filepath}")
                     
                     # Load the best weights after training
-                    model.load_state_dict(torch.load(filepath, map_location=self.device))
+                    load_torch_state(model, filepath, self.device)
 
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """Disaggregates a chunk of mains data."""

--- a/nilmtk_contrib/torch/WindowGRU.py
+++ b/nilmtk_contrib/torch/WindowGRU.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 from nilmtk.disaggregate import Disaggregator
 
+from nilmtk_contrib.utils.checkpoints import load_torch_state
 from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
 
 logger = module_logger(__name__)
@@ -260,7 +261,7 @@ class WindowGRU(Disaggregator):
                     _log_print(f'Epoch {epoch+1}/{self.n_epochs} - loss: {train_loss:.4f} - val_loss: {val_loss:.4f}')
                 
             # Load best weights (like TF version)
-            model.load_state_dict(torch.load(filepath))
+            load_torch_state(model, filepath, self.device)
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         if model is not None:
             self.models = model

--- a/nilmtk_contrib/torch/bert.py
+++ b/nilmtk_contrib/torch/bert.py
@@ -9,6 +9,7 @@ from nilmtk_contrib.utils.validation import safe_train_test_split as train_test_
 from nilmtk.disaggregate import Disaggregator
 from tqdm import tqdm  # Added for progress bars
 
+from nilmtk_contrib.utils.checkpoints import load_torch_state
 from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
 
 logger = module_logger(__name__)
@@ -291,7 +292,7 @@ class BERT(Disaggregator):
                                 _log_print(f'Epoch {epoch+1}/{self.n_epochs} - Train Loss: {train_loss:.4f}, Val Loss: {val_loss:.4f}')
                     
                     # Load best weights (like TF version)
-                    model.load_state_dict(torch.load(filepath))
+                    load_torch_state(model, filepath, self.device)
 
     # Remaining methods keep the legacy backend behavior.
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):

--- a/nilmtk_contrib/torch/conv_lstm.py
+++ b/nilmtk_contrib/torch/conv_lstm.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 from torch.utils.data import TensorDataset, DataLoader
 from nilmtk.disaggregate import Disaggregator
 
-
+from nilmtk_contrib.utils.checkpoints import load_torch_state
 from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
 
 logger = module_logger(__name__)
@@ -322,7 +322,7 @@ class ConvLSTM(Disaggregator):
                             _log_print(f"Validation loss improved, saving model to {filepath}")
                     
                     # Load best weights
-                    model.load_state_dict(torch.load(filepath, map_location=self.device))
+                    load_torch_state(model, filepath, self.device)
 
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """

--- a/nilmtk_contrib/torch/nilmformer.py
+++ b/nilmtk_contrib/torch/nilmformer.py
@@ -43,6 +43,7 @@ import torch.nn.functional as F
 from torch.utils.data import Dataset, DataLoader
 from tqdm import tqdm
 from nilmtk.disaggregate import Disaggregator
+from nilmtk_contrib.utils.checkpoints import load_torch_state
 from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
 
 logger = module_logger(__name__)
@@ -833,7 +834,7 @@ class NILMFormer(Disaggregator):
                     break
         
         # Load best model
-        model.load_state_dict(torch.load(best_model_path))
+        load_torch_state(model, best_model_path, self.device)
         model.eval()
         _log_print(f"Training completed for {appliance_name}")
 

--- a/nilmtk_contrib/torch/reformer.py
+++ b/nilmtk_contrib/torch/reformer.py
@@ -8,6 +8,7 @@ from torch.utils.data import TensorDataset, DataLoader
 import math
 from nilmtk.disaggregate import Disaggregator
 
+from nilmtk_contrib.utils.checkpoints import load_torch_state
 from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
 
 logger = module_logger(__name__)
@@ -540,7 +541,7 @@ class Reformer(Disaggregator):
                             _log_print(f"Validation loss improved, saving model to {filepath}")
                     
                     # Load best weights
-                    model.load_state_dict(torch.load(filepath, map_location=self.device))
+                    load_torch_state(model, filepath, self.device)
 
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """

--- a/nilmtk_contrib/torch/resnet_classification.py
+++ b/nilmtk_contrib/torch/resnet_classification.py
@@ -12,6 +12,7 @@ from nilmtk_contrib.utils.validation import safe_train_test_split as train_test_
 import copy
 
 # Set device
+from nilmtk_contrib.utils.checkpoints import load_torch_state
 from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
 from nilmtk_contrib.preprocessing.classification import (
     appliance_threshold,
@@ -476,7 +477,7 @@ class ResNet_classification(Disaggregator):
                             _log_print(f"Validation loss improved, saving model to {filepath}")
 
                     # Load best weights
-                    model.load_state_dict(torch.load(filepath, map_location=self.device))
+                    load_torch_state(model, filepath, self.device)
 
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """Disaggregates a chunk of mains data."""

--- a/nilmtk_contrib/torch/rnn.py
+++ b/nilmtk_contrib/torch/rnn.py
@@ -6,6 +6,7 @@ import torch
 import torch.nn as nn
 from torch.utils.data import TensorDataset, DataLoader
 
+from nilmtk_contrib.utils.checkpoints import load_torch_state
 from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
 
 logger = module_logger(__name__)
@@ -198,7 +199,7 @@ class RNN(Disaggregator):
                             _log_print(f'Epoch {epoch+1}/{self.n_epochs} - loss: {train_loss:.4f} - val_loss: {val_loss:.4f}')
                         
                     # Load the best performing model
-                    model.load_state_dict(torch.load(filepath))
+                    load_torch_state(model, filepath, self.device)
 
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """Disaggregates a chunk of mains data."""

--- a/nilmtk_contrib/torch/rnn_attention_classification.py
+++ b/nilmtk_contrib/torch/rnn_attention_classification.py
@@ -12,6 +12,7 @@ from nilmtk_contrib.utils.validation import safe_train_test_split as train_test_
 import copy
 
 # Set device
+from nilmtk_contrib.utils.checkpoints import load_torch_state
 from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
 from nilmtk_contrib.preprocessing.classification import (
     appliance_threshold,
@@ -455,7 +456,7 @@ class RNN_attention_classification(Disaggregator):
                             _log_print(f"Validation loss improved, saving model to {filepath}")
 
                     # Load the best performing model
-                    model.load_state_dict(torch.load(filepath, map_location=self.device))
+                    load_torch_state(model, filepath, self.device)
 
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """Disaggregates a chunk of mains data."""

--- a/nilmtk_contrib/torch/seq2point.py
+++ b/nilmtk_contrib/torch/seq2point.py
@@ -6,6 +6,7 @@ import torch.nn as nn
 from torch.utils.data import TensorDataset, DataLoader
 from nilmtk.disaggregate import Disaggregator
 
+from nilmtk_contrib.utils.checkpoints import load_torch_state
 from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
 
 logger = module_logger(__name__)
@@ -263,7 +264,7 @@ class Seq2PointTorch(Disaggregator):
                             _log_print(f"Validation loss improved, saving model to {filepath}")
                     
                     # Load the best performing model
-                    model.load_state_dict(torch.load(filepath, map_location=self.device))
+                    load_torch_state(model, filepath, self.device)
 
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """Disaggregates a chunk of mains data."""

--- a/nilmtk_contrib/torch/seq2seq.py
+++ b/nilmtk_contrib/torch/seq2seq.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from torch.utils.data import TensorDataset, DataLoader
 from nilmtk.disaggregate import Disaggregator
 
+from nilmtk_contrib.utils.checkpoints import load_torch_state
 from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
 
 logger = module_logger(__name__)
@@ -224,7 +225,7 @@ class Seq2Seq(Disaggregator):
                             _log_print(f'Epoch {epoch+1}/{self.n_epochs} - loss: {train_loss:.4f} - val_loss: {val_loss:.4f}')
                         
                     # Load the best performing model
-                    model.load_state_dict(torch.load(filepath))
+                    load_torch_state(model, filepath, self.device)
 
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """Disaggregates a chunk of mains data."""

--- a/nilmtk_contrib/utils/model.py
+++ b/nilmtk_contrib/utils/model.py
@@ -17,15 +17,27 @@ def _unsupported_load_model(self, *args, **kwargs):
     unsupported_persistence(model_name)
 
 
+def _needs_persistence_fallback(model, method_name):
+    method = getattr(model, method_name, None)
+    if not callable(method):
+        return True
+    function = getattr(method, "__func__", method)
+    return (
+        getattr(function, "__module__", "")
+        == "nilmtk.disaggregate.disaggregator"
+        and getattr(function, "__qualname__", "").startswith("Disaggregator.")
+    )
+
+
 def initialize_runtime(model, params, *, backends):
     """Attach common runtime controls to a model instance."""
     model.seed = params.get("seed", getattr(model, "seed", None))
     model.verbose = params.get("verbose", getattr(model, "verbose", False))
     configure_logging(model.verbose)
     set_random_seed(model.seed, backends=backends)
-    if not callable(getattr(model, "save_model", None)):
+    if _needs_persistence_fallback(model, "save_model"):
         model.save_model = MethodType(_unsupported_save_model, model)
-    if not callable(getattr(model, "load_model", None)):
+    if _needs_persistence_fallback(model, "load_model"):
         model.load_model = MethodType(_unsupported_load_model, model)
 
 

--- a/nilmtk_contrib/utils/params.py
+++ b/nilmtk_contrib/utils/params.py
@@ -1,6 +1,8 @@
 """Shared parameter parsing and validation helpers."""
 
 from dataclasses import dataclass
+import math
+from numbers import Integral, Real
 import warnings
 
 
@@ -61,35 +63,64 @@ def require_odd_sequence_length(sequence_length):
 
 def validate_positive_int(name, value):
     """Validate a positive integer parameter."""
-    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+    if not isinstance(value, Integral) or isinstance(value, bool) or value <= 0:
         raise ValueError(f"{name} must be a positive integer.")
     return value
 
 
 def validate_non_negative_int(name, value):
     """Validate a non-negative integer parameter."""
-    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+    if not isinstance(value, Integral) or isinstance(value, bool) or value < 0:
         raise ValueError(f"{name} must be a non-negative integer.")
     return value
 
 
 def validate_positive_number(name, value):
-    """Validate a positive numeric parameter."""
-    if isinstance(value, bool) or value <= 0:
-        raise ValueError(f"{name} must be a positive number.")
+    """Validate a positive, finite real-valued parameter."""
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, Real)
+        or not math.isfinite(value)
+        or value <= 0
+    ):
+        raise ValueError(f"{name} must be a positive finite number.")
     return value
 
 
 def _validate_non_zero_std(name, value):
+    if not isinstance(value, Real) or isinstance(value, bool):
+        raise ValueError(f"{name} must be a positive finite number.")
     if value == 0:
         raise ValueError(f"{name} must not be zero.")
+    if value < 0 or not math.isfinite(value):
+        raise ValueError(f"{name} must be a positive finite number.")
+    return value
+
+
+def _validate_finite_number(name, value):
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, Real)
+        or not math.isfinite(value)
+    ):
+        raise ValueError(f"{name} must be a finite number.")
     return value
 
 
 def _validate_appliance_params(appliance_params):
+    if not isinstance(appliance_params, dict):
+        raise ValueError("appliance_params must be a dictionary.")
     for appliance, stats in appliance_params.items():
+        if not isinstance(appliance, str) or not appliance.strip():
+            raise ValueError("appliance_params keys must be non-empty strings.")
         if not isinstance(stats, dict):
-            continue
+            raise ValueError(
+                f"appliance_params[{appliance!r}] must be a dictionary."
+            )
+        if "mean" in stats:
+            _validate_finite_number(
+                f"appliance_params[{appliance!r}]['mean']", stats["mean"]
+            )
         if "std" in stats:
             _validate_non_zero_std(f"appliance_params[{appliance!r}]['std']", stats["std"])
     return appliance_params
@@ -138,8 +169,19 @@ def normalize_common_params(params, defaults):
     validate_positive_int("sequence_length", sequence_length)
     validate_non_negative_int("n_epochs", n_epochs)
     validate_positive_int("batch_size", batch_size)
+    _validate_finite_number("mains_mean", mains_mean)
     _validate_non_zero_std("mains_std", mains_std)
     _validate_appliance_params(appliance_params)
+    if seed is not None and (
+        not isinstance(seed, Integral) or isinstance(seed, bool)
+    ):
+        raise ValueError("seed must be an integer or None.")
+    if not isinstance(verbose, bool):
+        raise ValueError("verbose must be a boolean.")
+    if not isinstance(chunk_wise_training, bool):
+        raise ValueError("chunk_wise_training must be a boolean.")
+    if device is not None and (not isinstance(device, str) or not device.strip()):
+        raise ValueError("device must be a non-empty string or None.")
 
     return CommonParams(
         sequence_length=sequence_length,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,3 +77,13 @@ def model_smoke_config(pytestconfig):
 @pytest.fixture(scope="session")
 def gpu_tests_enabled(pytestconfig):
     return pytestconfig.getoption("--run-gpu-tests")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def close_nilmtk_global_stats_cache():
+    """Close NILMTK's import-time temporary HDF store after the test session."""
+    yield
+    nilmtk = sys.modules.get("nilmtk")
+    stats_cache = getattr(nilmtk, "STATS_CACHE", None)
+    if stats_cache is not None:
+        stats_cache.close()

--- a/tests/test_model_registry_comprehensive.py
+++ b/tests/test_model_registry_comprehensive.py
@@ -130,6 +130,25 @@ def test_model_code_does_not_unpack_appliance_params_by_dict_order(repo_root):
     assert offenders == []
 
 
+def test_torch_models_use_the_safe_checkpoint_loader(repo_root):
+    offenders = []
+    for path in (repo_root / "nilmtk_contrib" / "torch").glob("*.py"):
+        if path.name in {"__init__.py", "preprocessing.py"}:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "torch"
+                and node.func.attr == "load"
+            ):
+                offenders.append(f"{path.name}:{node.lineno}")
+
+    assert offenders == []
+
+
 def test_model_constructors_accept_params_argument(repo_root):
     offenders = []
     for model_dir in (

--- a/tests/test_model_runtime.py
+++ b/tests/test_model_runtime.py
@@ -38,6 +38,21 @@ def test_initialize_runtime_preserves_real_persistence_methods():
     assert model.load_model() == "loaded"
 
 
+def test_initialize_runtime_replaces_nilmtk_abstract_persistence_methods():
+    nilmtk = pytest.importorskip("nilmtk.disaggregate")
+
+    class ModelWithoutPersistence(nilmtk.Disaggregator):
+        MODEL_NAME = "NoPersistence"
+
+    model = ModelWithoutPersistence()
+    initialize_runtime(model, {}, backends=("python",))
+
+    with pytest.raises(NotImplementedError, match="NoPersistence"):
+        model.save_model()
+    with pytest.raises(NotImplementedError, match="NoPersistence"):
+        model.load_model()
+
+
 def test_checkpoint_path_returns_string_for_keras_compatibility():
     path = checkpoint_path(".h5")
 

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -133,6 +133,13 @@ def test_normalize_common_params_accepts_load_model_aliases(alias):
         ("n_epochs", -1, "n_epochs must be a non-negative integer"),
         ("batch_size", 0, "batch_size must be a positive integer"),
         ("mains_std", 0, "mains_std must not be zero"),
+        ("mains_std", -1, "mains_std must be a positive finite number"),
+        ("mains_std", float("nan"), "mains_std must be a positive finite number"),
+        ("mains_std", float("inf"), "mains_std must be a positive finite number"),
+        ("mains_mean", float("nan"), "mains_mean must be a finite number"),
+        ("seed", True, "seed must be an integer or None"),
+        ("verbose", 1, "verbose must be a boolean"),
+        ("chunk_wise_training", "yes", "chunk_wise_training must be a boolean"),
     ],
 )
 def test_normalize_common_params_validates_common_values(field, value, message):
@@ -146,6 +153,24 @@ def test_normalize_common_params_validates_appliance_std():
             {"appliance_params": {"fridge": {"mean": 75, "std": 0}}},
             DEFAULTS,
         )
+
+
+@pytest.mark.parametrize(
+    "appliance_params",
+    [
+        [],
+        {"fridge": []},
+        {"": {"mean": 1, "std": 1}},
+        {"fridge": {"mean": float("nan"), "std": 1}},
+        {"fridge": {"mean": 1, "std": float("inf")}},
+        {"fridge": {"mean": 1, "std": -1}},
+    ],
+)
+def test_normalize_common_params_rejects_malformed_appliance_params(
+    appliance_params,
+):
+    with pytest.raises(ValueError, match="appliance_params"):
+        normalize_common_params({"appliance_params": appliance_params}, DEFAULTS)
 
 
 def test_require_odd_sequence_length_accepts_odd_values():
@@ -168,3 +193,9 @@ def test_model_specific_parameter_validators():
         validate_non_negative_int("iterations", -1)
     with pytest.raises(ValueError, match="learning_rate"):
         validate_positive_number("learning_rate", 0)
+    with pytest.raises(ValueError, match="learning_rate"):
+        validate_positive_number("learning_rate", float("nan"))
+    with pytest.raises(ValueError, match="learning_rate"):
+        validate_positive_number("learning_rate", float("inf"))
+    with pytest.raises(ValueError, match="learning_rate"):
+        validate_positive_number("learning_rate", "fast")


### PR DESCRIPTION
Stacked on #100. This focused follow-up rejects non-finite and mistyped common parameters, replaces inherited persistence stubs with explicit errors, uses weights-only device-aware Torch checkpoint loading across legacy models, closes the NILMTK stats cache in tests, and modernizes TCN weight normalization. Verified with 195 unit tests and all 17 PyTorch synthetic model smokes.