### PR TITLE
Migrate existing PyTorch models to the shared runtime

### DIFF
--- a/nilmtk_contrib/torch/TCN.py
+++ b/nilmtk_contrib/torch/TCN.py
@@ -1,12 +1,11 @@
-from collections import OrderedDict
 import numpy as np
 import pandas as pd
 import torch
 import torch.nn as nn
 from torch.utils.data import TensorDataset, DataLoader
-from nilmtk.disaggregate import Disaggregator
 
-from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
+from nilmtk_contrib.torch._base import TorchDisaggregator, torch_defaults
+from nilmtk_contrib.utils.model import legacy_print, module_logger, checkpoint_path
 
 logger = module_logger(__name__)
 _log_print = legacy_print(logger)
@@ -152,7 +151,7 @@ class Chomp1d(nn.Module):
     def forward(self, x):
         return x[:, :, :-self.chomp_size].contiguous() if self.chomp_size > 0 else x
 
-class TCN(Disaggregator):
+class TCN(TorchDisaggregator):
     """
     Temporal Convolutional Network (TCN) for Non-Intrusive Load Monitoring (NILM).
     
@@ -186,29 +185,17 @@ class TCN(Disaggregator):
             - mains_std (float): Standard deviation for mains power (default: 600)
             - chunk_wise_training (bool): Enable chunk-wise training (default: False)
     """
-    def __init__(self, params):
-        initialize_runtime(self, params, backends=("python", "numpy", "torch"))
-        super().__init__()
+    def __init__(self, params=None):
+        super().__init__(params, defaults=torch_defaults())
+        params = params or {}
         self.MODEL_NAME = "TCN"
-        self.models = OrderedDict()
         self.file_prefix = f"{self.MODEL_NAME.lower()}-temp-weights"
-        
-        # Hyperparameters
-        self.chunk_wise_training = params.get("chunk_wise_training", False)
-        self.sequence_length = params.get("sequence_length", 99)
-        self.n_epochs = params.get("n_epochs", 10)
-        self.batch_size = params.get("batch_size", 512)
-        self.appliance_params = params.get("appliance_params", {})
-        self.mains_mean = params.get("mains_mean", 1800)
-        self.mains_std = params.get("mains_std", 600)
         
         # TCN-specific parameters
         self.num_levels = params.get("num_levels", 8)
         self.num_filters = params.get("num_filters", 25)
         self.kernel_size = params.get("kernel_size", 7)
         self.dropout = params.get("dropout", 0.2)
-        
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         
         # Sequence length must be odd for centered windowing.
         if self.sequence_length % 2 == 0:
@@ -277,17 +264,6 @@ class TCN(Disaggregator):
                 new_mains = (new_mains - self.mains_mean) / self.mains_std
                 mains_df_list.append(pd.DataFrame(new_mains))
             return mains_df_list
-
-    def set_appliance_params(self, train_appliances):
-        """Computes and sets normalization parameters for each appliance."""
-        for app_name, df_list in train_appliances:
-            values = np.array(pd.concat(df_list, axis=0))
-            app_mean = np.mean(values)
-            app_std = np.std(values)
-            if app_std < 1:
-                app_std = 100
-            self.appliance_params.update({app_name: {'mean': app_mean, 'std': app_std}})
-        _log_print("Appliance parameters set:", self.appliance_params)
 
     def partial_fit(self, train_main, train_appliances, do_preprocessing=True, current_epoch=0, **load_kwargs):
         """Trains the model on a chunk of data."""
@@ -384,8 +360,7 @@ class TCN(Disaggregator):
 
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """Disaggregates a chunk of mains data."""
-        if model is not None:
-            self.models = model
+        self.require_models(model)
 
         # Preprocess test data
         if do_preprocessing:

--- a/nilmtk_contrib/torch/WindowGRU.py
+++ b/nilmtk_contrib/torch/WindowGRU.py
@@ -1,12 +1,11 @@
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader, TensorDataset
-from collections import OrderedDict
 import numpy as np
 import pandas as pd
-from nilmtk.disaggregate import Disaggregator
 
-from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
+from nilmtk_contrib.torch._base import TorchDisaggregator, torch_defaults
+from nilmtk_contrib.utils.model import legacy_print, module_logger, checkpoint_path
 
 logger = module_logger(__name__)
 _log_print = legacy_print(logger)
@@ -133,7 +132,7 @@ class GRUNet(nn.Module):
         out = self.fc2(h)           # [batch, 1] - linear activation (no activation)
         return out
 
-class WindowGRU(Disaggregator):
+class WindowGRU(TorchDisaggregator):
     """
     Window-based GRU neural network for Non-Intrusive Load Monitoring (NILM).
     
@@ -161,19 +160,13 @@ class WindowGRU(Disaggregator):
             - pretrained-model-path (str): Path to load pre-trained models (optional)
             - chunk_wise_training (bool): Enable chunk-wise training (default: False)
     """
-    def __init__(self, params):
-        initialize_runtime(self, params, backends=("python", "numpy", "torch"))
+    REQUIRED_APPLIANCE_STATS = ()
+
+    def __init__(self, params=None):
+        super().__init__(params, defaults=torch_defaults())
         self.MODEL_NAME = "WindowGRU"
         self.file_prefix = "{}-temp-weights".format(self.MODEL_NAME.lower())
-        self.save_model_path = params.get('save-model-path', None)
-        self.load_model_path = params.get('pretrained-model-path', None)
-        self.chunk_wise_training = params.get('chunk_wise_training', False)
-        self.sequence_length = params.get('sequence_length', 99)
-        self.n_epochs = params.get('n_epochs', 10)
-        self.models = OrderedDict()
         self.max_val = 800
-        self.batch_size = params.get('batch_size', 512)
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     def return_network(self):
         """Factory method to create a new GRU model instance"""
