### PR TITLE
Freeze upstream and container dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,12 +46,21 @@ RUN pip install --no-cache-dir "uv==${UV_VERSION}" \
 
 WORKDIR /app
 
-# Copy only install inputs first for better layer caching.
-COPY pyproject.toml README.md LICENSE ./
+# Copy only install inputs first for better layer caching. The lockfile is
+# required: containers must not resolve a different environment at build time.
+COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY nilmtk_contrib/ nilmtk_contrib/
 
-RUN uv pip install --system ".[${INSTALL_EXTRA}]" \
-    && if [ "${INSTALL_DEV}" = "true" ]; then uv pip install --system ".[dev]"; fi
+RUN if [ "${INSTALL_DEV}" = "true" ]; then \
+        uv export --frozen --group dev --extra "${INSTALL_EXTRA}" \
+            --no-emit-project --output-file /tmp/requirements.txt; \
+    else \
+        uv export --frozen --no-dev --extra "${INSTALL_EXTRA}" \
+            --no-emit-project --output-file /tmp/requirements.txt; \
+    fi \
+    && uv pip install --system --requirements /tmp/requirements.txt \
+    && uv pip install --system --no-deps . \
+    && rm /tmp/requirements.txt
 
 # Optional runtime assets (tests, notebooks) live outside the install layer.
 COPY tests/ tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.21.0"]
