### PR TITLE
Add a shared PyTorch disaggregator foundation

### DIFF
--- a/nilmtk_contrib/torch/_base.py
+++ b/nilmtk_contrib/torch/_base.py
@@ -7,6 +7,7 @@ the model modules where their scientific behavior is visible.
 
 from collections import OrderedDict
 from collections.abc import Iterable, Mapping
+from copy import deepcopy
 import math
 from numbers import Integral, Real
 
@@ -21,15 +22,66 @@ from nilmtk_contrib.utils.params import normalize_common_params
 SUPPORTED_DEVICE_TYPES = frozenset({"cpu", "cuda", "mps"})
 
 
+def _validate_appliance_name(name, *, label="Appliance"):
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError(f"{label} names must be non-empty strings.")
+    if name != name.strip():
+        raise ValueError(f"{label} names must not have surrounding whitespace.")
+    return name
+
+
+def _copy_appliance_params(appliance_params):
+    """Validate and detach caller-owned appliance normalization state."""
+    copied = {}
+    for appliance_name, stats in appliance_params.items():
+        _validate_appliance_name(appliance_name)
+        if not isinstance(stats, Mapping):
+            raise TypeError(f"appliance_params[{appliance_name!r}] must be a mapping.")
+        stats = deepcopy(dict(stats))
+        missing = {"mean", "std"}.difference(stats)
+        if missing:
+            fields = ", ".join(sorted(missing))
+            raise ValueError(
+                f"appliance_params[{appliance_name!r}] is missing {fields}."
+            )
+        for field in ("mean", "std", "min", "max"):
+            if field not in stats:
+                continue
+            value = stats[field]
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, Real)
+                or not math.isfinite(value)
+            ):
+                raise ValueError(
+                    f"appliance_params[{appliance_name!r}][{field!r}] "
+                    "must be a finite number."
+                )
+        if stats["std"] <= 0:
+            raise ValueError(
+                f"appliance_params[{appliance_name!r}]['std'] must be positive."
+            )
+        if "min" in stats and "max" in stats and stats["min"] > stats["max"]:
+            raise ValueError(
+                f"appliance_params[{appliance_name!r}]['min'] must not exceed max."
+            )
+        copied[appliance_name] = stats
+    return copied
+
+
 def resolve_torch_device(requested=None):
     """Resolve and validate a CPU, CUDA, or MPS device.
 
     Automatic selection deliberately preserves contrib's established policy:
     use CUDA when available and otherwise use CPU. MPS must be requested
     explicitly so migrating a model cannot silently change its numerics.
+    This is runtime placement, not checkpoint metadata; loaders should map
+    saved weights onto this resolved device.
     """
+    cuda_available = None
     if requested is None:
-        requested = "cuda" if torch.cuda.is_available() else "cpu"
+        cuda_available = torch.cuda.is_available()
+        requested = "cuda" if cuda_available else "cpu"
     if isinstance(requested, bool) or not isinstance(requested, (str, torch.device)):
         raise ValueError("device must be a non-empty string, torch.device, or None.")
     if isinstance(requested, str):
@@ -49,17 +101,26 @@ def resolve_torch_device(requested=None):
             f"Unsupported torch device type {device.type!r}; choose {supported}."
         )
     if device.type == "cuda":
-        if not torch.cuda.is_available():
+        if cuda_available is None:
+            cuda_available = torch.cuda.is_available()
+        if not cuda_available:
             raise RuntimeError("CUDA was requested but PyTorch cannot see a GPU.")
-        if device.index is not None and device.index >= torch.cuda.device_count():
+        device_count = torch.cuda.device_count()
+        if device_count < 1:
+            raise RuntimeError(
+                "CUDA was reported available but has no visible devices."
+            )
+        if device.index is not None and device.index >= device_count:
             raise RuntimeError(
                 f"CUDA device index {device.index} is unavailable; "
-                f"visible device count is {torch.cuda.device_count()}."
+                f"visible device count is {device_count}."
             )
     if device.type == "mps":
         mps = getattr(torch.backends, "mps", None)
         if mps is None or not mps.is_available():
             raise RuntimeError("MPS was requested but is unavailable.")
+        if device.index not in (None, 0):
+            raise RuntimeError("MPS exposes only device index 0.")
     return device
 
 
@@ -70,10 +131,11 @@ def compute_appliance_stats(
     std_fallback: float = 100.0,
     include_extrema: bool = False,
 ):
-    """Compute finite normalization statistics for appliance frames.
+    """Compute finite normalization statistics for one target power channel.
 
     ``std_fallback`` preserves the historical contrib convention for nearly
     constant targets while making that policy explicit and configurable.