@@ -262,8 +255,7 @@ class WindowGRU(Disaggregator):
             # Load best weights (like TF version)
             model.load_state_dict(torch.load(filepath))
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
-        if model is not None:
-            self.models = model
+        self.require_models(model)
 
         if do_preprocessing:
             test_main_list = self.call_preprocessing(

--- a/nilmtk_contrib/torch/_base.py
+++ b/nilmtk_contrib/torch/_base.py
@@ -20,6 +20,31 @@ from nilmtk_contrib.utils.params import normalize_common_params
 
 
 SUPPORTED_DEVICE_TYPES = frozenset({"cpu", "cuda", "mps"})
+_COMMON_DEFAULTS = {
+    "sequence_length": 99,
+    "n_epochs": 10,
+    "batch_size": 512,
+    "mains_mean": 1800.0,
+    "mains_std": 600.0,
+    "appliance_params": {},
+    "save_model_path": None,
+    "pretrained_model_path": None,
+    "chunk_wise_training": False,
+    "seed": None,
+    "verbose": False,
+    "device": None,
+}
+
+
+def torch_defaults(**overrides):
+    """Return isolated common defaults with model-specific overrides."""
+    unknown = set(overrides).difference(_COMMON_DEFAULTS)
+    if unknown:
+        names = ", ".join(sorted(unknown))
+        raise ValueError(f"Unknown common default parameters: {names}.")
+    defaults = deepcopy(_COMMON_DEFAULTS)
+    defaults.update(overrides)
+    return defaults
 
 
 def _validate_appliance_name(name, *, label="Appliance"):
@@ -110,7 +135,20 @@ def resolve_torch_device(requested=None):
             raise RuntimeError(
                 "CUDA was reported available but has no visible devices."
             )
-        if device.index is not None and device.index >= device_count:
+        if device.index is None:
+            current_index = torch.cuda.current_device()
+            if (
+                isinstance(current_index, bool)
+                or not isinstance(current_index, Integral)
+                or current_index < 0
+                or current_index >= device_count
+            ):
+                raise RuntimeError(
+                    f"CUDA current device index {current_index!r} is unavailable; "
+                    f"visible device count is {device_count}."
+                )
+            device = torch.device("cuda", current_index)
+        elif device.index >= device_count:
             raise RuntimeError(
                 f"CUDA device index {device.index} is unavailable; "
                 f"visible device count is {device_count}."
@@ -269,6 +307,7 @@ class TorchDisaggregator(Disaggregator):
     APPLIANCE_STD_FLOOR = 1.0
     APPLIANCE_STD_FALLBACK = 100.0
     INCLUDE_APPLIANCE_EXTREMA = False
+    REQUIRED_APPLIANCE_STATS = ("mean", "std")
 
     def __init__(self, params=None, *, defaults):
         if params is None:
@@ -338,6 +377,60 @@ class TorchDisaggregator(Disaggregator):
         )
         self.appliance_params.update(statistics)
 
+    def _validated_appliance_stats(self, appliance_name, required_fields):
+        """Return validated statistics required by one model appliance."""
+        _validate_appliance_name(appliance_name, label="Model appliance")
+        if appliance_name not in self.appliance_params:
+            raise ValueError(
+                f"Model appliance {appliance_name!r} has no normalization parameters."
+            )
+        statistics = _copy_appliance_params(
+            {appliance_name: self.appliance_params[appliance_name]}
+        )[appliance_name]
+        missing = set(required_fields).difference(statistics)
+        if missing:
+            fields = ", ".join(sorted(missing))
+            raise ValueError(
+                f"Normalization parameters for model appliance "
+                f"{appliance_name!r} are missing {fields}."
+            )
+        return statistics
+
+    def appliance_minmax_params(self, appliance_name):
+        """Return min, max, and a safe scale for min-max normalization.
+
+        A constant target has a valid physical range of zero. Its normalized
+        training target is therefore all zeros, using the established standard
+        deviation fallback solely as a non-zero divisor. Denormalization should
+        continue to use ``maximum - minimum`` so a constant target stays constant.
+        """
+        statistics = self._validated_appliance_stats(appliance_name, ("min", "max"))
+        minimum = statistics["min"]
+        maximum = statistics["max"]
+        value_range = maximum - minimum
+        scale = value_range if value_range > 0 else self.APPLIANCE_STD_FALLBACK
+        return minimum, maximum, scale
+
+    def _validate_model_device(self, appliance_name, model):
+        devices = {parameter.device for parameter in model.parameters()}
+        devices.update(buffer.device for buffer in model.buffers())
+        incompatible = sorted(
+            (
+                device
+                for device in devices
+                if device.type != self.device.type
+                or (self.device.index is not None and device.index != self.device.index)
+            ),
+            key=str,
+        )
+        if incompatible:
+            actual = ", ".join(str(device) for device in incompatible)
+            raise ValueError(
+                f"Model for {appliance_name!r} uses incompatible device(s) "
+                f"{actual}; expected {self.device}. Move the model before "
+                "installing it."
+            )
+
     def require_models(self, models=None):
         """Optionally install and then return a validated model mapping."""
         install_models = models is not None
@@ -357,7 +450,17 @@ class TorchDisaggregator(Disaggregator):
                 raise TypeError(
                     f"Model for {appliance_name!r} must be a torch.nn.Module."
                 )
+            self._validate_model_device(appliance_name, model)
             validated[appliance_name] = model
+
+        required_stats = self.REQUIRED_APPLIANCE_STATS
+        if not isinstance(required_stats, tuple) or not all(
+            isinstance(field, str) and field for field in required_stats
+        ):
+            raise TypeError("REQUIRED_APPLIANCE_STATS must be a tuple of field names.")
+        for appliance_name in validated:
+            if required_stats:
+                self._validated_appliance_stats(appliance_name, required_stats)
         if install_models:
             self.models = validated
         return self.models

--- a/nilmtk_contrib/torch/bert.py
+++ b/nilmtk_contrib/torch/bert.py
@@ -4,12 +4,11 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 from torch.utils.data import Dataset, DataLoader
-from collections import OrderedDict
 from nilmtk_contrib.utils.validation import safe_train_test_split as train_test_split
-from nilmtk.disaggregate import Disaggregator
 from tqdm import tqdm  # Added for progress bars
 
-from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
+from nilmtk_contrib.torch._base import TorchDisaggregator, torch_defaults
+from nilmtk_contrib.utils.model import legacy_print, module_logger, checkpoint_path
 
 logger = module_logger(__name__)
 _log_print = legacy_print(logger)
@@ -108,7 +107,7 @@ class NILMDataset(Dataset):
     def __getitem__(self, idx):
         return self.mains[idx], self.appliances[idx]
 
-class BERT(Disaggregator):
+class BERT(TorchDisaggregator):
     """
     BERT-inspired transformer model for non-intrusive load monitoring.
     
@@ -135,24 +134,14 @@ class BERT(Disaggregator):
             - chunk_wise_training (bool): Enable chunk-wise training (default: False)
             - appliance_params (dict): Appliance-specific normalization parameters
     """
-    def __init__(self, params):
-        initialize_runtime(self, params, backends=("python", "numpy", "torch"))
+    def __init__(self, params=None):
+        super().__init__(params, defaults=torch_defaults())
         self.MODEL_NAME = "BERT"
-        self.chunk_wise_training = params.get('chunk_wise_training', False)
-        self.sequence_length = params.get('sequence_length', 99)
-        self.n_epochs = params.get('n_epochs', 10)
-        self.models = OrderedDict()
-        self.mains_mean = 1800
-        self.mains_std = 600
-        self.batch_size = params.get('batch_size', 512)
-        self.appliance_params = params.get('appliance_params', {})
         
         if self.sequence_length % 2 == 0:
             _log_print("Sequence length should be odd!")
             raise SequenceLengthError
             
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        
     def return_network(self):
         """Create the BERT-inspired module used by this backend.
         
@@ -295,8 +284,7 @@ class BERT(Disaggregator):
 
     # Remaining methods keep the legacy backend behavior.
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
-        if model is not None:
-            self.models = model
+        self.require_models(model)
             
         if do_preprocessing:
             test_main_list = self.call_preprocessing(
@@ -393,12 +381,3 @@ class BERT(Disaggregator):
                 new_mains = new_mains.reshape((-1, self.sequence_length))
                 processed_mains_lst.append(pd.DataFrame(new_mains))
             return processed_mains_lst
-    
-    def set_appliance_params(self, train_appliances):
-        for (app_name, df_list) in train_appliances:
-            values = np.array(pd.concat(df_list, axis=0))
-            app_mean = np.mean(values)
-            app_std = np.std(values)
-            if app_std < 1:
-                app_std = 100
-            self.appliance_params.update({app_name: {'mean': app_mean, 'std': app_std}})

--- a/nilmtk_contrib/torch/conv_lstm.py
+++ b/nilmtk_contrib/torch/conv_lstm.py
@@ -1,13 +1,10 @@
-from collections import OrderedDict
 import numpy as np
 import pandas as pd
 import torch
 import torch.nn as nn
 from torch.utils.data import TensorDataset, DataLoader
-from nilmtk.disaggregate import Disaggregator
-
-
-from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
+from nilmtk_contrib.torch._base import TorchDisaggregator, torch_defaults
+from nilmtk_contrib.utils.model import legacy_print, module_logger, checkpoint_path
 
 logger = module_logger(__name__)
 _log_print = legacy_print(logger)
@@ -17,7 +14,7 @@ class SequenceLengthError(Exception):
 class ApplianceNotFoundError(Exception):
     pass
 
-class ConvLSTM(Disaggregator):
+class ConvLSTM(TorchDisaggregator):
     """
     Convolutional LSTM for non-intrusive load monitoring.
     
@@ -44,22 +41,10 @@ class ConvLSTM(Disaggregator):
             - mains_mean (float): Mean value for mains normalization (default: 1800)
             - mains_std (float): Standard deviation for mains normalization (default: 600)
     """
-    def __init__(self, params):
-        initialize_runtime(self, params, backends=("python", "numpy", "torch"))
-        super().__init__()
+    def __init__(self, params=None):
+        super().__init__(params, defaults=torch_defaults())
         self.MODEL_NAME = "ConvLSTM"
-        self.models = OrderedDict()
         self.file_prefix = f"{self.MODEL_NAME.lower()}-temp-weights"
-        
-        # Extract legacy hyperparameters used by the Seq2Point-style training path.
-        self.chunk_wise_training = params.get("chunk_wise_training", False)
-        self.sequence_length = params.get("sequence_length", 99)
-        self.n_epochs = params.get("n_epochs", 10)
-        self.batch_size = params.get("batch_size", 512)
-        self.appliance_params = params.get("appliance_params", {})
-        self.mains_mean = params.get("mains_mean", 1800)
-        self.mains_std = params.get("mains_std", 600)
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         
         # Sequence length must be odd for proper windowing
         if self.sequence_length % 2 == 0:
@@ -213,19 +198,6 @@ class ConvLSTM(Disaggregator):
                 mains_df_list.append(pd.DataFrame(new_mains))
             return mains_df_list
 
-    def set_appliance_params(self, train_appliances):
-        """
-        Computes and sets normalization parameters for each appliance.
-        """
-        for app_name, df_list in train_appliances:
-            values = np.array(pd.concat(df_list, axis=0))
-            app_mean = np.mean(values)
-            app_std = np.std(values)
-            if app_std < 1:
-                app_std = 100
-            self.appliance_params.update({app_name: {'mean': app_mean, 'std': app_std}})
-        _log_print(self.appliance_params)
-
     def partial_fit(self, train_main, train_appliances, do_preprocessing=True, current_epoch=0, **load_kwargs):
         """
         Trains the Conv-LSTM model on a chunk of data.
@@ -328,8 +300,7 @@ class ConvLSTM(Disaggregator):
         """
         Disaggregates a chunk of mains power data.
         """
-        if model is not None:
-            self.models = model
+        self.require_models(model)
 
         # Preprocess the test mains such as windowing and normalizing
         if do_preprocessing:

--- a/nilmtk_contrib/torch/dae.py
+++ b/nilmtk_contrib/torch/dae.py
@@ -6,9 +6,8 @@ import torch.optim as optim
 import numpy as np
 import pandas as pd
 from tqdm import tqdm
-from collections import OrderedDict
 from torch.utils.data import TensorDataset, DataLoader
-from nilmtk.disaggregate import Disaggregator
+from nilmtk_contrib.torch._base import TorchDisaggregator, torch_defaults
 from nilmtk_contrib.utils.checkpoints import (
     build_metadata,
     collect_dependencies,
@@ -19,9 +18,7 @@ from nilmtk_contrib.utils.checkpoints import (
     temporary_checkpoint,
 )
 from nilmtk_contrib.utils.logging import get_logger
-from nilmtk_contrib.utils.model import initialize_runtime, legacy_print
-from nilmtk_contrib.utils.params import normalize_common_params
-from nilmtk_contrib.utils.random import set_random_seed
+from nilmtk_contrib.utils.model import legacy_print
 from nilmtk_contrib.utils.validation import train_validation_split
 
 logger = get_logger(__name__)
@@ -56,7 +53,7 @@ class DAEModel(nn.Module):
         x = x.permute(0,2,1)       # -> [batch, seq_len, 1]
         return x
 
-class DAE(Disaggregator):
+class DAE(TorchDisaggregator):
     """
     Denoising Autoencoder for non-intrusive load monitoring.
     
@@ -85,60 +82,16 @@ class DAE(Disaggregator):
             - save-model-path (str): Path to save trained models
             - pretrained-model-path (str): Path to load pre-trained models
     """
-    def __init__(self, params):
-        initialize_runtime(self, params, backends=("python", "numpy", "torch"))
-        super().__init__()
-        common = normalize_common_params(
-            params,
-            defaults={
-                "sequence_length": 99,
-                "n_epochs": 10,
-                "batch_size": 512,
-                "mains_mean": 1000,
-                "mains_std": 600,
-                "appliance_params": {},
-                "save_model_path": None,
-                "pretrained_model_path": None,
-                "chunk_wise_training": False,
-                "seed": None,
-                "verbose": False,
-                "device": None,
-            },
-        )
+    def __init__(self, params=None):
+        super().__init__(params, defaults=torch_defaults(mains_mean=1000))
         self.MODEL_NAME        = "DAE"
         self.file_prefix       = f"{self.MODEL_NAME.lower()}-temp-weights"
-        self.sequence_length   = common.sequence_length
-        self.n_epochs          = common.n_epochs
-        self.batch_size        = common.batch_size
-        self.mains_mean        = common.mains_mean
-        self.mains_std         = common.mains_std
-        self.appliance_params  = common.appliance_params
-        self.save_model_path   = common.save_model_path
-        self.load_model_path   = common.pretrained_model_path
-        self.chunk_wise_training = common.chunk_wise_training
-        self.seed              = common.seed
-        self.verbose           = common.verbose
-        self.models            = OrderedDict()
-        device = common.device or ("cuda" if torch.cuda.is_available() else "cpu")
-        self.device            = torch.device(device)
-        set_random_seed(self.seed, backends=("python", "numpy", "torch"))
         if self.load_model_path:
             self.load_model()
 
     def return_network(self):
         """Returns the DAE model."""
         return DAEModel(self.sequence_length).to(self.device)
-
-    def set_appliance_params(self, train_appliances):
-        """
-        Set the mean and std for each appliance based on the training data.
-        """
-        for name, lst in train_appliances:
-            arr = pd.concat(lst, axis=0).values.flatten()
-            m, s = arr.mean(), arr.std()
-            if s < 1:
-                s = 100  # avoid zero std
-            self.appliance_params[name] = {'mean': m, 'std': s}
 
     def normalize_input(self, data, n, mean, std, overlap):
         """
@@ -328,6 +281,7 @@ class DAE(Disaggregator):
         """
         Disaggregates a chunk of mains data.
         """
+        self.require_models()
         if do_preprocessing:
             test_main_list = self.call_preprocessing(
                 test_main_list, None, 'test'

--- a/nilmtk_contrib/torch/msdc.py
+++ b/nilmtk_contrib/torch/msdc.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+from collections.abc import Mapping
 import numpy as np
 import pandas as pd
 import torch
@@ -6,10 +6,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 from torch.utils.data import DataLoader, TensorDataset
-from nilmtk.disaggregate import Disaggregator
-
-
-from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger
+from nilmtk_contrib.torch._base import TorchDisaggregator, torch_defaults
+from nilmtk_contrib.utils.model import legacy_print, module_logger
 
 logger = module_logger(__name__)
 _log_print = legacy_print(logger)
@@ -171,7 +169,7 @@ class CRF(nn.Module):
         return best_paths
 
 
-class MSDC(Disaggregator):
+class MSDC(TorchDisaggregator):
     """
     Multi-State Dual CNN for non-intrusive load monitoring.
     
@@ -320,44 +318,44 @@ class MSDC(Disaggregator):
         }
     }
     
