### PR TITLE
Modernize contrib CI and installation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  torch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Set up Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        run: python -m pip install uv==0.11.28
+
+      - name: Install locked dependencies
+        run: uv sync --frozen --group dev --extra torch
+
+      - name: Validate lock file
+        run: uv lock --check
+
+      - name: Lint
+        run: uv run ruff check nilmtk_contrib tests
+
+      - name: Run unit tests
+        run: uv run python -m pytest -W error -q
+
+      - name: Smoke-test every PyTorch model
+        run: >-
+          uv run python -m pytest tests/test_model_smoke_synthetic.py
+          --run-model-smoke --model-smoke-backend torch
+          --model-smoke-epochs 1 -q
+
+      - name: Build distributions
+        run: uv build

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,11 @@ FROM python:3.11-slim-bookworm
 
 ARG INSTALL_EXTRA=all
 ARG INSTALL_DEV=false
+ARG UV_VERSION=0.11.28
 
 LABEL org.opencontainers.image.title="nilmtk-contrib"
-LABEL org.opencontainers.image.description="NILMBench2026 benchmark toolkit with NILMTK-compatible disaggregation models"
-LABEL org.opencontainers.image.source="https://github.com/sustainability-lab/nilmbench"
+LABEL org.opencontainers.image.description="NILMTK-compatible energy-disaggregation models"
+LABEL org.opencontainers.image.source="https://github.com/nilmtk/nilmtk-contrib"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -39,9 +40,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
+RUN pip install --no-cache-dir "uv==${UV_VERSION}" \
+    && groupadd --gid 10001 nilmtk \
+    && useradd --create-home --uid 10001 --gid 10001 nilmtk
 
-RUN pip install --no-cache-dir "uv>=0.5"
+WORKDIR /app
 
 # Copy only install inputs first for better layer caching.
 COPY pyproject.toml README.md LICENSE ./
@@ -53,5 +56,9 @@ RUN uv pip install --system ".[${INSTALL_EXTRA}]" \
 # Optional runtime assets (tests, notebooks) live outside the install layer.
 COPY tests/ tests/
 COPY sample_notebooks/ sample_notebooks/
+
+RUN chown -R nilmtk:nilmtk /app
+
+USER nilmtk
 
 CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -98,21 +98,21 @@ uv pip install "nilmtk-contrib[all] @ git+https://github.com/nilmtk/nilmtk-contr
 Local development (from a clone of this repository):
 
 ```bash
-uv sync --extra dev
+uv sync --frozen --group dev
 ```
 
 Backend development examples:
 
 ```bash
-uv sync --extra dev --extra torch
-uv sync --extra dev --extra tensorflow
-uv sync --extra dev --extra classical
-uv sync --extra dev --extra all
+uv sync --frozen --group dev --extra torch
+uv sync --frozen --group dev --extra tensorflow
+uv sync --frozen --group dev --extra classical
+uv sync --frozen --group dev --extra all
 ```
 
 ### Verify your install
 
-After `uv sync --extra dev`, run a quick sanity check to confirm the package and core tests are in good shape:
+After `uv sync --frozen --group dev`, run a quick sanity check to confirm the package and core tests are in good shape:
 
 ```bash
 uv run python -m compileall -q nilmtk_contrib tests
@@ -122,7 +122,7 @@ uv run python -m pytest -q tests/test_imports.py tests/test_params.py tests/test
 Before launching full experiments, smoke-test the backend you plan to use. Sync the matching extra and run the full test suite—for example, with PyTorch:
 
 ```bash
-uv sync --extra dev --extra torch
+uv sync --frozen --group dev --extra torch
 uv run python -m pytest -q
 ```
 
@@ -243,6 +243,7 @@ docker run --rm nilmtk-contrib:all bash -lc "python -c \"import nilmtk_contrib; 
 |---|---|---|---|
 | `INSTALL_EXTRA` | `all` | `all`, `torch`, `tensorflow`, `classical` | Optional dependency extra to install |
 | `INSTALL_DEV` | `false` | `true`, `false` | Also install `.[dev]` for pytest and tooling |
+| `UV_VERSION` | `0.11.28` | A released uv version | Pin the installer used in the image |
 
 ### Files
 


### PR DESCRIPTION
Stacked on #101. This focused build-system follow-up adds pinned CI, monthly dependency updates, frozen uv development commands, a pinned uv release in Docker, correct OCI source metadata, and a non-root container user. It deliberately leaves runtime/model changes in the preceding PR. Verified with Ruff, 195 unit tests, 17 PyTorch model smokes, and uv lock --check under uv 0.11.28.