+    Frames may be one-dimensional or two-dimensional with exactly one column.
     """
     for name, value in (("std_floor", std_floor), ("std_fallback", std_fallback)):
         if (
@@ -104,31 +166,48 @@ def compute_appliance_stats(
             raise ValueError(
                 "Each appliance target must be a (name, frames) pair."
             ) from exc
-        if not isinstance(appliance_name, str) or not appliance_name.strip():
-            raise ValueError("Appliance names must be non-empty strings.")
+        _validate_appliance_name(appliance_name)
         if appliance_name in statistics:
             raise ValueError(f"Duplicate appliance name {appliance_name!r}.")
+        if isinstance(frames, (str, bytes)):
+            raise TypeError(
+                f"Training frames for {appliance_name!r} must be iterable arrays."
+            )
         try:
-            frames = list(frames)
+            frame_entries = iter(frames)
         except TypeError as exc:
             raise TypeError(
                 f"Training frames for {appliance_name!r} must be iterable."
             ) from exc
-        if not frames:
-            raise ValueError(
-                f"Training data for {appliance_name!r} contains no frames."
-            )
+        saw_frame = False
         sample_count = 0
         mean = 0.0
         sum_squared_deviations = 0.0
         minimum = math.inf
         maximum = -math.inf
-        for frame in frames:
-            if hasattr(frame, "to_numpy"):
-                values = frame.to_numpy(dtype=np.float64)
+        for frame in frame_entries:
+            saw_frame = True
+            try:
+                if hasattr(frame, "to_numpy"):
+                    raw_values = frame.to_numpy()
+                else:
+                    raw_values = np.asarray(frame)
+                if np.iscomplexobj(raw_values):
+                    raise ValueError("complex values are unsupported")
+                values = np.asarray(raw_values, dtype=np.float64)
+            except (TypeError, ValueError) as exc:
+                raise TypeError(
+                    f"Training data for {appliance_name!r} must be real numeric data."
+                ) from exc
+            if values.ndim == 1:
+                pass
+            elif values.ndim == 2 and values.shape[1] == 1:
+                values = values[:, 0]
             else:
-                values = np.asarray(frame, dtype=np.float64)
-            values = values.reshape(-1)
+                raise ValueError(
+                    f"Training data for {appliance_name!r} must contain exactly "
+                    "one power column."
+                )
             if values.size == 0:
                 continue
             if not np.isfinite(values).all():
@@ -136,7 +215,7 @@ def compute_appliance_stats(
                     f"Training data for {appliance_name!r} must be finite."
                 )
 
-            frame_count = values.size
+            frame_count = int(values.size)
             with np.errstate(over="ignore", invalid="ignore"):
                 frame_mean = float(np.mean(values))
                 frame_variance = float(np.var(values))
@@ -149,9 +228,14 @@ def compute_appliance_stats(
                         delta * delta * sample_count * frame_count / combined_count
                     )
             sample_count = combined_count
-            minimum = min(minimum, float(np.min(values)))
-            maximum = max(maximum, float(np.max(values)))
+            if include_extrema:
+                minimum = min(minimum, float(np.min(values)))
+                maximum = max(maximum, float(np.max(values)))
 
+        if not saw_frame:
+            raise ValueError(
+                f"Training data for {appliance_name!r} contains no frames."
+            )
         if sample_count == 0:
             raise ValueError(
                 f"Training data for {appliance_name!r} contains no samples."
@@ -223,6 +307,9 @@ class TorchDisaggregator(Disaggregator):
         if not isinstance(common.chunk_wise_training, bool):
             raise ValueError("chunk_wise_training must be a boolean.")
 
+        appliance_params = _copy_appliance_params(common.appliance_params)
+        device = resolve_torch_device(common.device)
+
         super().__init__()
         initialize_runtime(
             self,
@@ -234,12 +321,12 @@ class TorchDisaggregator(Disaggregator):
         self.batch_size = common.batch_size
         self.mains_mean = common.mains_mean
         self.mains_std = common.mains_std
-        self.appliance_params = dict(common.appliance_params)
+        self.appliance_params = appliance_params
         self.save_model_path = common.save_model_path
         self.load_model_path = common.pretrained_model_path
         self.chunk_wise_training = common.chunk_wise_training
         self.models = OrderedDict()
-        self.device = resolve_torch_device(common.device)
+        self.device = device
 
     def set_appliance_params(self, train_appliances):
         """Update target normalization using the class's explicit policy."""
@@ -253,22 +340,24 @@ class TorchDisaggregator(Disaggregator):
 
     def require_models(self, models=None):
         """Optionally install and then return a validated model mapping."""
-        if models is not None:
-            if not isinstance(models, Mapping):
-                raise TypeError(
-                    "models must be a mapping of appliance names to modules."
-                )
-            validated = OrderedDict()
-            for appliance_name, model in models.items():
-                if not isinstance(appliance_name, str) or not appliance_name.strip():
-                    raise ValueError("Model appliance names must be non-empty strings.")
-                if not isinstance(model, torch.nn.Module):
-                    raise TypeError(
-                        f"Model for {appliance_name!r} must be a torch.nn.Module."
-                    )
-                validated[appliance_name] = model
-            self.models = validated
-        if not self.models:
+        install_models = models is not None
+        candidate = models if install_models else self.models
+        if not isinstance(candidate, Mapping):
+            raise TypeError("models must be a mapping of appliance names to modules.")
+        if not candidate:
+            if install_models:
+                raise ValueError("models must contain at least one appliance model.")
             model_name = getattr(self, "MODEL_NAME", self.__class__.__name__)
             raise RuntimeError(f"{model_name} requires a trained or loaded model.")
+
+        validated = OrderedDict()
+        for appliance_name, model in candidate.items():
+            _validate_appliance_name(appliance_name, label="Model appliance")
+            if not isinstance(model, torch.nn.Module):
+                raise TypeError(
+                    f"Model for {appliance_name!r} must be a torch.nn.Module."
+                )
+            validated[appliance_name] = model
+        if install_models:
+            self.models = validated
         return self.models