-    def __init__(self, params):
-        initialize_runtime(self, params, backends=("python", "numpy", "torch"))
-        super().__init__()
-        
+    def __init__(self, params=None):
+        if params is None:
+            params = {}
+        if not isinstance(params, Mapping):
+            raise TypeError("params must be a mapping or None.")
+
+        dataset = params.get('dataset', 'uk_dale')
+        if not isinstance(dataset, str) or not dataset.strip():
+            raise ValueError("dataset must be a non-empty string.")
+        dataset = dataset.strip().lower()
+        if dataset not in self.DATASET_NORMALIZATION:
+            _log_print(f"Warning: Unknown dataset '{dataset}'. Defaulting to 'uk_dale'.")
+            dataset = 'uk_dale'
+        dataset_norm = self.DATASET_NORMALIZATION[dataset]
+        super().__init__(
+            params,
+            defaults=torch_defaults(
+                n_epochs=50,
+                batch_size=256,
+                mains_mean=dataset_norm['mains_mean'],
+                mains_std=dataset_norm['mains_std'],
+            ),
+        )
         self.MODEL_NAME = "MSDC"
         self.file_prefix = f"{self.MODEL_NAME.lower()}-temp-weights"
         
         # Dataset configuration
-        self.dataset = params.get('dataset', 'uk_dale').lower()
+        self.dataset = dataset
         self.house = params.get('house', None)
-        
-        # Validate and build dataset key
-        if self.dataset not in ['uk_dale', 'redd']:
-            _log_print(f"Warning: Unknown dataset '{self.dataset}'. Defaulting to 'uk_dale'.")
-            self.dataset = 'uk_dale'
-        
         self.dataset_key = f"{self.dataset}_house{self.house}" if self.house else self.dataset
         
         # Hyperparameters
-        self.sequence_length = params.get('sequence_length', 99)
         if self.sequence_length % 2 == 0:
             raise SequenceLengthError("Sequence length must be odd")
             
         self.num_states = params.get('num_states', 3)  # Will be overridden by appliance config
-        self.n_epochs = params.get('n_epochs', 50)
-        self.batch_size = params.get('batch_size', 256)
         self.learning_rate = params.get('learning_rate', 0.001)
         self.patience = params.get('patience', 5)
-        
-        # Dataset-specific normalization parameters
-        dataset_norm = self.DATASET_NORMALIZATION.get(self.dataset, self.DATASET_NORMALIZATION['uk_dale'])
-        self.mains_mean = params.get('mains_mean', dataset_norm['mains_mean'])
-        self.mains_std = params.get('mains_std', dataset_norm['mains_std'])
-        self.appliance_params = params.get('appliance_params', {})
-        
-        # Model and device configuration
-        self.models = OrderedDict()
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         
         # Display configuration
         _log_print(f"MSDC initialized for dataset: {self.dataset.upper()}")
@@ -399,18 +397,6 @@ class MSDC(Disaggregator):
             _log_print(f"Warning: No config found for {appliance_name}, using default {num_states} states")
         
         return MSDCNet(self.sequence_length, num_states).to(self.device)
-    
-    def set_appliance_params(self, train_appliances):
-        """Computes and sets normalization parameters for each appliance."""
-        for name, lst in train_appliances:
-            arr = pd.concat(lst, axis=0).values.flatten()
-            m, s = arr.mean(), arr.std()
-            # Avoid division by zero
-            if s < 1:
-                s = 100
-            _log_print(f"Computed normalization for {name}: mean={m:.2f}, std={s:.2f}")
-            
-            self.appliance_params[name] = {'mean': m, 'std': s}
     
     def _create_state_labels(self, power_sequence, appliance_name):
         """
@@ -588,9 +574,7 @@ class MSDC(Disaggregator):
     
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """Disaggregates a chunk of mains data using the trained models."""
-        
-        if model is not None:
-            self.models = model
+        self.require_models(model)
         
         # Preprocess test data
         if do_preprocessing:

--- a/nilmtk_contrib/torch/msdc_without_crf.py
+++ b/nilmtk_contrib/torch/msdc_without_crf.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+from collections.abc import Mapping
 import numpy as np
 import pandas as pd
 import torch
@@ -6,10 +6,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 from torch.utils.data import DataLoader, TensorDataset
-from nilmtk.disaggregate import Disaggregator
-
-
-from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger
+from nilmtk_contrib.torch._base import TorchDisaggregator, torch_defaults
+from nilmtk_contrib.utils.model import legacy_print, module_logger
 
 logger = module_logger(__name__)
 _log_print = legacy_print(logger)
@@ -94,7 +92,7 @@ class MSDCNet(nn.Module):
         return power_preds, state_preds
 
 
-class MSDC(Disaggregator):
+class MSDC(TorchDisaggregator):
     """
     Multi-State Dual CNN for non-intrusive load monitoring without CRF layer.
     
@@ -244,21 +242,35 @@ class MSDC(Disaggregator):
         }
     }
     
-    def __init__(self, params):
-        initialize_runtime(self, params, backends=("python", "numpy", "torch"))
-        super().__init__()
-        
+    def __init__(self, params=None):
+        if params is None:
+            params = {}
+        if not isinstance(params, Mapping):
+            raise TypeError("params must be a mapping or None.")
+
+        dataset = params.get('dataset', 'uk_dale')
+        if not isinstance(dataset, str) or not dataset.strip():
+            raise ValueError("dataset must be a non-empty string.")
+        dataset = dataset.strip().lower()
+        if dataset not in self.DATASET_NORMALIZATION:
+            _log_print(f"Warning: Unknown dataset '{dataset}'. Defaulting to 'uk_dale'.")
+            dataset = 'uk_dale'
+        dataset_norm = self.DATASET_NORMALIZATION[dataset]
+        super().__init__(
+            params,
+            defaults=torch_defaults(
+                n_epochs=50,
+                batch_size=256,
+                mains_mean=dataset_norm['mains_mean'],
+                mains_std=dataset_norm['mains_std'],
+            ),
+        )
         self.MODEL_NAME = "MSDC"
         self.file_prefix = f"{self.MODEL_NAME.lower()}-temp-weights"
         
         # Dataset configuration
-        self.dataset = params.get('dataset', 'uk_dale').lower()
+        self.dataset = dataset
         self.house = params.get('house', None)
-        
-        # Validate dataset
-        if self.dataset not in ['uk_dale', 'redd']:
-            _log_print(f"Warning: Unknown dataset '{self.dataset}'. Defaulting to 'uk_dale'.")
-            self.dataset = 'uk_dale'
         
         # Build dataset key for configuration lookup
         if self.house is not None:
@@ -267,27 +279,14 @@ class MSDC(Disaggregator):
             self.dataset_key = self.dataset
         
         # Extract hyperparameters
-        self.sequence_length = params.get('sequence_length', 99)
         if self.sequence_length % 2 == 0:
             raise SequenceLengthError("Sequence length must be odd")
             
         # Output length for sequence-to-sequence prediction
         self.out_len = params.get('out_len', 64)
         self.num_states = params.get('num_states', 3)  # Will be overridden by appliance config
-        self.n_epochs = params.get('n_epochs', 50)
-        self.batch_size = params.get('batch_size', 256)
         self.learning_rate = params.get('learning_rate', 0.001)
         self.patience = params.get('patience', 5)
-        
-        # Dataset-specific normalization parameters
-        dataset_norm = self.DATASET_NORMALIZATION.get(self.dataset, self.DATASET_NORMALIZATION['uk_dale'])
-        self.mains_mean = params.get('mains_mean', dataset_norm['mains_mean'])
-        self.mains_std = params.get('mains_std', dataset_norm['mains_std'])
-        self.appliance_params = params.get('appliance_params', {})
-        
-        # Model storage
-        self.models = OrderedDict()  # Store separate models for each appliance
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         
         # Display configuration
         _log_print(f"MSDC initialized for dataset: {self.dataset.upper()}")
@@ -329,19 +328,6 @@ class MSDC(Disaggregator):
             _log_print(f"Warning: No config found for {appliance_name}, using default {num_states} states")
         
         return MSDCNet(self.sequence_length, self.out_len, num_states).to(self.device)
-    
-    def set_appliance_params(self, train_appliances):
-        """Compute normalization statistics for each appliance from training data"""
-        for name, lst in train_appliances:
-            # Always compute normalization from training data
-            arr = pd.concat(lst, axis=0).values.flatten()
-            m, s = arr.mean(), arr.std()
-            # Prevent division by zero
-            if s < 1:
-                s = 100
-            _log_print(f"Computed normalization for {name}: mean={m:.2f}, std={s:.2f}")
-            
-            self.appliance_params[name] = {'mean': m, 'std': s}
     
     def _create_state_labels(self, power_sequence, appliance_name):
         """
@@ -519,9 +505,7 @@ class MSDC(Disaggregator):
     
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """Disaggregate power consumption using the trained MSDC model."""
-        
-        if model is not None:
-            self.models = model
+        self.require_models(model)
         
         # Preprocess the test mains
         if do_preprocessing:

--- a/nilmtk_contrib/torch/nilmformer.py
+++ b/nilmtk_contrib/torch/nilmformer.py
@@ -33,7 +33,6 @@ reproduction claims.
 """
 
 from typing import List, Optional
-from collections import OrderedDict
 import numpy as np
 import pandas as pd
 import torch
@@ -42,8 +41,8 @@ import torch.optim as optim
 import torch.nn.functional as F
 from torch.utils.data import Dataset, DataLoader
 from tqdm import tqdm
-from nilmtk.disaggregate import Disaggregator
-from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
+from nilmtk_contrib.torch._base import TorchDisaggregator, torch_defaults
+from nilmtk_contrib.utils.model import legacy_print, module_logger, checkpoint_path
 
 logger = module_logger(__name__)
 _log_print = legacy_print(logger)
@@ -504,7 +503,7 @@ class NILMFormerNetwork(nn.Module):
         return x
 
 
-class NILMFormer(Disaggregator):
+class NILMFormer(TorchDisaggregator):
     """
     NILMFormer: Transformer-based model for non-intrusive load monitoring.
     
@@ -531,12 +530,11 @@ class NILMFormer(Disaggregator):
             - d_model (int): Model dimension (default: 96)
             - n_heads (int): Number of attention heads (default: 8)
             - n_layers (int): Number of transformer layers (default: 6)
-            - n_epochs (int): Number of training epochs (default: 10)
-            - batch_size (int): Training batch size (default: 512)
+            - n_epochs (int): Number of training epochs (default: 100)
+            - batch_size (int): Training batch size (default: 1024)
     """
 
-    def __init__(self, params):
-        initialize_runtime(self, params, backends=("python", "numpy", "torch"))
+    def __init__(self, params=None):
         """
         Initialize NILMFormer model with specified parameters following the paper
         
@@ -559,14 +557,15 @@ class NILMFormer(Disaggregator):
             - batch_size: Batch size (default: 1024)
             - learning_rate: Learning rate (default: 1e-4)
         """
-        super().__init__()
-        
+        super().__init__(
+            params,
+            defaults=torch_defaults(n_epochs=100, batch_size=1024),
+        )
+        params = params or {}
         self.MODEL_NAME = "NILMFormer"
-        self.models = OrderedDict()
         self.file_prefix = f"{self.MODEL_NAME.lower()}-temp-weights"
         
         # Model architecture parameters intended to follow NILMFormer defaults.
-        self.sequence_length = params.get('sequence_length', 99)
         self.c_in = params.get('c_in', 1)
         self.c_embedding = params.get('c_embedding', 8)
         self.c_out = params.get('c_out', 1)
