### PR TITLE
Align runtime and distribution versions

### DIFF
--- a/nilmtk_contrib/__init__.py
+++ b/nilmtk_contrib/__init__.py
@@ -1,3 +1,3 @@
-from .version import version as __version__
+from .version import __version__
 
 __all__ = ["__version__"]

--- a/nilmtk_contrib/version.py
+++ b/nilmtk_contrib/version.py
@@ -1,2 +1,5 @@
-version = '0.1.2.dev1+git.0dd2ef5'
-short_version = '0.1.2'
+"""Package version used by both Hatch and runtime imports."""
+
+__version__ = "0.1.2"
+version = __version__
+short_version = __version__

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -2,6 +2,7 @@ import importlib
 import json
 import subprocess
 import sys
+from importlib.metadata import version
 from types import SimpleNamespace
 
 import pytest
@@ -28,6 +29,11 @@ def _imported_modules_after(statement):
 def test_top_level_import_is_lightweight():
     imported = _imported_modules_after("import nilmtk_contrib")
     assert imported == set()
+
+
+def test_runtime_version_matches_distribution_metadata():
+    package = importlib.import_module("nilmtk_contrib")
+    assert package.__version__ == version("nilmtk-contrib")
 
 
 def test_disaggregate_package_import_is_lightweight():


### PR DESCRIPTION
## Summary

- make the package runtime version match the built distribution version (`0.1.2`)
- export `nilmtk_contrib.__version__`
- add a regression test comparing the runtime version with installed metadata

## Verification

- `uv run pytest -W error -q` — 196 passed, 79 skipped
- source distribution and wheel build successfully
- clean Python 3.11 virtual environment installs the wheel and verifies both runtime and distribution metadata report `0.1.2`

## Stack

This intentionally tiny PR is based on #102 and should be merged after #100, #101, and #102.