--- a/nilmtk_contrib/torch/_base.py
+++ b/nilmtk_contrib/torch/_base.py
@@ -1,0 +1,274 @@
+"""Small, shared building blocks for PyTorch disaggregators.
+
+This module owns runtime concerns that should not be reimplemented by every
+algorithm. Architectures, preprocessing, losses, and training loops remain in
+the model modules where their scientific behavior is visible.
+"""
+
+from collections import OrderedDict
+from collections.abc import Iterable, Mapping
+import math
+from numbers import Integral, Real
+
+import numpy as np
+import torch
+from nilmtk.disaggregate import Disaggregator
+
+from nilmtk_contrib.utils.model import initialize_runtime
+from nilmtk_contrib.utils.params import normalize_common_params
+
+
+SUPPORTED_DEVICE_TYPES = frozenset({"cpu", "cuda", "mps"})
+
+
+def resolve_torch_device(requested=None):
+    """Resolve and validate a CPU, CUDA, or MPS device.
+
+    Automatic selection deliberately preserves contrib's established policy:
+    use CUDA when available and otherwise use CPU. MPS must be requested
+    explicitly so migrating a model cannot silently change its numerics.
+    """
+    if requested is None:
+        requested = "cuda" if torch.cuda.is_available() else "cpu"
+    if isinstance(requested, bool) or not isinstance(requested, (str, torch.device)):
+        raise ValueError("device must be a non-empty string, torch.device, or None.")
+    if isinstance(requested, str):
+        requested = requested.strip()
+        if not requested:
+            raise ValueError(
+                "device must be a non-empty string, torch.device, or None."
+            )
+    try:
+        device = torch.device(requested)
+    except (RuntimeError, TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid torch device {requested!r}.") from exc
+
+    if device.type not in SUPPORTED_DEVICE_TYPES:
+        supported = ", ".join(sorted(SUPPORTED_DEVICE_TYPES))
+        raise ValueError(
+            f"Unsupported torch device type {device.type!r}; choose {supported}."
+        )
+    if device.type == "cuda":
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA was requested but PyTorch cannot see a GPU.")
+        if device.index is not None and device.index >= torch.cuda.device_count():
+            raise RuntimeError(
+                f"CUDA device index {device.index} is unavailable; "
+                f"visible device count is {torch.cuda.device_count()}."
+            )
+    if device.type == "mps":
+        mps = getattr(torch.backends, "mps", None)
+        if mps is None or not mps.is_available():
+            raise RuntimeError("MPS was requested but is unavailable.")
+    return device
+
+
+def compute_appliance_stats(
+    train_appliances: Iterable,
+    *,
+    std_floor: float = 1.0,
+    std_fallback: float = 100.0,
+    include_extrema: bool = False,
+):
+    """Compute finite normalization statistics for appliance frames.
+
+    ``std_fallback`` preserves the historical contrib convention for nearly
+    constant targets while making that policy explicit and configurable.
+    """
+    for name, value in (("std_floor", std_floor), ("std_fallback", std_fallback)):
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, Real)
+            or not math.isfinite(value)
+            or value <= 0
+        ):
+            raise ValueError(f"{name} must be a positive finite number.")
+    if not isinstance(include_extrema, bool):
+        raise ValueError("include_extrema must be a boolean.")
+
+    if train_appliances is None:
+        raise ValueError("At least one appliance target is required.")
+
+    statistics = {}
+    try:
+        appliance_entries = iter(train_appliances)
+    except TypeError as exc:
+        raise TypeError(
+            "train_appliances must be an iterable of (name, frames) pairs."
+        ) from exc
+
+    for entry in appliance_entries:
+        try:
+            appliance_name, frames = entry
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "Each appliance target must be a (name, frames) pair."
+            ) from exc
+        if not isinstance(appliance_name, str) or not appliance_name.strip():
+            raise ValueError("Appliance names must be non-empty strings.")
+        if appliance_name in statistics:
+            raise ValueError(f"Duplicate appliance name {appliance_name!r}.")
+        try:
+            frames = list(frames)
+        except TypeError as exc:
+            raise TypeError(
+                f"Training frames for {appliance_name!r} must be iterable."
+            ) from exc
+        if not frames:
+            raise ValueError(
+                f"Training data for {appliance_name!r} contains no frames."
+            )
+        sample_count = 0
+        mean = 0.0
+        sum_squared_deviations = 0.0
+        minimum = math.inf
+        maximum = -math.inf
+        for frame in frames:
+            if hasattr(frame, "to_numpy"):
+                values = frame.to_numpy(dtype=np.float64)
+            else:
+                values = np.asarray(frame, dtype=np.float64)
+            values = values.reshape(-1)
+            if values.size == 0:
+                continue
+            if not np.isfinite(values).all():
+                raise ValueError(
+                    f"Training data for {appliance_name!r} must be finite."
+                )
+
+            frame_count = values.size
+            with np.errstate(over="ignore", invalid="ignore"):
+                frame_mean = float(np.mean(values))
+                frame_variance = float(np.var(values))
+                combined_count = sample_count + frame_count
+                delta = frame_mean - mean
+                mean += delta * frame_count / combined_count
+                sum_squared_deviations += frame_variance * frame_count
+                if sample_count:
+                    sum_squared_deviations += (
+                        delta * delta * sample_count * frame_count / combined_count
+                    )
+            sample_count = combined_count
+            minimum = min(minimum, float(np.min(values)))
+            maximum = max(maximum, float(np.max(values)))
+
+        if sample_count == 0:
+            raise ValueError(
+                f"Training data for {appliance_name!r} contains no samples."
+            )
+        with np.errstate(over="ignore", invalid="ignore"):
+            std = math.sqrt(sum_squared_deviations / sample_count)
+        if not math.isfinite(mean) or not math.isfinite(std):
+            raise ValueError(
+                f"Normalization statistics for {appliance_name!r} overflowed."
+            )
+        result = {
+            "mean": mean,
+            "std": float(std_fallback) if std < std_floor else std,
+        }
+        if include_extrema:
+            result.update(max=maximum, min=minimum)
+        statistics[appliance_name] = result
+    if not statistics:
+        raise ValueError("At least one appliance target is required.")
+    return statistics
+
+
+class TorchDisaggregator(Disaggregator):
+    """Shared runtime state for one-model-per-appliance disaggregators.
+
+    Subclasses still implement their architecture, preprocessing, training,
+    inference, and persistence. The base only centralizes configuration that
+    otherwise drifts between model implementations.
+    """
+
+    APPLIANCE_STD_FLOOR = 1.0
+    APPLIANCE_STD_FALLBACK = 100.0
+    INCLUDE_APPLIANCE_EXTREMA = False
+
+    def __init__(self, params=None, *, defaults):
+        if params is None:
+            params = {}
+        if not isinstance(params, Mapping):
+            raise TypeError("params must be a mapping or None.")
+        if not isinstance(defaults, Mapping):
+            raise TypeError("defaults must be a mapping.")
+
+        supplied_appliance_params = params.get(
+            "appliance_params", defaults.get("appliance_params", {})
+        )
+        if not isinstance(supplied_appliance_params, Mapping):
+            raise TypeError("appliance_params must be a mapping.")
+
+        common = normalize_common_params(dict(params), dict(defaults))
+        if (
+            isinstance(common.mains_mean, bool)
+            or not isinstance(common.mains_mean, Real)
+            or not math.isfinite(common.mains_mean)
+        ):
+            raise ValueError("mains_mean must be a finite number.")
+        if (
+            isinstance(common.mains_std, bool)
+            or not isinstance(common.mains_std, Real)
+            or not math.isfinite(common.mains_std)
+            or common.mains_std <= 0
+        ):
+            raise ValueError("mains_std must be a positive finite number.")
+        if common.seed is not None and (
+            isinstance(common.seed, bool) or not isinstance(common.seed, Integral)
+        ):
+            raise ValueError("seed must be an integer or None.")
+        if not isinstance(common.verbose, bool):
+            raise ValueError("verbose must be a boolean.")
+        if not isinstance(common.chunk_wise_training, bool):
+            raise ValueError("chunk_wise_training must be a boolean.")
+
+        super().__init__()
+        initialize_runtime(
+            self,
+            {"seed": common.seed, "verbose": common.verbose},
+            backends=("python", "numpy", "torch"),
+        )
+        self.sequence_length = common.sequence_length
+        self.n_epochs = common.n_epochs
+        self.batch_size = common.batch_size
+        self.mains_mean = common.mains_mean
+        self.mains_std = common.mains_std
+        self.appliance_params = dict(common.appliance_params)
+        self.save_model_path = common.save_model_path
+        self.load_model_path = common.pretrained_model_path
+        self.chunk_wise_training = common.chunk_wise_training
+        self.models = OrderedDict()
+        self.device = resolve_torch_device(common.device)
+
+    def set_appliance_params(self, train_appliances):
+        """Update target normalization using the class's explicit policy."""
+        statistics = compute_appliance_stats(
+            train_appliances,
+            std_floor=self.APPLIANCE_STD_FLOOR,
+            std_fallback=self.APPLIANCE_STD_FALLBACK,
+            include_extrema=self.INCLUDE_APPLIANCE_EXTREMA,
+        )
+        self.appliance_params.update(statistics)
+
+    def require_models(self, models=None):
+        """Optionally install and then return a validated model mapping."""
+        if models is not None:
+            if not isinstance(models, Mapping):
+                raise TypeError(
+                    "models must be a mapping of appliance names to modules."
+                )
+            validated = OrderedDict()
+            for appliance_name, model in models.items():
+                if not isinstance(appliance_name, str) or not appliance_name.strip():
+                    raise ValueError("Model appliance names must be non-empty strings.")
+                if not isinstance(model, torch.nn.Module):
+                    raise TypeError(
+                        f"Model for {appliance_name!r} must be a torch.nn.Module."
+                    )
+                validated[appliance_name] = model
+            self.models = validated
+        if not self.models:
+            model_name = getattr(self, "MODEL_NAME", self.__class__.__name__)
+            raise RuntimeError(f"{model_name} requires a trained or loaded model.")
+        return self.models