@@ -582,19 +581,8 @@ class NILMFormer(Disaggregator):
         self.norm_eps = params.get('norm_eps', 1e-5)
         
         # Training parameters (optimized for NILMFormer)
-        self.chunk_wise_training = params.get('chunk_wise_training', False)
-        self.n_epochs = params.get('n_epochs', 100)  # More epochs for transformer
-        self.batch_size = params.get('batch_size', 1024)  # Larger batch size
         self.learning_rate = params.get('learning_rate', 1e-4)  # Lower learning rate
         self.warmup_steps = params.get('warmup_steps', 1000)  # Learning rate warmup
-        
-        # Data parameters
-        self.appliance_params = params.get('appliance_params', {})
-        self.mains_mean = params.get('mains_mean', 1800)
-        self.mains_std = params.get('mains_std', 600)
-        
-        # Device configuration
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         _log_print(f"NILMFormer using device: {self.device}")
         
         if self.sequence_length % 2 == 0:
@@ -842,8 +830,7 @@ class NILMFormer(Disaggregator):
         Disaggregate power consumption for test data using NILMFormer
         """
         
-        if model is not None:
-            self.models = model
+        self.require_models(model)
 
         test_predictions = []
         for test_mains_df in test_main_list:
@@ -1022,18 +1009,3 @@ class NILMFormer(Disaggregator):
             return predictions * app_std + app_mean
         else:
             return predictions
-
-    def set_appliance_params(self, train_appliances):
-        """Calculate normalization parameters for each appliance"""
-        
-        for (app_name, df_list) in train_appliances:
-            values = np.array(pd.concat(df_list, axis=0))
-            app_mean = np.mean(values)
-            app_std = np.std(values)
-            if app_std < 1:
-                app_std = 100
-            self.appliance_params.update({
-                app_name: {'mean': app_mean, 'std': app_std}
-            })
-        
-        _log_print("Appliance parameters:", self.appliance_params)

--- a/nilmtk_contrib/torch/reformer.py
+++ b/nilmtk_contrib/torch/reformer.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 import numpy as np
 import pandas as pd
 import torch
@@ -6,9 +5,9 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.data import TensorDataset, DataLoader
 import math
-from nilmtk.disaggregate import Disaggregator
 
-from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
+from nilmtk_contrib.torch._base import TorchDisaggregator, torch_defaults
+from nilmtk_contrib.utils.model import legacy_print, module_logger, checkpoint_path
 
 logger = module_logger(__name__)
 _log_print = legacy_print(logger)
@@ -286,7 +285,7 @@ class ReformerNet(nn.Module):
         
         return x
 
-class Reformer(Disaggregator):
+class Reformer(TorchDisaggregator):
     """
     Reformer model for non-intrusive load monitoring.
     
@@ -319,21 +318,11 @@ class Reformer(Disaggregator):
             - n_epochs (int): Number of training epochs (default: 10)
             - batch_size (int): Training batch size (default: 512)
     """
-    def __init__(self, params):
-        initialize_runtime(self, params, backends=("python", "numpy", "torch"))
-        super().__init__()
+    def __init__(self, params=None):
+        super().__init__(params, defaults=torch_defaults())
+        params = params or {}
         self.MODEL_NAME = "Reformer"
-        self.models = OrderedDict()
         self.file_prefix = f"{self.MODEL_NAME.lower()}-temp-weights"
-        
-        # Extract hyperparameters from params dict
-        self.chunk_wise_training = params.get("chunk_wise_training", False)
-        self.sequence_length = params.get("sequence_length", 99)
-        self.n_epochs = params.get("n_epochs", 10)
-        self.batch_size = params.get("batch_size", 512)
-        self.appliance_params = params.get("appliance_params", {})
-        self.mains_mean = params.get("mains_mean", 1800)
-        self.mains_std = params.get("mains_std", 600)
         
         # Reformer specific parameters
         self.dim = params.get("dim", 512)
@@ -346,8 +335,6 @@ class Reformer(Disaggregator):
         self.dropout = params.get("dropout", 0.1)
         self.axial_position_emb = params.get("axial_position_emb", True)
         self.axial_position_shape = params.get("axial_position_shape", None)
-        
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         
         # Sequence length must be odd for proper windowing
         if self.sequence_length % 2 == 0:
@@ -430,19 +417,6 @@ class Reformer(Disaggregator):
                 new_mains = (new_mains - self.mains_mean) / self.mains_std
                 mains_df_list.append(pd.DataFrame(new_mains))
             return mains_df_list
-
-    def set_appliance_params(self, train_appliances):
-        """
-        Computes and sets normalization parameters for each appliance.
-        """
-        for app_name, df_list in train_appliances:
-            values = np.array(pd.concat(df_list, axis=0))
-            app_mean = np.mean(values)
-            app_std = np.std(values)
-            if app_std < 1:
-                app_std = 100
-            self.appliance_params.update({app_name: {'mean': app_mean, 'std': app_std}})
-        _log_print(self.appliance_params)
 
     def partial_fit(self, train_main, train_appliances, do_preprocessing=True, current_epoch=0, **load_kwargs):
         """
@@ -546,8 +520,7 @@ class Reformer(Disaggregator):
         """
         Disaggregates a chunk of mains power data.
         """
-        if model is not None:
-            self.models = model
+        self.require_models(model)
 
         # Preprocess the test mains such as windowing and normalizing
         if do_preprocessing:

--- a/nilmtk_contrib/torch/resnet.py
+++ b/nilmtk_contrib/torch/resnet.py
@@ -1,6 +1,5 @@
 from __future__ import print_function, division
 
-from nilmtk.disaggregate import Disaggregator
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -8,16 +7,13 @@ import torch.optim as optim
 from torch.utils.data import DataLoader, TensorDataset
 import pandas as pd
 import numpy as np
-from collections import OrderedDict
 from nilmtk_contrib.utils.validation import safe_train_test_split as train_test_split
 
-# Set device
-from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger
+from nilmtk_contrib.torch._base import TorchDisaggregator, torch_defaults
+from nilmtk_contrib.utils.model import legacy_print, module_logger
 
 logger = module_logger(__name__)
 _log_print = legacy_print(logger)
-device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-
 class SequenceLengthError(Exception):
     pass
 
@@ -155,7 +151,7 @@ class ResNetModel(nn.Module):
         
         return x
 
-class ResNet(Disaggregator):
+class ResNet(TorchDisaggregator):
     """
     ResNet-based model for non-intrusive load monitoring.
     
@@ -183,19 +179,11 @@ class ResNet(Disaggregator):
             - appliance_params (dict): Appliance-specific normalization parameters
             - load_model_path (str): Path to load pre-trained models
     """
-    def __init__(self, params):
-        initialize_runtime(self, params, backends=("python", "numpy", "torch"))
+    INCLUDE_APPLIANCE_EXTREMA = True
+
+    def __init__(self, params=None):
+        super().__init__(params, defaults=torch_defaults(sequence_length=299))
         self.MODEL_NAME = "ResNet"
-        self.chunk_wise_training = params.get('chunk_wise_training', False)
-        self.sequence_length = params.get('sequence_length', 299)
-        self.n_epochs = params.get('n_epochs', 10)
-        self.models = OrderedDict()
-        self.mains_mean = 1800
-        self.mains_std = 600
-        self.batch_size = params.get('batch_size', 512)
-        self.load_model_path = params.get('load_model_path', None)
-        self.appliance_params = params.get('appliance_params', {})
-        self.device = device
         
         if self.sequence_length % 2 == 0:
             raise SequenceLengthError("Sequence length must be odd!")
@@ -367,8 +355,7 @@ class ResNet(Disaggregator):
     
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """Disaggregates a chunk of mains data."""
-        if model is not None:
-            self.models = model
+        self.require_models(model)
         
         if do_preprocessing:
             _log_print("Preprocessing test data...")
@@ -442,21 +429,3 @@ class ResNet(Disaggregator):
         
         model.apply(init_weights)
         return model
-        
-    def set_appliance_params(self, train_appliances):
-        """Computes and sets normalization parameters for each appliance."""
-        _log_print("Setting appliance parameters...")
-        
-        for (app_name, df_list) in train_appliances:
-            values = np.concatenate([df.values for df in df_list])
-            app_mean = np.mean(values)
-            app_std = np.std(values)
-            app_max = np.max(values)
-            app_min = np.min(values)
-            if app_std < 1:
-                app_std = 100
-            self.appliance_params[app_name] = {
-                'mean': app_mean, 'std': app_std, 
-                'max': app_max, 'min': app_min
-            }
-            _log_print(f"  {app_name}: mean={app_mean:.2f}, std={app_std:.2f}")

--- a/nilmtk_contrib/torch/resnet_classification.py
+++ b/nilmtk_contrib/torch/resnet_classification.py
@@ -1,5 +1,4 @@
 from __future__ import print_function, division
-from nilmtk.disaggregate import Disaggregator
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -7,12 +6,11 @@ import torch.optim as optim
 from torch.utils.data import DataLoader, TensorDataset
 import pandas as pd
 import numpy as np
-from collections import OrderedDict
 from nilmtk_contrib.utils.validation import safe_train_test_split as train_test_split
 import copy
 
-# Set device
-from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
+from nilmtk_contrib.torch._base import TorchDisaggregator, torch_defaults
+from nilmtk_contrib.utils.model import legacy_print, module_logger, checkpoint_path
 from nilmtk_contrib.preprocessing.classification import (
     appliance_threshold,
     classification_metadata,
@@ -21,8 +19,6 @@ from nilmtk_contrib.preprocessing.classification import (
 
 logger = module_logger(__name__)
 _log_print = legacy_print(logger)
-device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-
 class SequenceLengthError(Exception):
     pass
 
@@ -207,7 +203,7 @@ class ResNetClassificationNet(nn.Module):
         
         return output, classification_output
 
-class ResNet_classification(Disaggregator):
+class ResNet_classification(TorchDisaggregator):
     """
     ResNet-based model with classification for non-intrusive load monitoring.
     
@@ -234,19 +230,14 @@ class ResNet_classification(Disaggregator):
             - appliance_params (dict): Appliance-specific normalization parameters
             - mains_params (dict): Mains-specific normalization parameters
     """
-    def __init__(self, params):
-        initialize_runtime(self, params, backends=("python", "numpy", "torch"))
+    INCLUDE_APPLIANCE_EXTREMA = True
+    REQUIRED_APPLIANCE_STATS = ("mean", "std", "min", "max")
+
+    def __init__(self, params=None):
+        super().__init__(params, defaults=torch_defaults())
+        params = params or {}
         self.MODEL_NAME = "ResNet_classification"
-        self.chunk_wise_training = params.get('chunk_wise_training', False)
-        self.sequence_length = params.get('sequence_length', 99)
-        self.n_epochs = params.get('n_epochs', 10)
-        self.models = OrderedDict()
-        self.mains_mean = 1800
-        self.mains_std = 600
-        self.batch_size = params.get('batch_size', 512)
-        self.appliance_params = params.get('appliance_params', {})
         self.mains_params = params.get('mains_params', {})
-        self.device = device
         self.classification_threshold = params.get('classification_threshold', params.get('on_power_threshold', 15))
         self.regression_loss_weight = params.get('regression_loss_weight', 1.0)
         self.classification_loss_weight = params.get('classification_loss_weight', 1.0)
@@ -306,10 +297,7 @@ class ResNet_classification(Disaggregator):
             appliance_list = []
             for app_index, (app_name, app_df_lst) in enumerate(submeters_lst):
                 if app_name in self.appliance_params:
-                    self.appliance_params[app_name]['mean']
-                    self.appliance_params[app_name]['std']
-                    app_min = self.appliance_params[app_name]['min']
-                    app_max = self.appliance_params[app_name]['max']
+                    app_min, _, app_scale = self.appliance_minmax_params(app_name)
                 else:
                     raise ApplianceNotFoundError(f"Parameters for appliance '{app_name}' not found!")
 
@@ -319,7 +307,7 @@ class ResNet_classification(Disaggregator):
                     new_app_readings = np.pad(new_app_readings, (units_to_pad, units_to_pad), 'constant', constant_values=(0, 0))
                     new_app_readings = np.array([new_app_readings[i:i + n] for i in range(len(new_app_readings) - n + 1)])
                     # Normalize using min-max scaling
-                    new_app_readings = (new_app_readings - app_min) / (app_max - app_min)
+                    new_app_readings = (new_app_readings - app_min) / app_scale
                     processed_app_dfs.append(pd.DataFrame(new_app_readings))
 
                 appliance_list.append((app_name, processed_app_dfs))
@@ -347,21 +335,6 @@ class ResNet_classification(Disaggregator):
             'min': np.min(values),
             'max': np.max(values)
         })