+requires = ["hatchling==1.31.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.metadata]
@@ -30,7 +30,7 @@ dependencies = []
 
 [project.optional-dependencies]
 tensorflow = [
-  "nilmtk @ git+https://github.com/nilmtk/nilmtk.git",
+  "nilmtk @ git+https://github.com/nilmtk/nilmtk.git@6b239d466556fed981f01c442f8ec471c5e2ddc7",
   "numpy>=1.26.0,<2",
   "pandas",
   "scikit-learn",
@@ -39,7 +39,7 @@ tensorflow = [
   "tensorflow-io-gcs-filesystem==0.31.0"
 ]
 torch = [
-  "nilmtk @ git+https://github.com/nilmtk/nilmtk.git",
+  "nilmtk @ git+https://github.com/nilmtk/nilmtk.git@6b239d466556fed981f01c442f8ec471c5e2ddc7",
   "numpy>=1.26.0,<2",
   "pandas",
   "scikit-learn",
@@ -48,7 +48,7 @@ torch = [
   "tqdm>=4.66"
 ]
 classical = [
-  "nilmtk @ git+https://github.com/nilmtk/nilmtk.git",
+  "nilmtk @ git+https://github.com/nilmtk/nilmtk.git@6b239d466556fed981f01c442f8ec471c5e2ddc7",
   "numpy>=1.26.0,<2",
   "pandas",
   "matplotlib",
@@ -58,10 +58,10 @@ classical = [
   "hmmlearn"
 ]
 nilm = [
-  "nilmtk @ git+https://github.com/nilmtk/nilmtk.git"
+  "nilmtk @ git+https://github.com/nilmtk/nilmtk.git@6b239d466556fed981f01c442f8ec471c5e2ddc7"
 ]
 all = [
-  "nilmtk @ git+https://github.com/nilmtk/nilmtk.git",
+  "nilmtk @ git+https://github.com/nilmtk/nilmtk.git@6b239d466556fed981f01c442f8ec471c5e2ddc7",
   "numpy>=1.26.0,<2",
   "pandas",
   "scikit-learn",

--- a/tests/test_packaging_contracts.py
+++ b/tests/test_packaging_contracts.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import tomllib
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_EXTRAS = {"all", "classical", "nilm", "tensorflow", "torch"}
+EXPECTED_UPSTREAMS = {
+    "nilmtk": (
+        "nilmtk @ git+https://github.com/nilmtk/nilmtk.git"
+        "@6b239d466556fed981f01c442f8ec471c5e2ddc7"
+    )
+}
+EXPECTED_BUILD_BACKEND = ["hatchling==1.31.0"]
+
+
+def test_runtime_extras_pin_upstream_repositories_to_commits():
+    with (PROJECT_ROOT / "pyproject.toml").open("rb") as handle:
+        optional_dependencies = tomllib.load(handle)["project"][
+            "optional-dependencies"
+        ]
+
+    assert RUNTIME_EXTRAS <= optional_dependencies.keys()
+    for extra in RUNTIME_EXTRAS:
+        requirements = {
+            requirement.partition(" @ ")[0]: requirement
+            for requirement in optional_dependencies[extra]
+            if " @ " in requirement
+        }
+        assert requirements == EXPECTED_UPSTREAMS, extra
+
+
+def test_build_backend_and_container_install_are_frozen():
+    with (PROJECT_ROOT / "pyproject.toml").open("rb") as handle:
+        project = tomllib.load(handle)
+    dockerfile = (PROJECT_ROOT / "Dockerfile").read_text()
+
+    assert project["build-system"]["requires"] == EXPECTED_BUILD_BACKEND
+    assert "COPY pyproject.toml uv.lock README.md LICENSE ./" in dockerfile
+    assert "uv export --frozen" in dockerfile
+    assert "uv pip install --system --requirements" in dockerfile

--- a/uv.lock
+++ b/uv.lock
@@ -713,8 +713,8 @@ wheels = [
 
 [[package]]
 name = "nilm-metadata"
-version = "0.2.6.dev4+g9082f10c2"
-source = { git = "https://github.com/nilmtk/nilm_metadata.git#9082f10c20f0120b1ff80db2fc8556dc74ca6a80" }
+version = "0.2.6.dev6+g59c9990de"
+source = { git = "https://github.com/nilmtk/nilm_metadata.git?rev=59c9990de4836d77c0dcd807bd4293e39e0cc314#59c9990de4836d77c0dcd807bd4293e39e0cc314" }
 dependencies = [
     { name = "pandas" },
     { name = "pyyaml" },
@@ -723,7 +723,7 @@ dependencies = [
 [[package]]
 name = "nilmtk"
 version = "0.4.1"
-source = { git = "https://github.com/nilmtk/nilmtk.git#1d6abbd2438bb868bcdb6209a5d73da2b09ef15e" }
+source = { git = "https://github.com/nilmtk/nilmtk.git?rev=6b239d466556fed981f01c442f8ec471c5e2ddc7#6b239d466556fed981f01c442f8ec471c5e2ddc7" }
 dependencies = [
     { name = "h5py" },
     { name = "hmmlearn" },
@@ -825,11 +825,11 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'classical'" },
     { name = "matplotlib", marker = "extra == 'tensorflow'" },
     { name = "matplotlib", marker = "extra == 'torch'" },
-    { name = "nilmtk", marker = "extra == 'all'", git = "https://github.com/nilmtk/nilmtk.git" },
-    { name = "nilmtk", marker = "extra == 'classical'", git = "https://github.com/nilmtk/nilmtk.git" },
-    { name = "nilmtk", marker = "extra == 'nilm'", git = "https://github.com/nilmtk/nilmtk.git" },
-    { name = "nilmtk", marker = "extra == 'tensorflow'", git = "https://github.com/nilmtk/nilmtk.git" },
-    { name = "nilmtk", marker = "extra == 'torch'", git = "https://github.com/nilmtk/nilmtk.git" },
+    { name = "nilmtk", marker = "extra == 'all'", git = "https://github.com/nilmtk/nilmtk.git?rev=6b239d466556fed981f01c442f8ec471c5e2ddc7" },
+    { name = "nilmtk", marker = "extra == 'classical'", git = "https://github.com/nilmtk/nilmtk.git?rev=6b239d466556fed981f01c442f8ec471c5e2ddc7" },
+    { name = "nilmtk", marker = "extra == 'nilm'", git = "https://github.com/nilmtk/nilmtk.git?rev=6b239d466556fed981f01c442f8ec471c5e2ddc7" },
+    { name = "nilmtk", marker = "extra == 'tensorflow'", git = "https://github.com/nilmtk/nilmtk.git?rev=6b239d466556fed981f01c442f8ec471c5e2ddc7" },
+    { name = "nilmtk", marker = "extra == 'torch'", git = "https://github.com/nilmtk/nilmtk.git?rev=6b239d466556fed981f01c442f8ec471c5e2ddc7" },
     { name = "numpy", marker = "extra == 'all'", specifier = ">=1.26.0,<2" },
     { name = "numpy", marker = "extra == 'classical'", specifier = ">=1.26.0,<2" },
     { name = "numpy", marker = "extra == 'dev'", specifier = ">=1.26.0,<2" },


### PR DESCRIPTION
## Summary

- pin NILMTK to the immutable prerequisite commit from nilmtk/nilmtk#1016
- freeze the current Hatchling build backend
- refresh only the NILMTK and NILM Metadata Git sources in `uv.lock`
- make Docker export the selected backend from the frozen lockfile before installing the local package
- add packaging regression tests for every runtime extra and the container install contract

## Verification

- 202 unit/contract tests pass under warnings-as-errors; 79 optional-backend skips
- Ruff passes
- pinned uv 0.11.28 lock check passes
- 17 PyTorch model training/inference smokes pass; 13 non-selected backend skips
- source distribution and wheel build successfully; wheel metadata contains the exact NILMTK commit for every runtime extra
- clean Python 3.11 install proves contrib 0.1.2, Torch 2.6.0, PatchTST import, NILMTK `6b239d4...`, and NILM Metadata `59c9990...`
- cold Docker build succeeds on Linux ARM, including a native locked dependency build
- final container runs as UID 10001 and proves the same runtime versions and Git provenance

## Stack

This PR is based on #103. Merge nilmtk/nilmtk#1016 first, then contrib #100, #101, #102, #103, and this PR.

The remaining PyTables shutdown warning is caused by NILMTK's global `STATS_CACHE` handle and is not hidden in contrib.