--- a/tests/test_model_registry_comprehensive.py
+++ b/tests/test_model_registry_comprehensive.py
@@ -106,7 +106,7 @@ def test_model_specs_cover_every_model_module_file(repo_root):
         repo_root / "nilmtk_contrib" / "torch",
     ):
         for path in package_dir.glob("*.py"):
-            if path.name.startswith("_") or path.name == "preprocessing.py":
+            if path.name in {"__init__.py", "_base.py", "preprocessing.py"}:
                 continue
             module_name = ".".join(path.relative_to(repo_root).with_suffix("").parts)
             model_files.add(module_name)

--- a/tests/test_model_registry_comprehensive.py
+++ b/tests/test_model_registry_comprehensive.py
@@ -106,7 +106,7 @@ def test_model_specs_cover_every_model_module_file(repo_root):
         repo_root / "nilmtk_contrib" / "torch",
     ):
         for path in package_dir.glob("*.py"):
-            if path.name in {"__init__.py", "preprocessing.py"}:
+            if path.name.startswith("_") or path.name == "preprocessing.py":
                 continue
             module_name = ".".join(path.relative_to(repo_root).with_suffix("").parts)
             model_files.add(module_name)

--- a/tests/test_torch_base.py
+++ b/tests/test_torch_base.py
@@ -1,0 +1,275 @@
+from collections import OrderedDict
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+DEFAULTS = {
+    "sequence_length": 99,
+    "n_epochs": 1,
+    "batch_size": 32,
+    "mains_mean": 1800.0,
+    "mains_std": 600.0,
+    "appliance_params": {},
+    "save_model_path": None,
+    "pretrained_model_path": None,
+    "chunk_wise_training": False,
+    "seed": None,
+    "verbose": False,
+    "device": "cpu",
+}
+
+
+def test_torch_disaggregator_centralizes_common_runtime_state():
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    model = TorchDisaggregator(
+        {
+            "sequence_length": 101,
+            "batch_size": 8,
+            "seed": 7,
+            "save_model_path": "/tmp/save",
+            "pretrained_model_path": "/tmp/load",
+        },
+        defaults=DEFAULTS,
+    )
+
+    assert model.sequence_length == 101
+    assert model.n_epochs == 1
+    assert model.batch_size == 8
+    assert model.seed == 7
+    assert model.save_model_path == "/tmp/save"
+    assert model.load_model_path == "/tmp/load"
+    assert model.device == torch.device("cpu")
+    assert model.models == OrderedDict()
+
+
+@pytest.mark.parametrize(
+    ("params", "error", "message"),
+    [
+        ([], TypeError, "params"),
+        ({"mains_mean": np.nan}, ValueError, "mains_mean"),
+        ({"mains_std": np.inf}, ValueError, "mains_std"),
+        ({"mains_std": -1.0}, ValueError, "mains_std"),
+        ({"seed": True}, ValueError, "seed"),
+        ({"verbose": 1}, ValueError, "verbose"),
+        ({"chunk_wise_training": 1}, ValueError, "chunk_wise_training"),
+        ({"appliance_params": []}, TypeError, "appliance_params"),
+    ],
+)
+def test_torch_disaggregator_rejects_invalid_common_state(params, error, message):
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    with pytest.raises(error, match=message):
+        TorchDisaggregator(params, defaults=DEFAULTS)
+
+
+def test_torch_disaggregator_requires_mapping_defaults():
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    with pytest.raises(TypeError, match="defaults"):
+        TorchDisaggregator(defaults=None)
+
+
+def test_resolve_torch_device_defaults_to_cpu_without_cuda(monkeypatch):
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import resolve_torch_device
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    assert resolve_torch_device() == torch.device("cpu")
+
+
+def test_resolve_torch_device_defaults_to_cuda_when_available(monkeypatch):
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import resolve_torch_device
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
+
+    assert resolve_torch_device() == torch.device("cuda")
+
+
+@pytest.mark.parametrize("requested", ["", "   ", True, 3, "meta", "cuda:not-an-index"])
+def test_resolve_torch_device_rejects_invalid_requests(requested):
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import resolve_torch_device
+
+    with pytest.raises(ValueError, match="device"):
+        resolve_torch_device(requested)
+
+
+def test_resolve_torch_device_rejects_unavailable_cuda(monkeypatch):
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import resolve_torch_device
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    with pytest.raises(RuntimeError, match="CUDA"):
+        resolve_torch_device("cuda")
+
+
+def test_resolve_torch_device_rejects_out_of_range_cuda_index(monkeypatch):
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import resolve_torch_device
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
+
+    with pytest.raises(RuntimeError, match="index 1"):
+        resolve_torch_device("cuda:1")
+
+
+def test_resolve_torch_device_rejects_unavailable_mps(monkeypatch):
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import resolve_torch_device
+
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: False)
+
+    with pytest.raises(RuntimeError, match="MPS"):
+        resolve_torch_device("mps")
+
+
+def test_compute_appliance_stats_handles_frames_and_explicit_flat_signal_policy():
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import compute_appliance_stats
+
+    stats = compute_appliance_stats(
+        [
+            ("fridge", [np.array([0.0, 2.0]), np.array([4.0])]),
+            ("kettle", [np.ones(3)]),
+        ],
+        std_fallback=10.0,
+        include_extrema=True,
+    )
+
+    assert stats["fridge"] == pytest.approx(
+        {"mean": 2.0, "std": np.std([0.0, 2.0, 4.0]), "max": 4.0, "min": 0.0}
+    )
+    assert stats["kettle"] == pytest.approx(
+        {"mean": 1.0, "std": 10.0, "max": 1.0, "min": 1.0}
+    )
+
+
+def test_compute_appliance_stats_accepts_pandas_frames():
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import compute_appliance_stats
+
+    frame = pd.DataFrame({"active": [1.0, 3.0], "apparent": [5.0, 7.0]})
+
+    assert compute_appliance_stats([("fridge", [frame])])["fridge"] == pytest.approx(
+        {"mean": 4.0, "std": np.std([1.0, 5.0, 3.0, 7.0])}
+    )
+
+
+@pytest.mark.parametrize(
+    ("appliances", "message"),
+    [
+        (None, "At least one"),
+        ([], "At least one"),
+        ([("", [np.ones(2)])], "names"),
+        ([("fridge", [])], "no frames"),
+        ([("fridge", [np.array([])])], "no samples"),
+        ([("fridge", [np.array([1.0, np.nan])])], "finite"),
+        ([("fridge", [np.array([1e308, -1e308])])], "overflowed"),
+        (
+            [("fridge", [np.ones(2)]), ("fridge", [np.ones(2)])],
+            "Duplicate",
+        ),
+    ],
+)
+def test_compute_appliance_stats_rejects_bad_training_data(appliances, message):
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import compute_appliance_stats
+
+    with pytest.raises(ValueError, match=message):
+        compute_appliance_stats(appliances)
+
+
+@pytest.mark.parametrize(
+    ("appliances", "error", "message"),
+    [
+        (1, TypeError, "iterable"),
+        (["fridge"], ValueError, "pair"),
+        ([("fridge", None)], TypeError, "frames"),
+    ],
+)
+def test_compute_appliance_stats_rejects_malformed_containers(
+    appliances, error, message
+):
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import compute_appliance_stats
+
+    with pytest.raises(error, match=message):
+        compute_appliance_stats(appliances)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"std_floor": 0}, "std_floor"),
+        ({"std_fallback": np.nan}, "std_fallback"),
+        ({"include_extrema": 1}, "include_extrema"),
+    ],
+)
+def test_compute_appliance_stats_rejects_invalid_policy(kwargs, message):
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import compute_appliance_stats
+
+    with pytest.raises(ValueError, match=message):
+        compute_appliance_stats([("fridge", [np.ones(2)])], **kwargs)
+
+
+def test_base_appliance_policy_is_overridable_without_reimplementing_stats():
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    class UnitScaleDisaggregator(TorchDisaggregator):
+        APPLIANCE_STD_FALLBACK = 1.0
+        INCLUDE_APPLIANCE_EXTREMA = True
+
+    model = UnitScaleDisaggregator(defaults=DEFAULTS)
+    model.set_appliance_params([("fridge", [np.ones(3)])])
+
+    assert model.appliance_params["fridge"] == {
+        "mean": 1.0,
+        "std": 1.0,
+        "max": 1.0,
+        "min": 1.0,
+    }
+
+
+def test_require_models_validates_external_model_mapping():
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    model = TorchDisaggregator(defaults=DEFAULTS)
+    network = torch.nn.Linear(1, 1)
+
+    installed = model.require_models({"fridge": network})
+
+    assert installed == OrderedDict([("fridge", network)])
+    assert installed is model.models
+
+
+@pytest.mark.parametrize(
+    ("models", "error", "message"),
+    [
+        (None, RuntimeError, "trained or loaded"),
+        ([], TypeError, "mapping"),
+        ({"": object()}, ValueError, "names"),
+        ({"fridge": object()}, TypeError, "torch.nn.Module"),
+    ],
+)
+def test_require_models_rejects_invalid_or_empty_models(models, error, message):
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    model = TorchDisaggregator(defaults=DEFAULTS)
+
+    with pytest.raises(error, match=message):
+        model.require_models(models)

