### PR TITLE
Preserve every DAE row during partial-chunk inference

### DIFF
--- a/nilmtk_contrib/torch/dae.py
+++ b/nilmtk_contrib/torch/dae.py
@@ -24,53 +24,56 @@ from nilmtk_contrib.utils.validation import train_validation_split
 logger = get_logger(__name__)
 _log_print = legacy_print(logger)
 
+
 class DAEModel(nn.Module):
     """
     Convolutional autoencoder for appliance load disaggregation.
     """
+
     def __init__(self, seq_len):
         super().__init__()
         # PyTorch 1.10+ supports padding="same"
-        self.conv1   = nn.Conv1d(1,  8, kernel_size=4, padding="same")
+        self.conv1 = nn.Conv1d(1, 8, kernel_size=4, padding="same")
         self.flatten = nn.Flatten()
-        self.fc1     = nn.Linear(seq_len*8, seq_len*8)
-        self.fc2     = nn.Linear(seq_len*8, 128)
-        self.fc3     = nn.Linear(128, seq_len*8)
+        self.fc1 = nn.Linear(seq_len * 8, seq_len * 8)
+        self.fc2 = nn.Linear(seq_len * 8, 128)
+        self.fc3 = nn.Linear(128, seq_len * 8)
         # unflatten back to (batch, channels=8, seq_len)
         self.seq_len = seq_len
-        self.conv2   = nn.Conv1d(8, 1, kernel_size=4, padding="same")
+        self.conv2 = nn.Conv1d(8, 1, kernel_size=4, padding="same")
 
     def forward(self, x):
         # x: [batch, seq_len, 1]
-        x = x.permute(0,2,1)       # -> [batch, 1, seq_len]
+        x = x.permute(0, 2, 1)  # -> [batch, 1, seq_len]
         x = torch.relu(self.conv1(x))
-        x = self.flatten(x)        # -> [batch, 8*seq_len]
+        x = self.flatten(x)  # -> [batch, 8*seq_len]
         x = torch.relu(self.fc1(x))
         x = torch.relu(self.fc2(x))
-        x = torch.relu(self.fc3(x))# -> [batch, 8*seq_len]
+        x = torch.relu(self.fc3(x))  # -> [batch, 8*seq_len]
         x = x.view(-1, 8, self.seq_len)  # -> [batch, 8, seq_len]
-        x = self.conv2(x)          # -> [batch, 1, seq_len]
-        x = x.permute(0,2,1)       # -> [batch, seq_len, 1]
+        x = self.conv2(x)  # -> [batch, 1, seq_len]
+        x = x.permute(0, 2, 1)  # -> [batch, seq_len, 1]
         return x
+
 
 class DAE(TorchDisaggregator):
     """
     Denoising Autoencoder for non-intrusive load monitoring.
-    
+
     This implementation is based on the paper:
     "Neural NILM: Deep Neural Networks Applied to Energy Disaggregation"
     https://arxiv.org/abs/1507.06594
-    
+
     The model uses a denoising autoencoder architecture for energy disaggregation tasks,
     learning to reconstruct individual appliance power consumption from aggregate
     household power measurements.
-    
+
     Architecture Overview:
     - Convolutional encoder layer for feature extraction
     - Fully connected bottleneck layers for dimensionality reduction
     - Convolutional decoder layer for sequence reconstruction
     - Sequence-to-sequence prediction for energy disaggregation
-    
+
     Parameters:
         params (dict): Configuration parameters including:
             - sequence_length (int): Length of input sequences (default: 99)
@@ -82,10 +85,11 @@ class DAE(TorchDisaggregator):
             - save-model-path (str): Path to save trained models
             - pretrained-model-path (str): Path to load pre-trained models
     """
+
     def __init__(self, params=None):
         super().__init__(params, defaults=torch_defaults(mains_mean=1000))
-        self.MODEL_NAME        = "DAE"
-        self.file_prefix       = f"{self.MODEL_NAME.lower()}-temp-weights"
+        self.MODEL_NAME = "DAE"
+        self.file_prefix = f"{self.MODEL_NAME.lower()}-temp-weights"
         if self.load_model_path:
             self.load_model()
 