-
-    def set_appliance_params(self, train_appliances):
-        """Computes and sets normalization parameters for each appliance."""
-        for (app_name, df_list) in train_appliances:
-            values = np.concatenate([df.values for df in df_list])
-            app_mean = np.mean(values)
-            app_std = np.std(values)
-            app_max = np.max(values)
-            app_min = np.min(values)
-            if app_std < 1:
-                app_std = 100
-            self.appliance_params[app_name] = {
-                'mean': app_mean, 'std': app_std, 
-                'min': app_min, 'max': app_max
-            }
 
     def partial_fit(self, train_main, train_appliances, do_preprocessing=True, **load_kwargs):
         """Trains the model on a chunk of data."""
@@ -480,8 +453,7 @@ class ResNet_classification(Disaggregator):
 
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """Disaggregates a chunk of mains data."""
-        if model is not None:
-            self.models = model
+        self.require_models(model)
 
         if do_preprocessing:
             test_main_list = self.call_preprocessing(
@@ -515,8 +487,7 @@ class ResNet_classification(Disaggregator):
                 averaged_prediction = sum_arr / counts_arr
                 
                 # Denormalize the predictions
-                app_min = self.appliance_params[appliance]['min']
-                app_max = self.appliance_params[appliance]['max']
+                app_min, app_max, _ = self.appliance_minmax_params(appliance)
                 prediction = averaged_prediction * (app_max - app_min) + app_min
                 prediction[prediction < 0] = 0
                 

--- a/nilmtk_contrib/torch/rnn.py
+++ b/nilmtk_contrib/torch/rnn.py
@@ -1,12 +1,11 @@
-from collections import OrderedDict
 import numpy as np
 import pandas as pd
-from nilmtk.disaggregate import Disaggregator
 import torch
 import torch.nn as nn
 from torch.utils.data import TensorDataset, DataLoader
 
-from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
+from nilmtk_contrib.torch._base import TorchDisaggregator, torch_defaults
+from nilmtk_contrib.utils.model import legacy_print, module_logger, checkpoint_path
 
 logger = module_logger(__name__)
 _log_print = legacy_print(logger)
@@ -73,7 +72,7 @@ class RNNModel(nn.Module):
         
         return x
 
-class RNN(Disaggregator):
+class RNN(TorchDisaggregator):
     """
     RNN disaggregator for Non-Intrusive Load Monitoring (NILM).
     
@@ -97,21 +96,11 @@ class RNN(Disaggregator):
             - mains_std (float): Standard deviation for mains power (default: 600)
             - chunk_wise_training (bool): Enable chunk-wise training (default: False)
     """
-    def __init__(self, params):
-        initialize_runtime(self, params, backends=("python", "numpy", "torch"))
+    def __init__(self, params=None):
         """Initializes the disaggregator and its hyperparameters."""
+        super().__init__(params, defaults=torch_defaults(sequence_length=19))
         self.MODEL_NAME = "RNN"
-        self.models = OrderedDict()
         self.file_prefix = f"{self.MODEL_NAME.lower()}-temp-weights"
-        
-        self.chunk_wise_training = params.get('chunk_wise_training', False)
-        self.sequence_length = params.get('sequence_length', 19)
-        self.n_epochs = params.get('n_epochs', 10)
-        self.batch_size = params.get('batch_size', 512)
-        self.appliance_params = params.get('appliance_params', {})
-        self.mains_mean = params.get('mains_mean', 1800)
-        self.mains_std = params.get('mains_std', 600)
-        self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         
         if self.sequence_length % 2 == 0:
             raise SequenceLengthError("Sequence length must be odd for proper windowing.")
@@ -202,8 +191,7 @@ class RNN(Disaggregator):
 
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """Disaggregates a chunk of mains data."""
-        if model is not None:
-            self.models = model
+        self.require_models(model)
 
         if do_preprocessing:
             test_main_list = self.call_preprocessing(
@@ -291,14 +279,3 @@ class RNN(Disaggregator):
                 new_mains = (new_mains - self.mains_mean) / self.mains_std
                 processed_mains_lst.append(pd.DataFrame(new_mains))
             return processed_mains_lst
-
-    def set_appliance_params(self, train_appliances):
-        """Computes and sets normalization parameters for each appliance."""
-        for (app_name, df_list) in train_appliances:
-            values = np.concatenate([df.values for df in df_list])
-            app_mean = np.mean(values)
-            app_std = np.std(values)
-            if app_std < 1:
-                app_std = 100  # Avoid division by zero for flat signals
-            self.appliance_params[app_name] = {'mean': app_mean, 'std': app_std}
-        _log_print("Appliance parameters set:", self.appliance_params)

--- a/nilmtk_contrib/torch/rnn_attention.py
+++ b/nilmtk_contrib/torch/rnn_attention.py
@@ -1,5 +1,4 @@
 from __future__ import print_function, division
-from nilmtk.disaggregate import Disaggregator
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -7,16 +6,13 @@ import torch.optim as optim
 from torch.utils.data import DataLoader, TensorDataset
 import pandas as pd
 import numpy as np
-from collections import OrderedDict
 from nilmtk_contrib.utils.validation import safe_train_test_split as train_test_split
 
-# Use GPU if available, otherwise fall back to CPU
-from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
+from nilmtk_contrib.torch._base import TorchDisaggregator, torch_defaults
+from nilmtk_contrib.utils.model import legacy_print, module_logger, checkpoint_path
 
 logger = module_logger(__name__)
 _log_print = legacy_print(logger)
-device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-
 class SequenceLengthError(Exception):
     pass
 
@@ -116,7 +112,7 @@ class RNNAttentionModel(nn.Module):
         
         return x
 
-class RNN_attention(Disaggregator):
+class RNN_attention(TorchDisaggregator):
     """
     RNN with attention mechanism for non-intrusive load monitoring.
     
@@ -142,21 +138,10 @@ class RNN_attention(Disaggregator):
             - chunk_wise_training (bool): Enable chunk-wise training (default: False)
             - appliance_params (dict): Appliance-specific normalization parameters
     """
-    def __init__(self, params):
-        initialize_runtime(self, params, backends=("python", "numpy", "torch"))
+    def __init__(self, params=None):
         """Initializes the disaggregator and its hyperparameters."""
+        super().__init__(params, defaults=torch_defaults(sequence_length=19))
         self.MODEL_NAME = "RNN_attention"
-        self.models = OrderedDict()
-        
-        self.chunk_wise_training = params.get('chunk_wise_training', False)
-        self.sequence_length = params.get('sequence_length', 19)
-        self.n_epochs = params.get('n_epochs', 10)
-        self.batch_size = params.get('batch_size', 512)
-        self.load_model_path = params.get('load_model_path', None)
-        self.appliance_params = params.get('appliance_params', {})
-        self.mains_mean = params.get('mains_mean', 1800)
-        self.mains_std = params.get('mains_std', 600)
-        self.device = device
         
         if self.sequence_length % 2 == 0:
             raise SequenceLengthError("Sequence length must be odd for proper windowing.")
@@ -259,8 +244,7 @@ class RNN_attention(Disaggregator):
     
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """Disaggregates a chunk of mains data."""
-        if model is not None:
-            self.models = model
+        self.require_models(model)
         
         if do_preprocessing:
             test_main_list = self.call_preprocessing(
@@ -354,14 +338,3 @@ class RNN_attention(Disaggregator):
                 new_mains = (new_mains - self.mains_mean) / self.mains_std
                 processed_mains_lst.append(pd.DataFrame(new_mains))
             return processed_mains_lst
-        
-    def set_appliance_params(self, train_appliances):
-        """Computes and sets normalization parameters for each appliance."""
-        for (app_name, df_list) in train_appliances:
-            values = np.concatenate([df.values for df in df_list])
-            app_mean = np.mean(values)
-            app_std = np.std(values)
-            if app_std < 1:
-                app_std = 100  # Avoid division by zero for flat signals
-            self.appliance_params[app_name] = {'mean': app_mean, 'std': app_std}
-        _log_print("Appliance parameters set:", self.appliance_params)

--- a/nilmtk_contrib/torch/rnn_attention_classification.py
+++ b/nilmtk_contrib/torch/rnn_attention_classification.py
@@ -1,5 +1,4 @@
 from __future__ import print_function, division
-from nilmtk.disaggregate import Disaggregator
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -11,8 +10,8 @@ from collections import OrderedDict
 from nilmtk_contrib.utils.validation import safe_train_test_split as train_test_split
 import copy
 
-# Set device
-from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
+from nilmtk_contrib.torch._base import TorchDisaggregator, torch_defaults
+from nilmtk_contrib.utils.model import legacy_print, module_logger, checkpoint_path
 from nilmtk_contrib.preprocessing.classification import (
     appliance_threshold,
     classification_metadata,
@@ -21,8 +20,6 @@ from nilmtk_contrib.preprocessing.classification import (
 
 logger = module_logger(__name__)
 _log_print = legacy_print(logger)
-device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-
 class SequenceLengthError(Exception):
     pass
 
@@ -157,7 +154,7 @@ class RNNAttentionClassificationNet(nn.Module):
         
         return output, classification_output, attention_weights
 
-class RNN_attention_classification(Disaggregator):
+class RNN_attention_classification(TorchDisaggregator):
     """
     RNN with attention and classification for non-intrusive load monitoring.
     
@@ -185,20 +182,15 @@ class RNN_attention_classification(Disaggregator):
             - appliance_params (dict): Appliance-specific normalization parameters
             - mains_params (dict): Mains-specific normalization parameters
     """
-    def __init__(self, params):
-        initialize_runtime(self, params, backends=("python", "numpy", "torch"))
+    INCLUDE_APPLIANCE_EXTREMA = True
+    REQUIRED_APPLIANCE_STATS = ("mean", "std", "min", "max")
+
+    def __init__(self, params=None):
+        super().__init__(params, defaults=torch_defaults())
+        params = params or {}
         self.MODEL_NAME = "RNN_attention_classification"
-        self.chunk_wise_training = params.get('chunk_wise_training', False)
-        self.sequence_length = params.get('sequence_length', 99)
-        self.n_epochs = params.get('n_epochs', 10)
-        self.models = OrderedDict()
         self.att_models = OrderedDict()  # Store attention models separately like TensorFlow
-        self.mains_mean = 1800
-        self.mains_std = 600
-        self.batch_size = params.get('batch_size', 512)
-        self.appliance_params = params.get('appliance_params', {})
         self.mains_params = params.get('mains_params', {})
-        self.device = device
         self.classification_threshold = params.get('classification_threshold', params.get('on_power_threshold', 15))
         self.regression_loss_weight = params.get('regression_loss_weight', 1.0)
         self.classification_loss_weight = params.get('classification_loss_weight', 1.0)
@@ -284,10 +276,7 @@ class RNN_attention_classification(Disaggregator):
             appliance_list = []
             for app_index, (app_name, app_df_lst) in enumerate(submeters_lst):
                 if app_name in self.appliance_params:
-                    self.appliance_params[app_name]['mean']
-                    self.appliance_params[app_name]['std']
-                    app_min = self.appliance_params[app_name]['min']
-                    app_max = self.appliance_params[app_name]['max']
+                    app_min, _, app_scale = self.appliance_minmax_params(app_name)
                 else:
                     raise ApplianceNotFoundError(f"Parameters for appliance '{app_name}' not found!")
 
@@ -297,7 +286,7 @@ class RNN_attention_classification(Disaggregator):
                     new_app_readings = np.pad(new_app_readings, (units_to_pad, units_to_pad), 'constant', constant_values=(0, 0))
                     new_app_readings = np.array([new_app_readings[i:i + n] for i in range(len(new_app_readings) - n + 1)])
                     # Normalize with min-max scaling, matching TensorFlow
-                    new_app_readings = (new_app_readings - app_min) / (app_max - app_min)
+                    new_app_readings = (new_app_readings - app_min) / app_scale
                     processed_app_dfs.append(pd.DataFrame(new_app_readings))
 
                 appliance_list.append((app_name, processed_app_dfs))
@@ -325,21 +314,6 @@ class RNN_attention_classification(Disaggregator):
             'min': np.min(all_mains_data),
             'max': np.max(all_mains_data)
         }
-
-    def set_appliance_params(self, train_appliances):
-        """Computes and sets normalization parameters for each appliance."""
-        for (app_name, df_list) in train_appliances:
-            app_data = np.concatenate([df.values for df in df_list])
-            app_mean = np.mean(app_data)
-            app_std = np.std(app_data)
-            if app_std < 1:
-                app_std = 100  # Avoid division by zero for flat signals
-            self.appliance_params[app_name] = {
-                'mean': app_mean,
-                'std': app_std,
-                'min': np.min(app_data),
-                'max': np.max(app_data)
-            }
 
     def partial_fit(self, train_main, train_appliances, do_preprocessing=True, **load_kwargs):
         """Trains the model on a chunk of data."""
@@ -459,8 +433,7 @@ class RNN_attention_classification(Disaggregator):
 
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """Disaggregates a chunk of mains data."""
-        if model is not None:
-            self.models = model
+        self.require_models(model)
 
         if do_preprocessing:
             test_main_list = self.call_preprocessing(
@@ -495,8 +468,7 @@ class RNN_attention_classification(Disaggregator):
                 averaged_prediction = sum_arr / counts_arr
 
                 # Denormalize the prediction
-                app_min = self.appliance_params[appliance]['min']
-                app_max = self.appliance_params[appliance]['max']
+                app_min, app_max, _ = self.appliance_minmax_params(appliance)
                 denormalized_prediction = app_min + (averaged_prediction * (app_max - app_min))
                 
                 # Set negative values to zero

--- a/nilmtk_contrib/torch/seq2point.py
+++ b/nilmtk_contrib/torch/seq2point.py
@@ -1,12 +1,10 @@
-from collections import OrderedDict
 import numpy as np
 import pandas as pd
 import torch
 import torch.nn as nn
 from torch.utils.data import TensorDataset, DataLoader
-from nilmtk.disaggregate import Disaggregator
-
-from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
+from nilmtk_contrib.torch._base import TorchDisaggregator, torch_defaults
+from nilmtk_contrib.utils.model import legacy_print, module_logger, checkpoint_path
 
 logger = module_logger(__name__)
 _log_print = legacy_print(logger)
@@ -16,7 +14,7 @@ class SequenceLengthError(Exception):
 class ApplianceNotFoundError(Exception):
     pass
 
-class Seq2PointTorch(Disaggregator):
+class Seq2PointTorch(TorchDisaggregator):
     """
     Sequence-to-Point neural network for Non-Intrusive Load Monitoring (NILM).
     
@@ -45,22 +43,11 @@ class Seq2PointTorch(Disaggregator):
             - mains_std (float): Standard deviation for mains power (default: 600)
             - chunk_wise_training (bool): Enable chunk-wise training (default: False)
     """
-    def __init__(self, params):
-        initialize_runtime(self, params, backends=("python", "numpy", "torch"))
+    def __init__(self, params=None):
         """Initializes the disaggregator and its hyperparameters."""
-        super().__init__()
+        super().__init__(params, defaults=torch_defaults())
         self.MODEL_NAME = "Seq2PointTorch"
-        self.models = OrderedDict()
         self.file_prefix = f"{self.MODEL_NAME.lower()}-temp-weights"
-        
-        self.chunk_wise_training = params.get("chunk_wise_training", False)
-        self.sequence_length = params.get("sequence_length", 99)
-        self.n_epochs = params.get("n_epochs", 10)
-        self.batch_size = params.get("batch_size", 512)
-        self.appliance_params = params.get("appliance_params", {})
-        self.mains_mean = params.get("mains_mean", 1800)
-        self.mains_std = params.get("mains_std", 600)
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         
         if self.sequence_length % 2 == 0:
             raise SequenceLengthError("Sequence length must be odd for proper windowing.")
@@ -165,17 +152,6 @@ class Seq2PointTorch(Disaggregator):
                 processed_mains_lst.append(pd.DataFrame(new_mains))
             return processed_mains_lst
 
-    def set_appliance_params(self, train_appliances):
-        """Computes and sets normalization parameters for each appliance."""
-        for app_name, df_list in train_appliances:
-            values = np.concatenate([df.values for df in df_list])
-            app_mean = np.mean(values)
-            app_std = np.std(values)
-            if app_std < 1:
-                app_std = 100 # Avoid division by zero for flat signals
-            self.appliance_params[app_name] = {'mean': app_mean, 'std': app_std}
-        _log_print("Appliance parameters set:", self.appliance_params)
-
     def partial_fit(self, train_main, train_appliances, do_preprocessing=True, current_epoch=0, **load_kwargs):
         """Trains the model on a chunk of data."""
         if not self.appliance_params:
@@ -267,8 +243,7 @@ class Seq2PointTorch(Disaggregator):
 
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """Disaggregates a chunk of mains data."""
-        if model is not None:
-            self.models = model
+        self.require_models(model)
 
         if do_preprocessing:
             test_main_list = self.call_preprocessing(test_main_list, submeters_lst=None, method='test')

--- a/nilmtk_contrib/torch/seq2seq.py
+++ b/nilmtk_contrib/torch/seq2seq.py
@@ -2,11 +2,10 @@ import numpy as np
 import pandas as pd
 import torch
 import torch.nn as nn
-from collections import OrderedDict
 from torch.utils.data import TensorDataset, DataLoader
-from nilmtk.disaggregate import Disaggregator
 
-from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger, checkpoint_path
+from nilmtk_contrib.torch._base import TorchDisaggregator, torch_defaults
+from nilmtk_contrib.utils.model import legacy_print, module_logger, checkpoint_path
 
 logger = module_logger(__name__)
 _log_print = legacy_print(logger)
@@ -84,7 +83,7 @@ class Seq2SeqModel(nn.Module):
         x = self.fc2(x) # Linear activation
         return x
 
-class Seq2Seq(Disaggregator):
+class Seq2Seq(TorchDisaggregator):
     """
     Sequence-to-Sequence CNN for Non-Intrusive Load Monitoring (NILM).
     
@@ -111,20 +110,11 @@ class Seq2Seq(Disaggregator):
             - appliance_params (dict): Appliance-specific normalization parameters
             - chunk_wise_training (bool): Enable chunk-wise training (default: False)
     """
-    def __init__(self, params):
-        initialize_runtime(self, params, backends=("python", "numpy", "torch"))
+    def __init__(self, params=None):
         """Initializes the disaggregator and its hyperparameters."""
+        super().__init__(params, defaults=torch_defaults())
         self.MODEL_NAME = "Seq2Seq"
         self.file_prefix = f"{self.MODEL_NAME.lower()}-temp-weights"
-        self.chunk_wise_training = params.get('chunk_wise_training', False)
-        self.sequence_length = params.get('sequence_length', 99)
-        self.n_epochs = params.get('n_epochs', 10)
-        self.models = OrderedDict()
-        self.mains_mean = 1800
-        self.mains_std = 600
-        self.batch_size = params.get('batch_size', 512)
-        self.appliance_params = params.get('appliance_params', {})
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         
         if self.sequence_length % 2 == 0:
             raise SequenceLengthError("Sequence length must be odd!")
@@ -132,16 +122,6 @@ class Seq2Seq(Disaggregator):
     def return_network(self):
         """Returns a new, initialized Seq2SeqModel instance."""
         return Seq2SeqModel(self.sequence_length).to(self.device)
-
-    def set_appliance_params(self, train_appliances):
-        """Computes and sets normalization parameters for each appliance."""
-        for (app_name, df_list) in train_appliances:
-            values = np.concatenate([df.values for df in df_list])
-            app_mean = np.mean(values)
-            app_std = np.std(values)
-            if app_std < 1:
-                app_std = 100 # Avoid division by zero for flat signals
-            self.appliance_params[app_name] = {'mean': app_mean, 'std': app_std}
 
     def partial_fit(self, train_main, train_appliances, do_preprocessing=True, current_epoch=0, **load_kwargs):
         """Trains the model on a chunk of data."""
@@ -228,8 +208,7 @@ class Seq2Seq(Disaggregator):
 
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """Disaggregates a chunk of mains data."""
-        if model is not None:
-            self.models = model
+        self.require_models(model)
 
         if do_preprocessing:
             test_main_list = self.call_preprocessing(

--- a/tests/test_model_registry_comprehensive.py
+++ b/tests/test_model_registry_comprehensive.py
@@ -246,10 +246,13 @@ def _attach_ast_parents(tree):
 def test_model_self_method_calls_are_defined_or_known_runtime_methods(repo_root):
     known_runtime_methods = {
         "apply",
+        "appliance_minmax_params",
         "load_model",
         "modules",
         "named_parameters",
+        "require_models",
         "save_model",
+        "set_appliance_params",
     }
     offenders = []
     for model_dir in (

--- a/tests/test_torch_base.py
+++ b/tests/test_torch_base.py
@@ -23,6 +23,25 @@ DEFAULTS = {
 }
 
 
+def _appliance_params(*names):
+    return {name: {"mean": 1.0, "std": 2.0, "min": 0.0, "max": 3.0} for name in names}
+
+
+def test_torch_defaults_are_complete_isolated_and_typo_safe():
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import torch_defaults
+
+    first = torch_defaults(sequence_length=19)
+    second = torch_defaults()
+    first["appliance_params"]["fridge"] = {"mean": 1.0, "std": 2.0}
+
+    assert first["sequence_length"] == 19
+    assert second == DEFAULTS | {"n_epochs": 10, "batch_size": 512, "device": None}
+    assert second["appliance_params"] == {}
+    with pytest.raises(ValueError, match="typo"):
+        torch_defaults(typo=1)
+
+
 def test_torch_disaggregator_centralizes_common_runtime_state():
     torch = pytest.importorskip("torch")
     from nilmtk_contrib.torch._base import TorchDisaggregator
@@ -196,8 +215,35 @@ def test_resolve_torch_device_defaults_to_cuda_when_available(monkeypatch):
 
     monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
     monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
 
-    assert resolve_torch_device() == torch.device("cuda")
+    assert resolve_torch_device() == torch.device("cuda:0")
+
+
+def test_resolve_torch_device_resolves_generic_cuda_to_current_index(monkeypatch):
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import resolve_torch_device
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 2)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 1)
+
+    assert resolve_torch_device("cuda") == torch.device("cuda:1")
+
+
+@pytest.mark.parametrize("current_index", [True, -1, 1, "zero"])
+def test_resolve_torch_device_rejects_invalid_current_cuda_index(
+    monkeypatch, current_index
+):
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import resolve_torch_device
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: current_index)
+
+    with pytest.raises(RuntimeError, match="current device index"):
+        resolve_torch_device("cuda")
 
 
 @pytest.mark.parametrize("requested", ["", "   ", True, 3, "meta", "cuda:not-an-index"])
@@ -535,7 +581,9 @@ def test_require_models_validates_external_model_mapping():
     torch = pytest.importorskip("torch")
     from nilmtk_contrib.torch._base import TorchDisaggregator
 
-    model = TorchDisaggregator(defaults=DEFAULTS)
+    model = TorchDisaggregator(
+        {"appliance_params": _appliance_params("fridge")}, defaults=DEFAULTS
+    )
     network = torch.nn.Linear(1, 1)
 
     external = {"fridge": network}
@@ -575,7 +623,10 @@ def test_require_models_rejects_atomically_without_erasing_installed_models(
     torch = pytest.importorskip("torch")
     from nilmtk_contrib.torch._base import TorchDisaggregator
 
-    model = TorchDisaggregator(defaults=DEFAULTS)
+    model = TorchDisaggregator(
+        {"appliance_params": _appliance_params("fridge", "kettle")},
+        defaults=DEFAULTS,
+    )
     network = torch.nn.Linear(1, 1)
     installed = model.require_models({"fridge": network})
 
@@ -590,7 +641,10 @@ def test_require_models_rejects_partially_valid_map_atomically():
     torch = pytest.importorskip("torch")
     from nilmtk_contrib.torch._base import TorchDisaggregator
 
-    model = TorchDisaggregator(defaults=DEFAULTS)
+    model = TorchDisaggregator(
+        {"appliance_params": _appliance_params("fridge", "kettle", "bad")},
+        defaults=DEFAULTS,
+    )
     fridge = torch.nn.Linear(1, 1)
     installed = model.require_models({"fridge": fridge})
 
@@ -606,6 +660,114 @@ def test_require_models_rejects_partially_valid_map_atomically():
 
     assert model.models is installed
     assert model.models == OrderedDict([("fridge", fridge)])
+
+
+def test_require_models_rejects_missing_normalization_state_atomically():
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    model = TorchDisaggregator(defaults=DEFAULTS)
+
+    with pytest.raises(ValueError, match="normalization parameters"):
+        model.require_models({"fridge": torch.nn.Linear(1, 1)})
+
+    assert model.models == {}
+
+
+def test_require_models_rejects_incompatible_module_device_atomically():
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    model = TorchDisaggregator(
+        {"appliance_params": _appliance_params("fridge")}, defaults=DEFAULTS
+    )
+    network = torch.nn.Linear(1, 1, device="meta")
+
+    with pytest.raises(ValueError, match="incompatible device"):
+        model.require_models({"fridge": network})
+
+    assert model.models == {}
+
+
+def test_require_models_distinguishes_cuda_indices_atomically():
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    class ReportedParameter:
+        def __init__(self, device):
+            self.device = torch.device(device)
+
+    class DeviceReportingModule(torch.nn.Module):
+        def __init__(self, device):
+            super().__init__()
+            self.reported_parameter = ReportedParameter(device)
+
+        def parameters(self, recurse=True):
+            return iter((self.reported_parameter,))
+
+        def buffers(self, recurse=True):
+            return iter(())
+
+    model = TorchDisaggregator(
+        {"appliance_params": _appliance_params("fridge")}, defaults=DEFAULTS
+    )
+    model.device = torch.device("cuda:0")
+    matching = DeviceReportingModule("cuda:0")
+    installed = model.require_models({"fridge": matching})
+
+    with pytest.raises(ValueError, match="cuda:1.*cuda:0"):
+        model.require_models({"fridge": DeviceReportingModule("cuda:1")})
+
+    assert model.models is installed
+    assert model.models == OrderedDict([("fridge", matching)])
+
+
+@pytest.mark.parametrize(
+    "required_fields",
+    [
+        ["mean"],
+        ("",),
+        (1,),
+    ],
+)
+def test_require_models_rejects_invalid_required_statistics_contract(
+    required_fields,
+):
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    class InvalidContractDisaggregator(TorchDisaggregator):
+        REQUIRED_APPLIANCE_STATS = required_fields
+
+    model = InvalidContractDisaggregator(
+        {"appliance_params": _appliance_params("fridge")}, defaults=DEFAULTS
+    )
+
+    with pytest.raises(TypeError, match="REQUIRED_APPLIANCE_STATS"):
+        model.require_models({"fridge": torch.nn.Identity()})
+
+
+def test_appliance_minmax_params_handles_variable_and_constant_targets():
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    model = TorchDisaggregator(
+        {
+            "appliance_params": {
+                "variable": {"mean": 2.0, "std": 2.0, "min": 0.0, "max": 5.0},
+                "constant": {"mean": 3.0, "std": 100.0, "min": 3.0, "max": 3.0},
+                "no-extrema": {"mean": 1.0, "std": 2.0},
+            }
+        },
+        defaults=DEFAULTS,
+    )
+
+    assert model.appliance_minmax_params("variable") == (0.0, 5.0, 5.0)
+    assert model.appliance_minmax_params("constant") == (3.0, 3.0, 100.0)
+    with pytest.raises(ValueError, match="missing max, min"):
+        model.appliance_minmax_params("no-extrema")
+    with pytest.raises(ValueError, match="no normalization parameters"):
+        model.appliance_minmax_params("missing")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_torch_migration_contract.py
+++ b/tests/test_torch_migration_contract.py
@@ -1,0 +1,368 @@
+from dataclasses import dataclass
+import importlib
+import inspect
+from pathlib import Path
+import re
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from model_smoke_helpers import TORCH_MODEL_SPECS
+
+
+@dataclass(frozen=True)
+class ExpectedDefaults:
+    sequence_length: int
+    n_epochs: int
+    batch_size: int
+    mains_mean: float
+    mains_std: float
+
+
+DEFAULTS_BY_MODULE = {
+    "nilmtk_contrib.torch.TCN": ExpectedDefaults(99, 10, 512, 1800, 600),
+    "nilmtk_contrib.torch.WindowGRU": ExpectedDefaults(99, 10, 512, 1800, 600),
+    "nilmtk_contrib.torch.bert": ExpectedDefaults(99, 10, 512, 1800, 600),
+    "nilmtk_contrib.torch.conv_lstm": ExpectedDefaults(99, 10, 512, 1800, 600),
+    "nilmtk_contrib.torch.dae": ExpectedDefaults(99, 10, 512, 1000, 600),
+    "nilmtk_contrib.torch.msdc": ExpectedDefaults(99, 50, 256, 1800, 600),
+    "nilmtk_contrib.torch.msdc_without_crf": ExpectedDefaults(99, 50, 256, 1800, 600),
+    "nilmtk_contrib.torch.nilmformer": ExpectedDefaults(99, 100, 1024, 1800, 600),
+    "nilmtk_contrib.torch.reformer": ExpectedDefaults(99, 10, 512, 1800, 600),
+    "nilmtk_contrib.torch.resnet": ExpectedDefaults(299, 10, 512, 1800, 600),
+    "nilmtk_contrib.torch.resnet_classification": ExpectedDefaults(
+        99, 10, 512, 1800, 600
+    ),
+    "nilmtk_contrib.torch.rnn": ExpectedDefaults(19, 10, 512, 1800, 600),
+    "nilmtk_contrib.torch.rnn_attention": ExpectedDefaults(19, 10, 512, 1800, 600),
+    "nilmtk_contrib.torch.rnn_attention_classification": ExpectedDefaults(
+        99, 10, 512, 1800, 600
+    ),
+    "nilmtk_contrib.torch.seq2point": ExpectedDefaults(99, 10, 512, 1800, 600),
+    "nilmtk_contrib.torch.seq2seq": ExpectedDefaults(99, 10, 512, 1800, 600),
+}
+
+EXTREMA_MODULES = {
+    "nilmtk_contrib.torch.resnet",
+    "nilmtk_contrib.torch.resnet_classification",
+    "nilmtk_contrib.torch.rnn_attention_classification",
+}
+
+NO_STATISTICS_MODULES = {"nilmtk_contrib.torch.WindowGRU"}
+MINMAX_MODULES = {
+    "nilmtk_contrib.torch.resnet_classification",
+    "nilmtk_contrib.torch.rnn_attention_classification",
+}
+
+
+def _load_class(spec):
+    pytest.importorskip("torch")
+    module = importlib.import_module(spec.module_name)
+    return getattr(module, spec.class_name)
+
+
+@pytest.mark.parametrize(
+    "spec",
+    TORCH_MODEL_SPECS,
+    ids=lambda spec: f"{spec.module_name}.{spec.class_name}",
+)
+def test_every_torch_model_uses_shared_runtime_with_legacy_defaults(spec):
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    cls = _load_class(spec)
+    expected = DEFAULTS_BY_MODULE[spec.module_name]
+
+    assert issubclass(cls, TorchDisaggregator)
+    model = cls({"device": "cpu"})
+
+    assert model.sequence_length == expected.sequence_length
+    assert model.n_epochs == expected.n_epochs
+    assert model.batch_size == expected.batch_size
+    assert model.mains_mean == expected.mains_mean
+    assert model.mains_std == expected.mains_std
+    assert model.appliance_params == {}
+    assert model.models == {}
+    assert model.chunk_wise_training is False
+    assert model.seed is None
+    assert model.verbose is False
+    assert str(model.device) == "cpu"
+
+
+@pytest.mark.parametrize(
+    "spec",
+    TORCH_MODEL_SPECS,
+    ids=lambda spec: f"{spec.module_name}.{spec.class_name}",
+)
+def test_every_torch_model_accepts_none_and_rejects_non_mapping_params(spec):
+    cls = _load_class(spec)
+
+    assert cls().models == {}
+    with pytest.raises(TypeError, match="params"):
+        cls([])
+
+
+@pytest.mark.parametrize(
+    "spec",
+    TORCH_MODEL_SPECS,
+    ids=lambda spec: f"{spec.module_name}.{spec.class_name}",
+)
+def test_every_torch_model_honors_validated_common_overrides(spec):
+    cls = _load_class(spec)
+    supplied_stats = {
+        "fridge": {
+            "mean": 42.0,
+            "std": 3.0,
+            "metadata": {"source": "caller"},
+        }
+    }
+    model = cls(
+        {
+            "device": "cpu",
+            "sequence_length": 101,
+            "n_epochs": 3,
+            "batch_size": 7,
+            "mains_mean": 123.0,
+            "mains_std": 45.0,
+            "appliance_params": supplied_stats,
+            "chunk_wise_training": True,
+            "seed": 17,
+            "verbose": True,
+        }
+    )
+
+    supplied_stats["fridge"]["metadata"]["source"] = "mutated"
+    assert model.sequence_length == 101
+    assert model.n_epochs == 3
+    assert model.batch_size == 7
+    assert model.mains_mean == 123.0
+    assert model.mains_std == 45.0
+    assert model.chunk_wise_training is True
+    assert model.seed == 17
+    assert model.verbose is True
+    assert model.appliance_params["fridge"]["metadata"] == {"source": "caller"}
+
+
+@pytest.mark.parametrize(
+    "spec",
+    TORCH_MODEL_SPECS,
+    ids=lambda spec: f"{spec.module_name}.{spec.class_name}",
+)
+def test_every_torch_model_inherits_shared_statistics_policy(spec):
+    from nilmtk_contrib.torch._base import TorchDisaggregator
+
+    cls = _load_class(spec)
+
+    assert cls.set_appliance_params is TorchDisaggregator.set_appliance_params
+    assert cls.APPLIANCE_STD_FLOOR == 1.0
+    assert cls.APPLIANCE_STD_FALLBACK == 100.0
+    assert cls.INCLUDE_APPLIANCE_EXTREMA is (spec.module_name in EXTREMA_MODULES)
+    if spec.module_name in NO_STATISTICS_MODULES:
+        assert cls.REQUIRED_APPLIANCE_STATS == ()
+    elif spec.module_name in MINMAX_MODULES:
+        assert cls.REQUIRED_APPLIANCE_STATS == ("mean", "std", "min", "max")
+    else:
+        assert cls.REQUIRED_APPLIANCE_STATS == ("mean", "std")
+
+
+@pytest.mark.parametrize(
+    "spec",
+    TORCH_MODEL_SPECS,
+    ids=lambda spec: f"{spec.module_name}.{spec.class_name}",
+)
+def test_torch_model_source_does_not_reintroduce_shared_boilerplate(spec):
+    module = importlib.import_module(spec.module_name)
+    source_path = Path(module.__file__)
+    source = source_path.read_text(encoding="utf-8")
+
+    forbidden = {
+        "direct Disaggregator inheritance": rf"class\s+{spec.class_name}\(Disaggregator\)",
+        "direct Disaggregator import": r"from nilmtk\.disaggregate import Disaggregator",
+        "duplicated runtime initialization": r"\binitialize_runtime\(",
+        "duplicated common parameter normalization": r"\bnormalize_common_params\(",
+        "duplicated appliance statistics": r"def set_appliance_params\(",
+        "module-global device selection": r"(?m)^device\s*=\s*torch\.device",
+        "unsafe model-map aliasing": r"self\.models\s*=\s*model\b",
+    }
+    for label, pattern in forbidden.items():
+        assert (
+            re.search(pattern, source) is None
+        ), f"{label} remains in {source_path.name}"
+
+    parameters = inspect.signature(getattr(module, spec.class_name).disaggregate_chunk)
+    if "model" in parameters.parameters:
+        assert "self.require_models(model)" in source
+    else:
+        assert "self.require_models()" in source
+
+
+@pytest.mark.parametrize(
+    "spec",
+    TORCH_MODEL_SPECS,
+    ids=lambda spec: f"{spec.module_name}.{spec.class_name}",
+)
+def test_every_torch_disaggregation_path_validates_and_detaches_models(spec):
+    torch = pytest.importorskip("torch")
+    cls = _load_class(spec)
+    normalization = {"fridge": {"mean": 95.0, "std": 40.0, "min": 0.0, "max": 200.0}}
+    model = cls({"device": "cpu", "appliance_params": normalization})
+    parameters = inspect.signature(model.disaggregate_chunk).parameters
+
+    with pytest.raises(RuntimeError, match="trained or loaded"):
+        model.disaggregate_chunk([], do_preprocessing=False)
+
+    external = {"fridge": torch.nn.Identity()}
+    if cls.REQUIRED_APPLIANCE_STATS:
+        missing_stats = cls({"device": "cpu"})
+        with pytest.raises(ValueError, match="normalization parameters"):
+            if "model" in parameters:
+                missing_stats.disaggregate_chunk(
+                    [], model=external, do_preprocessing=False
+                )
+            else:
+                missing_stats.models.update(external)
+                missing_stats.disaggregate_chunk([], do_preprocessing=False)
+
+    if "model" in parameters:
+        assert (
+            model.disaggregate_chunk([], model=external, do_preprocessing=False) == []
+        )
+        assert model.models is not external
+    else:
+        model.models.update(external)
+        assert model.disaggregate_chunk([], do_preprocessing=False) == []
+
+    external["kettle"] = torch.nn.Identity()
+    assert list(model.models) == ["fridge"]
+
+
+def test_external_model_runs_nonempty_seq2point_inference_with_validated_state():
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch.seq2point import Seq2PointTorch
+
+    class ZeroPoint(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.bias = torch.nn.Parameter(torch.zeros(1))
+
+        def forward(self, values):
+            return self.bias.expand(values.shape[0], 1)
+
+    model = Seq2PointTorch(
+        {
+            "device": "cpu",
+            "appliance_params": {"fridge": {"mean": 95.0, "std": 40.0}},
+        }
+    )
+    mains = pd.DataFrame({"power": np.full(99, 140.0, dtype=np.float32)})
+
+    predictions = model.disaggregate_chunk([mains], model={"fridge": ZeroPoint()})
+
+    assert len(predictions) == 1
+    assert len(predictions[0]) == len(mains)
+    assert np.isfinite(predictions[0]["fridge"]).all()
+    assert predictions[0]["fridge"].to_numpy() == pytest.approx(95.0)
+
+
+@pytest.mark.parametrize("module_name", MINMAX_MODULES)
+def test_classification_preprocessing_is_finite_for_all_off_target(module_name):
+    module = importlib.import_module(module_name)
+    cls = getattr(
+        module,
+        (
+            "ResNet_classification"
+            if module_name.endswith("resnet_classification")
+            else "RNN_attention_classification"
+        ),
+    )
+    model = cls({"device": "cpu"})
+    all_off = pd.DataFrame({"power": np.zeros(99, dtype=np.float32)})
+    model.set_appliance_params([("fridge", [all_off])])
+
+    _, processed_appliances = model.call_preprocessing(
+        [all_off], [("fridge", [all_off])], "train"
+    )
+    normalized = processed_appliances[0][1][0].to_numpy()
+
+    assert np.isfinite(normalized).all()
+    assert normalized == pytest.approx(0.0)
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    (
+        "nilmtk_contrib.torch.msdc",
+        "nilmtk_contrib.torch.msdc_without_crf",
+    ),
+)
+def test_msdc_preserves_dataset_specific_defaults_and_common_overrides(module_name):
+    cls = getattr(importlib.import_module(module_name), "MSDC")
+
+    redd = cls({"device": "cpu", "dataset": " REDD "})
+    assert redd.dataset == "redd"
+    assert redd.mains_mean == pytest.approx(352.32)
+    assert redd.mains_std == pytest.approx(608.42)
+
+    overridden = cls(
+        {
+            "device": "cpu",
+            "dataset": "redd",
+            "mains_mean": 1.0,
+            "mains_std": 2.0,
+        }
+    )
+    assert overridden.mains_mean == 1.0
+    assert overridden.mains_std == 2.0
+
+    with pytest.raises(ValueError, match="dataset"):
+        cls({"device": "cpu", "dataset": " "})
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name", "parameter", "value", "attribute"),
+    (
+        ("nilmtk_contrib.torch.TCN", "TCN", "num_levels", 2, "num_levels"),
+        ("nilmtk_contrib.torch.msdc", "MSDC", "num_states", 4, "num_states"),
+        (
+            "nilmtk_contrib.torch.msdc_without_crf",
+            "MSDC",
+            "out_len",
+            32,
+            "out_len",
+        ),
+        (
+            "nilmtk_contrib.torch.nilmformer",
+            "NILMFormer",
+            "d_model",
+            48,
+            "d_model",
+        ),
+        ("nilmtk_contrib.torch.reformer", "Reformer", "dim", 128, "dim"),
+        (
+            "nilmtk_contrib.torch.resnet_classification",
+            "ResNet_classification",
+            "classification_threshold",
+            25.0,
+            "classification_threshold",
+        ),
+        (
+            "nilmtk_contrib.torch.rnn_attention_classification",
+            "RNN_attention_classification",
+            "classification_loss_weight",
+            2.0,
+            "classification_loss_weight",
+        ),
+    ),
+)
+def test_model_specific_params_remain_owned_by_subclasses(
+    module_name, class_name, parameter, value, attribute
+):
+    cls = getattr(importlib.import_module(module_name), class_name)
+
+    model = cls({"device": "cpu", parameter: value})
+
+    assert getattr(model, attribute) == value
+
+
+def test_migration_contract_covers_every_registered_torch_model():
+    assert set(DEFAULTS_BY_MODULE) == {spec.module_name for spec in TORCH_MODEL_SPECS}


### PR DESCRIPTION
## Why

#105 introduced a shared, validated PyTorch runtime, but the 16 existing PyTorch disaggregators still duplicated device selection, common defaults, mutable model state, and normalization logic. That made fixes easy to apply inconsistently and each new model unnecessarily expensive to review.

## What changed

- migrate all 16 existing PyTorch disaggregators to `TorchDisaggregator`
- centralize common defaults with typo-safe `torch_defaults(...)` overrides
- preserve every model-specific legacy default, including DAE, RNN, ResNet, MSDC, and NILMFormer values
- centralize appliance-statistics collection while retaining each model's required fields
- validate model maps atomically before inference: mapping shape, module type, normalization fields, and parameter/buffer device
- resolve generic `cuda` to the concrete current CUDA index, preventing silent cross-GPU mismatches
- detach caller-owned model and statistics mappings
- keep flat all-off classification targets finite without changing their physical denormalization range
- add structural contract tests so migrated models cannot silently reintroduce the removed boilerplate
- make the external Seq2Point model test execute non-empty inference and denormalization

## Scope and compatibility

This is deliberately a migration PR, not an architecture redesign. It adds no algorithms and changes no training loop. Public class names and model-specific defaults are preserved.

## Verification

- full suite: **374 passed, 76 skipped**
- focused shared-runtime and migration suite: **206 passed**
- `nilmtk_contrib/torch/_base.py`: **100% statement and branch coverage** (265 statements, 136 branches)
- opt-in synthetic CPU train -> infer smoke, one epoch: **all 16 PyTorch models passed**
- Ramanujan CUDA placement: **all 16 full networks passed** on an NVIDIA A100-SXM4-80GB; every parameter and buffer was on concrete `cuda:0`
- Ruff, `compileall`, and `git diff --check`: passed
- final-state sdist and wheel build: passed
- isolated wheel install/import: passed; missing Torch extra raises the intended `OptionalDependencyError`
- independent adversarial review found and drove fixes for flat-target NaNs, incomplete external-model validation, missing-stat failures, false-confidence empty inference, and CUDA-index mismatches; final re-review found no remaining P0-P2 issue

The remaining warnings are pre-existing framework warnings (same-padding, legacy `weight_norm`, and PyTables shutdown cleanup).

## Follow-up

After this lands, new algorithms such as PatchTST can use the shared runtime in a separate, much smaller PR. NILMbench integration and real-dataset benchmark results will also remain separate so each change is independently reviewable and revertible.