--- a/tests/test_torch_base.py
+++ b/tests/test_torch_base.py
@@ -1,4 +1,6 @@
 from collections import OrderedDict
+from copy import deepcopy
+import random
 
 import numpy as np
 import pandas as pd
@@ -50,7 +52,11 @@ def test_torch_disaggregator_centralizes_common_runtime_state():
     ("params", "error", "message"),
     [
         ([], TypeError, "params"),
+        ({"mains_mean": True}, ValueError, "mains_mean"),
         ({"mains_mean": np.nan}, ValueError, "mains_mean"),
+        ({"mains_mean": np.inf}, ValueError, "mains_mean"),
+        ({"mains_std": True}, ValueError, "mains_std"),
+        ({"mains_std": "large"}, ValueError, "mains_std"),
         ({"mains_std": np.inf}, ValueError, "mains_std"),
         ({"mains_std": -1.0}, ValueError, "mains_std"),
         ({"seed": True}, ValueError, "seed"),
@@ -75,11 +81,111 @@ def test_torch_disaggregator_requires_mapping_defaults():
         TorchDisaggregator(defaults=None)
 
 
+@pytest.mark.parametrize(
+    ("appliance_params", "error", "message"),
+    [
+        ({1: {"mean": 1.0, "std": 2.0}}, ValueError, "names"),
+        ({" fridge ": {"mean": 1.0, "std": 2.0}}, ValueError, "whitespace"),
+        ({"fridge": []}, TypeError, "mapping"),
+        ({"fridge": {"std": 2.0}}, ValueError, "mean"),
+        ({"fridge": {"mean": 1.0}}, ValueError, "std"),
+        ({"fridge": {"mean": True, "std": 2.0}}, ValueError, "finite"),
+        ({"fridge": {"mean": np.inf, "std": 2.0}}, ValueError, "finite"),
+        ({"fridge": {"mean": 1.0, "std": -2.0}}, ValueError, "positive"),
+        (
+            {"fridge": {"mean": 1.0, "std": 2.0, "min": np.nan}},
+            ValueError,
+            "finite",
+        ),
+        (
+            {"fridge": {"mean": 1.0, "std": 2.0, "min": 5.0, "max": 4.0}},
+            ValueError,
+            "exceed",
+        ),
+    ],
+)
+def test_torch_disaggregator_rejects_invalid_appliance_params(
+    appliance_params, error, message
+):
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    with pytest.raises(error, match=message):
+        TorchDisaggregator({"appliance_params": appliance_params}, defaults=DEFAULTS)
+
+
+def test_torch_disaggregator_detaches_caller_owned_appliance_params():
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    params = {
+        "appliance_params": {
+            "fridge": {
+                "mean": 1.0,
+                "std": 2.0,
+                "threshold": 60.0,
+                "metadata": {"source": "caller"},
+            }
+        }
+    }
+    original = deepcopy(params)
+
+    model = TorchDisaggregator(params, defaults=DEFAULTS)
+    assert params == original
+
+    params["appliance_params"]["fridge"]["mean"] = 99.0
+    params["appliance_params"]["fridge"]["metadata"]["source"] = "mutated"
+    model.appliance_params["fridge"]["std"] = 3.0
+
+    assert model.appliance_params["fridge"] == {
+        "mean": 1.0,
+        "std": 3.0,
+        "threshold": 60.0,
+        "metadata": {"source": "caller"},
+    }
+    assert params["appliance_params"]["fridge"]["std"] == 2.0
+
+
+def test_torch_disaggregator_seed_reproducibly_controls_all_rngs():
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    TorchDisaggregator({"seed": 17}, defaults=DEFAULTS)
+    first = (random.random(), np.random.random(), torch.rand(1).item())
+    TorchDisaggregator({"seed": 17}, defaults=DEFAULTS)
+    second = (random.random(), np.random.random(), torch.rand(1).item())
+
+    assert second == pytest.approx(first)
+
+
+def test_invalid_device_does_not_mutate_global_rng_state(monkeypatch):
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    def draw_rngs():
+        return random.random(), np.random.random(), torch.rand(1).item()
+
+    random.seed(23)
+    np.random.seed(23)
+    torch.manual_seed(23)
+    expected = draw_rngs()
+    random.seed(23)
+    np.random.seed(23)
+    torch.manual_seed(23)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    with pytest.raises(RuntimeError, match="CUDA"):
+        TorchDisaggregator({"seed": 999, "device": "cuda"}, defaults=DEFAULTS)
+
+    assert draw_rngs() == pytest.approx(expected)
+
+
 def test_resolve_torch_device_defaults_to_cpu_without_cuda(monkeypatch):
     torch = pytest.importorskip("torch")
     from nilmtk_contrib.torch._base import resolve_torch_device
 
     monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: True)
 
     assert resolve_torch_device() == torch.device("cpu")
 