@@ -98,27 +102,27 @@ class DAE(TorchDisaggregator):
         Normalizes and windows the input data.
         """
         flat = data.flatten()
-        pad  = (n - flat.size % n) % n
+        pad = (n - flat.size % n) % n
         flat = np.concatenate([flat, np.zeros(pad)])
         if overlap:
             # sliding windows
-            w = np.array([flat[i:i+n] for i in range(len(flat)-n+1)])
+            w = np.array([flat[i : i + n] for i in range(len(flat) - n + 1)])
         else:
             # non-overlapping windows
             w = flat.reshape(-1, n)
-        return ((w - mean)/std).reshape(-1, n, 1)  # normalize and reshape for model
+        return ((w - mean) / std).reshape(-1, n, 1)  # normalize and reshape for model
 
     def denormalize_output(self, data, mean, std):
         """
         Denormalizes the output data.
         """
-        return mean + data*std
+        return mean + data * std
 
     def call_preprocessing(self, mains_lst, subs, method):
         """
         Preprocesses the mains and appliance data.
         """
-        if method == 'train':
+        if method == "train":
             pm, apps = [], []
             for mains in mains_lst:
                 x = self.normalize_input(
@@ -126,14 +130,19 @@ class DAE(TorchDisaggregator):
                     self.sequence_length,
                     self.mains_mean,
                     self.mains_std,
-                    True
+                    True,
                 )
                 pm.append(pd.DataFrame(x.reshape(-1, self.sequence_length)))
             for name, lst in subs:
-                m,s = self.appliance_params[name]['mean'], self.appliance_params[name]['std']
+                m, s = (
+                    self.appliance_params[name]["mean"],
+                    self.appliance_params[name]["std"],
+                )
                 dfs = []
                 for df in lst:
-                    y = self.normalize_input(df.values, self.sequence_length, m, s, True)
+                    y = self.normalize_input(
+                        df.values, self.sequence_length, m, s, True
+                    )
                     dfs.append(pd.DataFrame(y.reshape(-1, self.sequence_length)))
                 apps.append((name, dfs))
             return pm, apps
@@ -146,12 +155,14 @@ class DAE(TorchDisaggregator):
                 self.sequence_length,
                 self.mains_mean,
                 self.mains_std,
-                False
+                False,
             )
             pm.append(pd.DataFrame(x.reshape(-1, self.sequence_length)))
         return pm
 
-    def partial_fit(self, train_main, train_appliances, do_preprocessing=True, current_epoch=0, **_):
+    def partial_fit(
+        self, train_main, train_appliances, do_preprocessing=True, current_epoch=0, **_
+    ):
         """
         Trains the model on a chunk of data.
         """
@@ -160,13 +171,15 @@ class DAE(TorchDisaggregator):
 
         if do_preprocessing:
             train_main, train_appliances = self.call_preprocessing(
-                train_main, train_appliances, 'train'
+                train_main, train_appliances, "train"
             )
-        mains_arr = pd.concat(train_main, axis=0).values.reshape(-1, self.sequence_length, 1)
+        mains_arr = pd.concat(train_main, axis=0).values.reshape(
+            -1, self.sequence_length, 1
+        )
 
         apps = []
         for name, dfs in train_appliances:
-            arr = pd.concat(dfs,axis=0).values.reshape(-1, self.sequence_length, 1)
+            arr = pd.concat(dfs, axis=0).values.reshape(-1, self.sequence_length, 1)
             apps.append((name, arr))
 
         for name, arr in apps:
@@ -189,15 +202,17 @@ class DAE(TorchDisaggregator):
                 continue
 
             tr_ds = TensorDataset(split.X_train, split.y_train)  # train set
-            tr = DataLoader(tr_ds, batch_size=self.batch_size, shuffle=True)  # train loader
+            tr = DataLoader(
+                tr_ds, batch_size=self.batch_size, shuffle=True
+            )  # train loader
             va = None
             if split.metadata.validation_enabled:
                 va_ds = TensorDataset(split.X_val, split.y_val)  # validation set
                 va = DataLoader(va_ds, batch_size=self.batch_size)  # validation loader
 
-            opt     = optim.Adam(model.parameters())
+            opt = optim.Adam(model.parameters())
             loss_fn = nn.MSELoss()
-            best = float('inf')
+            best = float("inf")
             with temporary_checkpoint(".pt") as ckpt:
                 epochs = tqdm(range(self.n_epochs), desc=name, disable=not self.verbose)
                 for _ in epochs:
@@ -219,7 +234,7 @@ class DAE(TorchDisaggregator):
                                 xb, yb = xb.to(self.device), yb.to(self.device)
                                 vl.append(loss_fn(model(xb), yb).item())
                         if vl:
-                            val_loss = sum(vl)/len(vl)
+                            val_loss = sum(vl) / len(vl)
                             if val_loss < best:
                                 best = val_loss
                                 save_torch_state(model, ckpt)
@@ -243,7 +258,9 @@ class DAE(TorchDisaggregator):
             appliance_params=self.appliance_params,
             mains_mean=self.mains_mean,
             mains_std=self.mains_std,
-            dependencies=collect_dependencies(["nilmtk-contrib", "torch", "numpy", "pandas"]),
+            dependencies=collect_dependencies(
+                ["nilmtk-contrib", "torch", "numpy", "pandas"]
+            ),
         )
         save_metadata(model_folder, metadata)
         for name, m in self.models.items():
@@ -266,47 +283,144 @@ class DAE(TorchDisaggregator):
             logger.warning(
                 "Loading legacy %s model metadata from model.json.", self.MODEL_NAME
             )
-            with open(model_folder / 'model.json') as f:
+            with open(model_folder / "model.json") as f:
                 p = json.load(f)
-        self.sequence_length = p['sequence_length']
-        self.mains_mean      = p['mains_mean']
-        self.mains_std       = p['mains_std']
-        self.appliance_params= p['appliance_params']
+        self.sequence_length = p["sequence_length"]
+        self.mains_mean = p["mains_mean"]
+        self.mains_std = p["mains_std"]
+        self.appliance_params = p["appliance_params"]
         for name in self.appliance_params:
             m = self.return_network()
             load_torch_state(m, model_folder / f"{name}.pt", self.device)
             self.models[name] = m
 
-    def disaggregate_chunk(self, test_main_list, do_preprocessing=True):
-        """
-        Disaggregates a chunk of mains data.
-        """
-        self.require_models()
+    def disaggregate_chunk(self, test_main_list, do_preprocessing=True, model=None):
+        """Disaggregate every sample without exposing preprocessing padding."""
+        models = self.require_models(model)
+        test_main_list = list(test_main_list)
+        if not test_main_list:
+            return []
+
+        output_metadata = []
         if do_preprocessing:
-            test_main_list = self.call_preprocessing(
-                test_main_list, None, 'test'
-            )
+            for position, frame in enumerate(test_main_list):
+                if not hasattr(frame, "index") or not hasattr(frame, "to_numpy"):
+                    raise TypeError(
+                        "Raw DAE inference chunks must be pandas objects with indexes."
+                    )
+                raw = frame.to_numpy()
+                if np.iscomplexobj(raw):
+                    raise TypeError(
+                        f"Inference mains chunk {position} must be real numeric data."
+                    )
+                try:
+                    values = np.asarray(raw, dtype=np.float64)
+                except (TypeError, ValueError) as exc:
+                    raise TypeError(
+                        f"Inference mains chunk {position} must be real numeric data."
+                    ) from exc
+                if values.ndim == 1:
+                    pass
+                elif values.ndim == 2 and values.shape[1] == 1:
+                    values = values[:, 0]
+                else:
+                    raise ValueError(
+                        f"Inference mains chunk {position} must contain exactly "
+                        "one power column."
+                    )
+                if not np.isfinite(values).all():
+                    raise ValueError(
+                        f"Inference mains chunk {position} must contain only "
+                        "finite values."
+                    )
+                output_metadata.append((frame.index.copy(), len(values)))
+            test_main_list = self.call_preprocessing(test_main_list, None, "test")
+
         results = []
-        for tm in test_main_list:
-            arr = tm.values.reshape(-1, self.sequence_length, 1)
-            ds  = DataLoader(
+        for position, tm in enumerate(test_main_list):
+            try:
+                raw_windows = (
+                    tm.to_numpy() if hasattr(tm, "to_numpy") else np.asarray(tm)
+                )
+                if np.iscomplexobj(raw_windows):
+                    raise ValueError("complex values are unsupported")
+                with np.errstate(over="ignore", invalid="ignore"):
+                    windows = np.asarray(raw_windows, dtype=np.float32)
+            except (TypeError, ValueError) as exc:
+                raise TypeError(
+                    f"Inference windows for chunk {position} must be real numeric data."
+                ) from exc
+            if windows.ndim != 2 or windows.shape[1] != self.sequence_length:
+                raise ValueError(
+                    f"Inference windows for chunk {position} must have shape "
+                    f"[samples, {self.sequence_length}]."
+                )
+            if not np.isfinite(windows).all():
+                raise ValueError(
+                    f"Inference windows for chunk {position} must contain only "
+                    "finite values."
+                )
+            arr = windows.reshape(-1, self.sequence_length, 1)
+            if do_preprocessing:
+                output_index, output_length = output_metadata[position]
+            else:
+                output_length = len(arr) * self.sequence_length
+                output_index = pd.RangeIndex(output_length)
+            ds = DataLoader(
                 TensorDataset(torch.tensor(arr, dtype=torch.float32)),
-                batch_size=self.batch_size
+                batch_size=self.batch_size,
             )
             outd = {}
-            for name, m in self.models.items():
+            for name, m in models.items():
                 preds = []
                 m.eval()
-                with torch.no_grad():
+                with torch.inference_mode():
                     for (xb,) in ds:
                         xb = xb.to(self.device)
-                        p  = m(xb).cpu().numpy()
-                        preds.append(p)
-                p_all = np.concatenate(preds).reshape(-1, self.sequence_length)
+                        prediction = m(xb)
+                        expected_shape = (len(xb), self.sequence_length, 1)
+                        if not isinstance(prediction, torch.Tensor):
+                            raise TypeError(
+                                f"Model for {name!r} must return a torch.Tensor."
+                            )
+                        if prediction.shape != expected_shape:
+                            raise ValueError(
+                                f"Model for {name!r} returned shape "
+                                f"{tuple(prediction.shape)}; expected "
+                                f"{expected_shape}."
+                            )
+                        if not torch.is_floating_point(prediction) or torch.is_complex(
+                            prediction
+                        ):
+                            raise TypeError(
+                                f"Model for {name!r} must return real floating values."
+                            )
+                        if prediction.device != xb.device:
+                            raise ValueError(
+                                f"Model for {name!r} returned values on "
+                                f"{prediction.device}; expected {xb.device}."
+                            )
+                        if not torch.isfinite(prediction).all():
+                            raise RuntimeError(
+                                f"Model for {name!r} returned non-finite values."
+                            )
+                        preds.append(prediction.detach().cpu())
+                if preds:
+                    p_all = torch.cat(preds).numpy().reshape(-1)
+                else:
+                    p_all = np.empty(0, dtype=np.float32)
+                p_all = p_all[:output_length]
                 mean = self.appliance_params[name]["mean"]
                 std = self.appliance_params[name]["std"]
-                p_den = self.denormalize_output(p_all, mean, std).flatten()
-                p_den = np.clip(p_den, 0, None)
-                outd[name] = pd.Series(p_den)
-            results.append(pd.DataFrame(outd, dtype='float32'))
+                with np.errstate(over="ignore", invalid="ignore"):
+                    p_den = self.denormalize_output(p_all.astype(np.float64), mean, std)
+                    p_den = np.clip(p_den, 0, None)
+                if not np.isfinite(p_den).all():
+                    raise RuntimeError(f"Predictions for {name!r} became non-finite.")
+                with np.errstate(over="ignore", invalid="ignore"):
+                    public_values = p_den.astype(np.float32)
+                if not np.isfinite(public_values).all():
+                    raise ValueError(f"Predictions for {name!r} overflow float32.")
+                outd[name] = public_values
+            results.append(pd.DataFrame(outd, index=output_index, dtype="float32"))
         return results

--- a/tests/test_dae_partial_inference.py
+++ b/tests/test_dae_partial_inference.py
@@ -1,0 +1,266 @@
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+torch = pytest.importorskip("torch")
+dae_module = pytest.importorskip("nilmtk_contrib.torch.dae")
+DAE = dae_module.DAE
+
+
+class RecordingSequence(torch.nn.Module):
+    def __init__(self, value=0.0):
+        super().__init__()
+        self.bias = torch.nn.Parameter(torch.tensor(float(value)))
+        self.batch_sizes = []
+
+    def forward(self, values):
+        self.batch_sizes.append(len(values))
+        return torch.ones_like(values) * self.bias
+
+
+class EchoSequence(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.bias = torch.nn.Parameter(torch.zeros(1))
+
+    def forward(self, values):
+        return values + self.bias
+
+
+class BadShape(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.bias = torch.nn.Parameter(torch.zeros(1))
+
+    def forward(self, values):
+        return values.squeeze(-1) + self.bias
+
+
+class NonFiniteSequence(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.bias = torch.nn.Parameter(torch.tensor(float("nan")))
+
+    def forward(self, values):
+        return torch.ones_like(values) * self.bias
+
+
+class NonTensorSequence(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.bias = torch.nn.Parameter(torch.zeros(1))
+
+    def forward(self, values):
+        return values.detach().cpu().numpy()
+
+
+class WrongOutputDevice(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.bias = torch.nn.Parameter(torch.zeros(1))
+
+    def forward(self, values):
+        return torch.empty(values.shape, device="meta")
+
+
+def _model(sequence_length=99, batch_size=4, appliance_params=None):
+    if appliance_params is None:
+        appliance_params = {"fridge": {"mean": 11.0, "std": 2.0}}
+    return DAE(
+        {
+            "device": "cpu",
+            "sequence_length": sequence_length,
+            "batch_size": batch_size,
+            "appliance_params": appliance_params,
+        }
+    )
+
+
+def _frame(length, start=0):
+    index = pd.Index(
+        np.arange(start, start + 2 * length, 2, dtype=np.int64), name="sample"
+    )
+    values = np.linspace(20.0, 40.0, length, dtype=np.float32)
+    return pd.DataFrame({"power": values}, index=index)
+
+
+@pytest.mark.parametrize("length", [0, 1, 98, 99, 100, 1024])
+def test_raw_inference_preserves_every_length_and_original_index(length):
+    model = _model()
+    mains = _frame(length, start=1000)
+
+    prediction = model.disaggregate_chunk(
+        [mains], model={"fridge": RecordingSequence(0.0)}
+    )[0]
+
+    assert len(prediction) == length
+    assert prediction.index.equals(mains.index)
+    assert prediction.columns.tolist() == ["fridge"]
+    assert prediction.dtypes.tolist() == [np.dtype("float32")]
+    np.testing.assert_array_equal(
+        prediction["fridge"].to_numpy(), np.full(length, 11.0, dtype=np.float32)
+    )
+
+
+def test_multiple_chunks_each_preserve_their_own_length_and_index():
+    lengths = [0, 1, 98, 99, 100, 2448]
+    mains = [
+        _frame(length, start=position * 10_000)
+        for position, length in enumerate(lengths)
+    ]
+    model = _model()
+
+    predictions = model.disaggregate_chunk(
+        mains, model={"fridge": RecordingSequence(0.5)}
+    )
+
+    assert len(predictions) == len(mains)
+    for source, prediction in zip(mains, predictions, strict=True):
+        assert len(prediction) == len(source)
+        assert prediction.index.equals(source.index)
+        assert np.isfinite(prediction.to_numpy()).all()
+        np.testing.assert_array_equal(
+            prediction["fridge"].to_numpy(),
+            np.full(len(source), 12.0, dtype=np.float32),
+        )
+
+
+def test_partial_final_batch_is_run_but_padding_is_trimmed():
+    model = _model(sequence_length=99, batch_size=4)
+    network = RecordingSequence(0.0)
+    mains = _frame(1024)
+
+    prediction = model.disaggregate_chunk([mains], model={"fridge": network})[0]
+
+    assert network.batch_sizes == [4, 4, 3]
+    assert len(prediction) == 1024
+    assert prediction.index.equals(mains.index)
+
+
+def test_trimmed_predictions_remain_row_aligned_not_shifted():
+    model = DAE(
+        {
+            "device": "cpu",
+            "sequence_length": 99,
+            "batch_size": 4,
+            "mains_mean": 0.0,
+            "mains_std": 1.0,
+            "appliance_params": {"fridge": {"mean": 0.0, "std": 1.0}},
+        }
+    )
+    mains = _frame(100, start=500)
+
+    prediction = model.disaggregate_chunk([mains], model={"fridge": EchoSequence()})[0]
+
+    assert prediction.index.equals(mains.index)
+    np.testing.assert_array_equal(
+        prediction["fridge"].to_numpy(), mains["power"].to_numpy()
+    )
+
+
+def test_external_model_mapping_is_validated_and_detached():
+    model = _model(sequence_length=7, batch_size=2)
+    mains = _frame(8)
+    external = {"fridge": RecordingSequence(0.0)}
+
+    prediction = model.disaggregate_chunk([mains], model=external)[0]
+    external["kettle"] = RecordingSequence(0.0)
+
+    assert len(prediction) == 8
+    assert model.models is not external
+    assert list(model.models) == ["fridge"]
+
+
+def test_real_dae_network_preserves_a_partial_raw_chunk():
+    model = _model(sequence_length=7, batch_size=2)
+    mains = _frame(8)
+
+    prediction = model.disaggregate_chunk(
+        [mains], model={"fridge": model.return_network()}
+    )[0]
+
+    assert len(prediction) == len(mains)
+    assert prediction.index.equals(mains.index)
+    assert np.isfinite(prediction.to_numpy()).all()
+
+
+def test_inference_requires_a_model_and_matching_normalization():
+    mains = _frame(1)
+    with pytest.raises(RuntimeError, match="trained or loaded"):
+        _model().disaggregate_chunk([mains])
+
+    with pytest.raises(ValueError, match="normalization parameters"):
+        _model(appliance_params={}).disaggregate_chunk(
+            [mains], model={"fridge": RecordingSequence()}
+        )
+
+    with pytest.raises(TypeError, match="torch.nn.Module"):
+        _model().disaggregate_chunk([mains], model={"fridge": object()})
+
+
+def test_inference_rejects_model_on_an_incompatible_device():
+    model = _model()
+    meta_model = torch.nn.Linear(1, 1, device="meta")
+
+    with pytest.raises(ValueError, match="incompatible device"):
+        model.disaggregate_chunk([_frame(1)], model={"fridge": meta_model})
+
+
+def test_inference_rejects_invalid_external_model_outputs():
+    model = _model(sequence_length=7)
+    mains = _frame(8)
+
+    with pytest.raises(ValueError, match="returned shape"):
+        model.disaggregate_chunk([mains], model={"fridge": BadShape()})
+    with pytest.raises(RuntimeError, match="non-finite"):
+        model.disaggregate_chunk([mains], model={"fridge": NonFiniteSequence()})
+    with pytest.raises(TypeError, match="torch.Tensor"):
+        model.disaggregate_chunk([mains], model={"fridge": NonTensorSequence()})
+    with pytest.raises(ValueError, match="returned values on"):
+        model.disaggregate_chunk([mains], model={"fridge": WrongOutputDevice()})
+
+
+@pytest.mark.parametrize("bad_value", [math.nan, math.inf, -math.inf])
+def test_raw_inference_rejects_nonfinite_mains(bad_value):
+    model = _model(sequence_length=7)
+    mains = _frame(8)
+    mains.iloc[3, 0] = bad_value
+
+    with pytest.raises(ValueError, match="finite"):
+        model.disaggregate_chunk([mains], model={"fridge": RecordingSequence()})
+
+
+def test_raw_inference_rejects_ambiguous_multiple_power_columns():
+    mains = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
+
+    with pytest.raises(ValueError, match="one power column"):
+        _model(sequence_length=7).disaggregate_chunk(
+            [mains], model={"fridge": RecordingSequence()}
+        )
+
+
+def test_public_float32_output_overflow_is_rejected():
+    model = _model(
+        sequence_length=7,
+        appliance_params={"fridge": {"mean": 0.0, "std": 1e300}},
+    )
+
+    with pytest.raises(ValueError, match="overflow float32"):
+        model.disaggregate_chunk([_frame(1)], model={"fridge": RecordingSequence(1.0)})
+
+
+def test_preprocessed_inference_retains_legacy_window_semantics():
+    model = _model(sequence_length=7, batch_size=2)
+    windows = pd.DataFrame(np.zeros((3, 7), dtype=np.float32))
+
+    prediction = model.disaggregate_chunk(
+        [windows],
+        do_preprocessing=False,
+        model={"fridge": RecordingSequence(0.0)},
+    )[0]
+
+    assert len(prediction) == 21
+    assert prediction.index.equals(pd.RangeIndex(21))


### PR DESCRIPTION
## Why

DAE padded inference chunks to a full sequence but returned the padding as predictions. A 2,448-row T0 input therefore produced 2,475 rows, breaking row alignment and making the result unsafe to benchmark.

## What changed

- trim only preprocessing padding while preserving every real sample
- preserve each raw chunk index independently, including empty and sub-sequence chunks
- execute partial final batches
- validate raw/preprocessed inputs and model output shape, dtype, device, and finiteness
- reject float32 overflow instead of silently publishing invalid predictions
- retain the established preprocessed-window behavior

## Verification

- full suite: 394 passed, 76 skipped
- DAE/shared-runtime regression suites: 226 passed
- adversarial partial-inference suite covers lengths 0, 1, 98, 99, 100, 1,024, and 2,448, multiple chunks, alignment, malformed inputs, malformed external models, non-finite values, and overflow
- one-epoch synthetic DAE model smoke: passed
- source distribution and wheel: built successfully
- Ruff and git diff checks: passed

The remaining PyTorch same-padding warning and PyTables exit warning are pre-existing and do not affect the assertions.