@@ -124,6 +230,37 @@ def test_resolve_torch_device_rejects_out_of_range_cuda_index(monkeypatch):
         resolve_torch_device("cuda:1")
 
 
+def test_resolve_torch_device_accepts_visible_cuda_and_counts_devices_once(
+    monkeypatch,
+):
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import resolve_torch_device
+
+    calls = 0
+
+    def device_count():
+        nonlocal calls
+        calls += 1
+        return 1
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "device_count", device_count)
+
+    assert resolve_torch_device("cuda:0") == torch.device("cuda:0")
+    assert calls == 1
+
+
+def test_resolve_torch_device_rejects_inconsistent_cuda_runtime(monkeypatch):
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import resolve_torch_device
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 0)
+
+    with pytest.raises(RuntimeError, match="no visible devices"):
+        resolve_torch_device("cuda")
+
+
 def test_resolve_torch_device_rejects_unavailable_mps(monkeypatch):
     torch = pytest.importorskip("torch")
     from nilmtk_contrib.torch._base import resolve_torch_device
@@ -132,6 +269,27 @@ def test_resolve_torch_device_rejects_unavailable_mps(monkeypatch):
 
     with pytest.raises(RuntimeError, match="MPS"):
         resolve_torch_device("mps")
+
+
+def test_resolve_torch_device_accepts_explicit_cpu_and_available_mps(monkeypatch):
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import resolve_torch_device
+
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: True)
+
+    assert resolve_torch_device(" cpu ") == torch.device("cpu")
+    assert resolve_torch_device(torch.device("cpu")) == torch.device("cpu")
+    assert resolve_torch_device("mps:0") == torch.device("mps:0")
+
+
+def test_resolve_torch_device_rejects_nonzero_mps_index(monkeypatch):
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import resolve_torch_device
+
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: True)
+
+    with pytest.raises(RuntimeError, match="index 0"):
+        resolve_torch_device("mps:1")
 
 
 def test_compute_appliance_stats_handles_frames_and_explicit_flat_signal_policy():
@@ -159,10 +317,102 @@ def test_compute_appliance_stats_accepts_pandas_frames():
     pytest.importorskip("torch")
     from nilmtk_contrib.torch._base import compute_appliance_stats
 
-    frame = pd.DataFrame({"active": [1.0, 3.0], "apparent": [5.0, 7.0]})
+    frame = pd.DataFrame({"active": [1.0, 3.0, 5.0, 7.0]})
 
     assert compute_appliance_stats([("fridge", [frame])])["fridge"] == pytest.approx(
-        {"mean": 4.0, "std": np.std([1.0, 5.0, 3.0, 7.0])}
+        {"mean": 4.0, "std": np.std([1.0, 3.0, 5.0, 7.0])}
+    )
+
+
+@pytest.mark.parametrize(
+    "frame",
+    [
+        pd.DataFrame({"active": [1.0, 2.0], "apparent": [2.0, 3.0]}),
+        np.array([[1.0, 2.0, 3.0]]),
+        np.ones((2, 1, 1)),
+        np.array(1.0),
+    ],
+)
+def test_compute_appliance_stats_rejects_ambiguous_target_shapes(frame):
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import compute_appliance_stats
+
+    with pytest.raises(ValueError, match="one power column"):
+        compute_appliance_stats([("fridge", [frame])])
+
+
+def test_compute_appliance_stats_is_partition_invariant_at_large_offsets():
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import compute_appliance_stats
+
+    values = 1e12 + np.arange(100, dtype=np.float64) * 2.0
+    whole = compute_appliance_stats(
+        [("fridge", [values])], std_floor=0.01, include_extrema=True
+    )["fridge"]
+    partitioned = compute_appliance_stats(
+        [("fridge", [values[:1], values[1:17], values[17:63], values[63:]])],
+        std_floor=0.01,
+        include_extrema=True,
+    )["fridge"]
+
+    assert partitioned["mean"] == pytest.approx(whole["mean"], abs=1e-4)
+    assert partitioned["std"] == pytest.approx(whole["std"], rel=1e-12)
+    assert partitioned["min"] == whole["min"]
+    assert partitioned["max"] == whole["max"]
+
+
+def test_compute_appliance_stats_consumes_frames_without_materializing_them():
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import compute_appliance_stats
+
+    class StreamingFrames:
+        def __iter__(self):
+            yield np.array([1.0, 2.0])
+            yield np.array([3.0, 4.0])
+
+        def __len__(self):
+            raise AssertionError("streaming frames must not be materialized")
+
+    stats = compute_appliance_stats([("fridge", StreamingFrames())])
+
+    assert stats["fridge"] == pytest.approx(
+        {"mean": 2.5, "std": np.std([1.0, 2.0, 3.0, 4.0])}
+    )
+
+
+def test_compute_appliance_stats_matches_numpy_for_uneven_nilm_like_chunks():
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import compute_appliance_stats
+
+    rng = np.random.default_rng(31)
+    samples = np.arange(4097)
+    values = (
+        8.0
+        + 90.0 * ((samples // 137) % 2)
+        + 1200.0 * ((samples % 997) < 9)
+        + rng.normal(0.0, 1.5, samples.size)
+    )
+    frames = [
+        np.array([]),
+        values[:1],
+        values[1:73],
+        values[73:1000],
+        values[1000:4096],
+        values[4096:],
+    ]
+
+    stats = compute_appliance_stats(
+        [("fridge", frames)], std_floor=0.01, include_extrema=True
+    )["fridge"]
+
+    assert stats == pytest.approx(
+        {
+            "mean": np.mean(values),
+            "std": np.std(values),
+            "min": np.min(values),
+            "max": np.max(values),
+        },
+        rel=1e-12,
     )
 
 
@@ -172,6 +422,7 @@ def test_compute_appliance_stats_accepts_pandas_frames():
         (None, "At least one"),
         ([], "At least one"),
         ([("", [np.ones(2)])], "names"),
+        ([(" fridge ", [np.ones(2)])], "whitespace"),
         ([("fridge", [])], "no frames"),
         ([("fridge", [np.array([])])], "no samples"),
         ([("fridge", [np.array([1.0, np.nan])])], "finite"),
@@ -196,6 +447,9 @@ def test_compute_appliance_stats_rejects_bad_training_data(appliances, message):
         (1, TypeError, "iterable"),
         (["fridge"], ValueError, "pair"),
         ([("fridge", None)], TypeError, "frames"),
+        ([("fridge", "not frames")], TypeError, "arrays"),
+        ([("fridge", [np.array([1.0 + 2.0j])])], TypeError, "real numeric"),
+        ([("fridge", [np.array(["not power"])])], TypeError, "real numeric"),
     ],
 )
 def test_compute_appliance_stats_rejects_malformed_containers(
@@ -243,6 +497,40 @@ def test_base_appliance_policy_is_overridable_without_reimplementing_stats():
     }
 
 
+def test_set_appliance_params_is_atomic_when_later_target_is_invalid():
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    existing = {"fridge": {"mean": 10.0, "std": 2.0}}
+    model = TorchDisaggregator({"appliance_params": existing}, defaults=DEFAULTS)
+    before = deepcopy(model.appliance_params)
+
+    with pytest.raises(ValueError, match="finite"):
+        model.set_appliance_params(
+            [
+                ("fridge", [np.array([1.0, 2.0])]),
+                ("kettle", [np.array([1.0, np.nan])]),
+            ]
+        )
+
+    assert model.appliance_params == before
+
+
+def test_invalid_subclass_normalization_policy_fails_before_state_update():
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    class InvalidPolicyDisaggregator(TorchDisaggregator):
+        APPLIANCE_STD_FALLBACK = 0
+
+    model = InvalidPolicyDisaggregator(defaults=DEFAULTS)
+
+    with pytest.raises(ValueError, match="std_fallback"):
+        model.set_appliance_params([("fridge", [np.ones(2)])])
+
+    assert model.appliance_params == {}
+
+
 def test_require_models_validates_external_model_mapping():
     torch = pytest.importorskip("torch")
     from nilmtk_contrib.torch._base import TorchDisaggregator
@@ -250,10 +538,13 @@ def test_require_models_validates_external_model_mapping():
     model = TorchDisaggregator(defaults=DEFAULTS)
     network = torch.nn.Linear(1, 1)
 
-    installed = model.require_models({"fridge": network})
+    external = {"fridge": network}
+    installed = model.require_models(external)
+    external.clear()
 
     assert installed == OrderedDict([("fridge", network)])
     assert installed is model.models
+    assert model.require_models() is installed
 
 
 @pytest.mark.parametrize(
@@ -261,7 +552,9 @@ def test_require_models_validates_external_model_mapping():
     [
         (None, RuntimeError, "trained or loaded"),
         ([], TypeError, "mapping"),
+        ({}, ValueError, "at least one"),
         ({"": object()}, ValueError, "names"),
+        ({" fridge ": object()}, ValueError, "whitespace"),
         ({"fridge": object()}, TypeError, "torch.nn.Module"),
     ],
 )
@@ -273,3 +566,63 @@ def test_require_models_rejects_invalid_or_empty_models(models, error, message):
 
     with pytest.raises(error, match=message):
         model.require_models(models)
+
+
+@pytest.mark.parametrize("invalid_models", [{}, {"kettle": object()}])
+def test_require_models_rejects_atomically_without_erasing_installed_models(
+    invalid_models,
+):
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    model = TorchDisaggregator(defaults=DEFAULTS)
+    network = torch.nn.Linear(1, 1)
+    installed = model.require_models({"fridge": network})
+
+    with pytest.raises((TypeError, ValueError)):
+        model.require_models(invalid_models)
+
+    assert model.models is installed
+    assert model.models == OrderedDict([("fridge", network)])
+
+
+def test_require_models_rejects_partially_valid_map_atomically():
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    model = TorchDisaggregator(defaults=DEFAULTS)
+    fridge = torch.nn.Linear(1, 1)
+    installed = model.require_models({"fridge": fridge})
+
+    with pytest.raises(TypeError, match="bad"):
+        model.require_models(
+            OrderedDict(
+                [
+                    ("kettle", torch.nn.Linear(1, 1)),
+                    ("bad", object()),
+                ]
+            )
+        )
+
+    assert model.models is installed
+    assert model.models == OrderedDict([("fridge", fridge)])
+
+
+@pytest.mark.parametrize(
+    "installed_models",
+    [
+        {"fridge": object()},
+        {" fridge ": object()},
+    ],
+)
+def test_require_models_validates_previously_installed_internal_state(
+    installed_models,
+):
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    model = TorchDisaggregator(defaults=DEFAULTS)
+    model.models = installed_models
+
+    with pytest.raises((TypeError, ValueError)):
+        model.require_models()


### PR DESCRIPTION
## Why

PyTorch model implementations currently repeat runtime initialization, device selection, appliance normalization, and model-map validation. Those copies have drifted, making new algorithms larger and harder to review.

## What changed

- add a private TorchDisaggregator base for shared NILMTK runtime state
- validate explicit CPU, CUDA, and MPS placement before model construction
- calculate appliance statistics incrementally without concatenating real-dataset frames
- accept one target power channel and reject accidental active/apparent channel mixing
- make flat-signal normalization policy explicit and subclass-overridable
- validate and detach caller-owned normalization dictionaries
- validate both supplied and checkpoint-installed model mappings atomically
- keep the internal base out of model-registry coverage without broadly hiding private files

## Correctness guarantees

Construction validates all configuration and device state before resetting global random generators. Appliance-statistic updates and model-map replacement are transactional: malformed later entries cannot partially overwrite valid state. Constant, sparse-event, large-offset, overflow, NaN, complex, empty, generator, multi-column, CUDA, and MPS cases are covered.

No published model is migrated in this PR. That is intentional: the foundation can be merged without changing existing algorithm behavior. Existing models are the follow-up migration.

## Verification

- repository-wide Ruff passes; Black passes on changed Python files
- 84 focused adversarial tests pass
- foundation coverage: 219/219 statements and 118/118 branches
- full default suite: 252 passed, 76 skipped
- every existing PyTorch CPU train-to-disaggregate smoke: 16 passed
- wheel builds, installs from the artifact, and imports the private foundation
- independent architecture and correctness re-review found no P0-P2 issue and marked the delta safe to commit

The existing smoke run still reports the repository baseline BERT padding warning, TCN weight_norm deprecation warning, and NILMTK/PyTables shutdown warning; none originates in this foundation.

## Follow-up

After this merges, migrate the existing PyTorch implementations onto the common contracts and remove their repeated initialization, statistics, device, and model-validation code. Hold #100 until it is rebased and reduced against this foundation.