### PR TITLE
Add PatchTST on a shared sequence-to-point engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ The table below lists the public model surface. "Verification" describes how the
 | MSDC | PyTorch | `nilmtk_contrib.torch.MSDC` | NILM paper implementation requiring experiment validation for new claims | MSDC dual-CNN NILM paper | Canonical CRF-enabled implementation path |
 | MSDC without CRF | PyTorch | `nilmtk_contrib.torch.msdc_without_crf.MSDC` | MSDC ablation | MSDC paper/source implementation | No-CRF ablation, not the canonical MSDC path |
 | NILMFormer | PyTorch | `nilmtk_contrib.torch.NILMFormer` | NILMFormer implementation requiring experiment validation for new claims | Petralia et al., NILMFormer | PyTorch backend |
+| PatchTST | PyTorch | `nilmtk_contrib.torch.PatchTST` | PatchTST-inspired sequence-to-point adaptation; benchmark claims require NILMbench result bundles | Nie et al., PatchTST | PyTorch backend |
 
 ## Reference Papers And Codebases
 
@@ -311,6 +312,7 @@ NILM-specific references:
 - Sudoso and Piccialli, "Non-Intrusive Load Monitoring with an Attention-based Deep Neural Network", arXiv:1912.00759, https://arxiv.org/abs/1912.00759.
 - MSDC, "Exploiting Multi-State Power Consumption in Non-intrusive Load Monitoring based on A Dual-CNN Model", arXiv:2302.05565, https://arxiv.org/abs/2302.05565.
 - Petralia et al., "NILMFormer: Non-Intrusive Load Monitoring that Accounts for Non-Stationarity", arXiv:2506.05880, https://arxiv.org/abs/2506.05880.
+- Nie et al., "A Time Series is Worth 64 Words: Long-term Forecasting with Transformers", arXiv:2211.14730, https://arxiv.org/abs/2211.14730.
 
 Generic architecture references:
 
@@ -339,4 +341,3 @@ Supported experiment workflows include:
 - Training and testing across multiple buildings.
 - Training and testing with artificial aggregate.
 - Training and testing with different sampling frequencies.
-

--- a/nilmtk_contrib/metadata.py
+++ b/nilmtk_contrib/metadata.py
@@ -32,6 +32,7 @@ MODEL_CATALOG = (
     ModelCatalogEntry("MSDC", "torch", "nilmtk_contrib.torch.msdc", "MSDC", "nilmtk_contrib.torch"),
     ModelCatalogEntry("MSDC without CRF", "torch", "nilmtk_contrib.torch.msdc_without_crf", "MSDC", None),
     ModelCatalogEntry("NILMFormer", "torch", "nilmtk_contrib.torch.nilmformer", "NILMFormer", "nilmtk_contrib.torch"),
+    ModelCatalogEntry("PatchTST", "torch", "nilmtk_contrib.torch.patchtst", "PatchTST", "nilmtk_contrib.torch"),
     ModelCatalogEntry("Reformer", "torch", "nilmtk_contrib.torch.reformer", "Reformer", "nilmtk_contrib.torch"),
     ModelCatalogEntry("ResNet", "torch", "nilmtk_contrib.torch.resnet", "ResNet", "nilmtk_contrib.torch"),
     ModelCatalogEntry("ResNet_classification", "torch", "nilmtk_contrib.torch.resnet_classification", "ResNet_classification", "nilmtk_contrib.torch"),

--- a/nilmtk_contrib/torch/__init__.py
+++ b/nilmtk_contrib/torch/__init__.py
@@ -10,6 +10,7 @@ _EXPORTS = {
     "DAE": ("nilmtk_contrib.torch.dae", "DAE"),
     "MSDC": ("nilmtk_contrib.torch.msdc", "MSDC"),
     "NILMFormer": ("nilmtk_contrib.torch.nilmformer", "NILMFormer"),
+    "PatchTST": ("nilmtk_contrib.torch.patchtst", "PatchTST"),
     "Reformer": ("nilmtk_contrib.torch.reformer", "Reformer"),
     "ResNet": ("nilmtk_contrib.torch.resnet", "ResNet"),
     "ResNet_classification": (

--- a/nilmtk_contrib/torch/_seq2point.py
+++ b/nilmtk_contrib/torch/_seq2point.py
@@ -1,0 +1,792 @@
+"""Reusable, fail-closed runtime for PyTorch sequence-to-point models."""
+
+from collections import OrderedDict
+from collections.abc import Mapping
+from contextlib import contextmanager
+from copy import deepcopy
+import hashlib
+import hmac
+import math
+from numbers import Real
+import os
+from pathlib import Path
+import re
+import tempfile
+import uuid
+
+import numpy as np
+import pandas as pd
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from nilmtk_contrib.torch._base import (
+    TorchDisaggregator,
+    _validate_appliance_name,
+)
+from nilmtk_contrib.utils.checkpoints import (
+    build_metadata,
+    collect_dependencies,
+    load_metadata,
+    load_torch_payload,
+    save_metadata_atomic,
+)
+from nilmtk_contrib.utils.logging import get_logger
+from nilmtk_contrib.utils.params import get_param, require_odd_sequence_length
+from nilmtk_contrib.utils.validation import train_validation_split
+
+
+logger = get_logger(__name__)
+
+
+def finite_number(name, value, *, minimum=None, strict=False):
+    """Return a finite float subject to an optional lower bound."""
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, Real)
+        or not math.isfinite(value)
+    ):
+        raise ValueError(f"{name} must be a finite number.")
+    if minimum is not None:
+        invalid = value <= minimum if strict else value < minimum
+        if invalid:
+            qualifier = "greater than" if strict else "at least"
+            raise ValueError(f"{name} must be {qualifier} {minimum}.")
+    return float(value)
+
+
+def _float32_array(frame, label):
+    """Convert real numeric input without silently accepting lossy values."""
+    raw = frame.to_numpy() if hasattr(frame, "to_numpy") else np.asarray(frame)
+    if not np.issubdtype(raw.dtype, np.number) or np.issubdtype(raw.dtype, np.bool_):
+        raise TypeError(f"{label} must contain real numeric data.")
+    if np.iscomplexobj(raw):
+        raise TypeError(f"{label} must contain real numeric data.")
+    if not np.isfinite(raw).all():
+        raise ValueError(f"{label} must contain only finite values.")
+    with np.errstate(over="ignore", invalid="ignore"):
+        values = np.asarray(raw, dtype=np.float32)
+    if not np.isfinite(values).all():
+        raise ValueError(f"{label} is not representable as float32.")
+    return values
+
+
+def power_vector(frame, label, *, allow_empty=False):
+    """Validate one raw power channel and return a float32 vector."""
+    values = _float32_array(frame, label)
+    if values.ndim == 1:
+        vector = values
+    elif values.ndim == 2 and values.shape[1] == 1:
+        vector = values[:, 0]
+    else:
+        raise ValueError(f"{label} must contain exactly one power column.")
+    if not allow_empty and not len(vector):
+        raise ValueError(f"{label} must contain at least one sample.")
+    return vector
+
+
+def window_matrix(frame, sequence_length, label, *, allow_empty=False):
+    """Validate already-windowed sequence-to-point input."""
+    values = _float32_array(frame, label)
+    expected = ("samples", sequence_length)
+    if values.ndim != 2 or values.shape[1] != sequence_length:
+        raise ValueError(f"{label} must have shape {expected}; got {values.shape}.")
+    if not allow_empty and not len(values):
+        raise ValueError(f"{label} must contain at least one window.")
+    return values
+
+
+def centered_windows(values, sequence_length, mean, std):
+    """Create one zero-padded normalized window for every raw input row."""
+    values = power_vector(values, "mains", allow_empty=True)
+    if not len(values):
+        return np.empty((0, sequence_length), dtype=np.float32)
+    padding = sequence_length // 2
+    padded = np.pad(values, (padding, padding), mode="constant")
+    windows = np.lib.stride_tricks.sliding_window_view(padded, sequence_length)
+    with np.errstate(over="ignore", invalid="ignore"):
+        normalized = (windows.astype(np.float64) - mean) / std
+        normalized = normalized.astype(np.float32)
+    if not np.isfinite(normalized).all():
+        raise ValueError("Normalized mains windows must be finite float32 values.")
+    return np.ascontiguousarray(normalized)
+
+
+def _model_state_is_finite(model):
+    state = model.state_dict()
+    return all(
+        not (torch.is_floating_point(value) or torch.is_complex(value))
+        or torch.isfinite(value).all().item()
+        for value in (state[name] for name in state)
+    )
+
+
+def _snapshot_models(models):
+    snapshots = OrderedDict()
+    for appliance_name, model in models.items():
+        snapshots[appliance_name] = {
+            "model": model,
+            "state": {
+                name: value.detach().cpu().clone()
+                for name, value in model.state_dict().items()
+            },
+            "training": model.training,
+            "gradients": {
+                name: (
+                    None if parameter.grad is None else parameter.grad.detach().clone()
+                )
+                for name, parameter in model.named_parameters()
+            },
+        }
+    return snapshots
+
+
+def _restore_models(snapshots):
+    restored = OrderedDict()
+    for appliance_name, snapshot in snapshots.items():
+        model = snapshot["model"]
+        model.load_state_dict(snapshot["state"])
+        model.train(snapshot["training"])
+        for name, parameter in model.named_parameters():
+            gradient = snapshot["gradients"][name]
+            parameter.grad = (
+                None
+                if gradient is None
+                else gradient.to(parameter.device, parameter.dtype).clone()
+            )
+        restored[appliance_name] = model
+    return restored
+
+
+@contextmanager
+def _isolated_torch_rng(device, seed):
+    if seed is None:
+        yield
+        return
+    cuda_devices = [device.index] if device.type == "cuda" else []
+    mps = getattr(torch, "mps", None)
+    mps_state = None
+    if device.type == "mps" and mps is not None and hasattr(mps, "get_rng_state"):
+        mps_state = mps.get_rng_state()
+    with torch.random.fork_rng(devices=cuda_devices):
+        torch.manual_seed(seed)
+        if device.type == "cuda":
+            with torch.cuda.device(device):
+                torch.cuda.manual_seed(seed)
+        elif device.type == "mps" and mps is not None:
+            mps.manual_seed(seed)
+        try:
+            yield
+        finally:
+            if mps_state is not None:
+                mps.set_rng_state(mps_state)
+
+
+def _sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+class SequenceToPointTorchDisaggregator(TorchDisaggregator):
+    """Shared data, optimization, inference, and persistence contract.
+
+    Subclasses only define their network and architecture parameters.  The
+    engine keeps every raw row/index, validates preprocessed windows, trains
+    one model per appliance, and publishes checksum-bound checkpoints.
+    """
+
+    CHECKPOINT_PREFIX = None
+    MODEL_CONFIG_FIELDS = ()
+
+    def __init__(self, params=None, *, defaults):
+        super().__init__(params, defaults=defaults)
+        params = {} if params is None else params
+        require_odd_sequence_length(self.sequence_length)
+        self.learning_rate = finite_number(
+            "learning_rate",
+            get_param(params, "learning_rate", 1e-3),
+            minimum=0,
+            strict=True,
+        )
+        self.weight_decay = finite_number(
+            "weight_decay", get_param(params, "weight_decay", 0.0), minimum=0
+        )
+        self.validation_fraction = finite_number(
+            "validation_fraction",
+            get_param(params, "validation_fraction", 0.15),
+            minimum=0,
+            strict=True,
+        )
+        if self.validation_fraction >= 1:
+            raise ValueError("validation_fraction must be less than 1.")
+        self.validation_strategy = get_param(params, "validation_strategy", "tail")
+        if not isinstance(
+            self.validation_strategy, str
+        ) or self.validation_strategy not in {
+            "tail",
+            "random",
+        }:
+            raise ValueError("validation_strategy must be 'tail' or 'random'.")
+        self.gradient_clip_norm = finite_number(
+            "gradient_clip_norm",
+            get_param(params, "gradient_clip_norm", 1.0),
+            minimum=0,
+            strict=True,
+        )
+        self.last_split_metadata = OrderedDict()
+
+    def return_network(self):
+        raise NotImplementedError
+
+    def model_config(self):
+        fields = self.MODEL_CONFIG_FIELDS
+        if (
+            not isinstance(fields, tuple)
+            or len(fields) != len(set(fields))
+            or not all(isinstance(field, str) and field for field in fields)
+        ):
+            raise TypeError("MODEL_CONFIG_FIELDS must be a tuple of field names.")
+        return {field: getattr(self, field) for field in fields}
+
+    @staticmethod
+    def _index(frame, length):
+        index = getattr(frame, "index", None)
+        return index if index is not None else pd.RangeIndex(length)
+
+    def call_preprocessing(self, mains_lst, submeters_lst=None, method="test"):
+        if not isinstance(method, str) or method not in {"train", "test"}:
+            raise ValueError("method must be 'train' or 'test'.")
+        mains_frames = list(mains_lst)
+        processed_main = []
+        for chunk_index, frame in enumerate(mains_frames):
+            values = power_vector(
+                frame, f"mains chunk {chunk_index}", allow_empty=method == "test"
+            )
+            windows = centered_windows(
+                values, self.sequence_length, self.mains_mean, self.mains_std
+            )
+            processed_main.append(
+                pd.DataFrame(windows, index=self._index(frame, len(values)))
+            )
+        if method == "test":
+            return processed_main
+        if submeters_lst is None:
+            raise ValueError("Training requires appliance targets.")
+
+        processed_appliances = []
+        for appliance_name, frames in submeters_lst:
+            statistics = self._validated_appliance_stats(
+                appliance_name, self.REQUIRED_APPLIANCE_STATS
+            )
+            processed = []
+            for chunk_index, frame in enumerate(frames):
+                values = power_vector(
+                    frame, f"{appliance_name!r} target chunk {chunk_index}"
+                )
+                with np.errstate(over="ignore", invalid="ignore"):
+                    normalized = (
+                        (values.astype(np.float64) - statistics["mean"])
+                        / statistics["std"]
+                    ).astype(np.float32)
+                if not np.isfinite(normalized).all():
+                    raise ValueError(
+                        f"Normalized targets for {appliance_name!r} must be finite."
+                    )
+                processed.append(
+                    pd.DataFrame(normalized, index=self._index(frame, len(values)))
+                )
+            processed_appliances.append((appliance_name, processed))
+        return processed_main, processed_appliances
+
+    def _training_arrays(self, train_main, train_appliances, do_preprocessing):
+        mains_frames = list(train_main)
+        if not mains_frames:
+            raise ValueError("Training requires at least one mains chunk.")
+        appliance_entries = []
+        seen = set()
+        for entry in train_appliances:
+            try:
+                appliance_name, frames = entry
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    "Each appliance target must be a (name, frames) pair."
+                ) from exc
+            _validate_appliance_name(appliance_name)
+            if appliance_name in seen:
+                raise ValueError(f"Duplicate appliance name {appliance_name!r}.")
+            seen.add(appliance_name)
+            frames = list(frames)
+            if len(frames) != len(mains_frames):
+                raise ValueError(
+                    f"{appliance_name!r} has {len(frames)} chunks but mains has "
+                    f"{len(mains_frames)}."
+                )
+            appliance_entries.append((appliance_name, frames))
+        if not appliance_entries:
+            raise ValueError("Training requires at least one appliance target.")
+
+        missing = [
+            entry
+            for entry in appliance_entries
+            if entry[0] not in self.appliance_params
+        ]
+        if not do_preprocessing and missing:
+            raise ValueError(
+                "Preprocessed training requires appliance_params for every target."
+            )
+        if do_preprocessing:
+            mains_vectors = [
+                power_vector(frame, f"mains chunk {index}")
+                for index, frame in enumerate(mains_frames)
+            ]
+            for appliance_name, frames in appliance_entries:
+                for index, (mains_frame, target_frame) in enumerate(
+                    zip(mains_frames, frames)
+                ):
+                    target = power_vector(
+                        target_frame, f"{appliance_name!r} target chunk {index}"
+                    )
+                    if len(target) != len(mains_vectors[index]):
+                        raise ValueError(
+                            f"Mains and {appliance_name!r} target chunk {index} "
+                            "must contain the same number of samples."
+                        )
+                    if not self._index(mains_frame, len(target)).equals(
+                        self._index(target_frame, len(target))
+                    ):
+                        raise ValueError(
+                            f"Mains and {appliance_name!r} target chunk {index} "
+                            "must have aligned indexes."
+                        )
+            if missing:
+                self.set_appliance_params(missing)
+            processed_main, processed_appliances = self.call_preprocessing(
+                mains_frames, appliance_entries, method="train"
+            )
+        else:
+            processed_main, processed_appliances = mains_frames, appliance_entries
+
+        main_chunks = [
+            window_matrix(frame, self.sequence_length, f"mains chunk {index}")
+            for index, frame in enumerate(processed_main)
+        ]
+        targets_by_appliance = []
+        for appliance_name, frames in processed_appliances:
+            targets = []
+            for index, (main_chunk, frame) in enumerate(zip(main_chunks, frames)):
+                target = power_vector(
+                    frame, f"{appliance_name!r} target chunk {index}"
+                ).reshape(-1, 1)
+                if len(target) != len(main_chunk):
+                    raise ValueError(
+                        f"Processed mains and {appliance_name!r} target chunk "
+                        f"{index} must be aligned."
+                    )
+                if not self._index(processed_main[index], len(main_chunk)).equals(
+                    self._index(frame, len(target))
+                ):
+                    raise ValueError(
+                        f"Processed mains and {appliance_name!r} target chunk "
+                        f"{index} must have aligned indexes."
+                    )
+                targets.append(target)
+            targets_by_appliance.append((appliance_name, np.concatenate(targets)))
+        return np.concatenate(main_chunks), targets_by_appliance
+
+    def _checked_prediction(self, network, batch, appliance_name):
+        prediction = network(batch.to(self.device).unsqueeze(1))
+        if not isinstance(prediction, torch.Tensor):
+            raise TypeError(f"Model for {appliance_name!r} must return a torch.Tensor.")
+        if prediction.shape != (len(batch), 1):
+            raise ValueError(
+                f"Model for {appliance_name!r} returned shape "
+                f"{tuple(prediction.shape)}; expected ({len(batch)}, 1)."
+            )
+        if not torch.is_floating_point(prediction) or torch.is_complex(prediction):
+            raise TypeError(
+                f"Model for {appliance_name!r} must return real floating values."
+            )
+        if prediction.device != self.device:
+            raise ValueError(
+                f"Model for {appliance_name!r} returned values on "
+                f"{prediction.device}; expected {self.device}."
+            )
+        if not torch.isfinite(prediction).all():
+            raise FloatingPointError(
+                f"Model for {appliance_name!r} returned non-finite values."
+            )
+        return prediction
+
+    def _score(self, network, inputs, targets, appliance_name):
+        loader = DataLoader(
+            TensorDataset(torch.from_numpy(inputs), torch.from_numpy(targets)),
+            batch_size=self.batch_size,
+        )
+        total = torch.zeros((), device=self.device)
+        count = 0
+        network.eval()
+        with torch.inference_mode():
+            for batch_inputs, batch_targets in loader:
+                prediction = self._checked_prediction(
+                    network, batch_inputs, appliance_name
+                )
+                target = batch_targets.to(self.device)
+                total += nn.functional.mse_loss(prediction, target, reduction="sum")
+                count += len(batch_inputs)
+        score = (total / count).item()
+        if not math.isfinite(score):
+            raise FloatingPointError("Validation loss became non-finite.")
+        return score
+
+    def _fit_appliance(self, appliance_name, inputs, targets):
+        split = train_validation_split(
+            inputs,
+            targets,
+            validation_fraction=self.validation_fraction,
+            strategy=self.validation_strategy,
+            seed=self.seed,
+            min_train=1,
+            min_val=1,
+            allow_no_validation=True,
+        )
+        self.last_split_metadata[appliance_name] = split.metadata
+        if not split.metadata.should_train:
+            return
+        network = self.models.get(appliance_name)
+        if network is None:
+            network = self.return_network()
+            self.models[appliance_name] = network
+        loader = DataLoader(
+            TensorDataset(
+                torch.from_numpy(split.X_train), torch.from_numpy(split.y_train)
+            ),
+            batch_size=self.batch_size,
+            shuffle=True,
+            generator=(
+                None if self.seed is None else torch.Generator().manual_seed(self.seed)
+            ),
+        )
+        optimizer = torch.optim.AdamW(
+            network.parameters(), lr=self.learning_rate, weight_decay=self.weight_decay
+        )
+        best_loss = math.inf
+        best_state = None
+        for epoch in range(self.n_epochs):
+            network.train()
+            total = torch.zeros((), device=self.device)
+            count = 0
+            for batch_inputs, batch_targets in loader:
+                optimizer.zero_grad(set_to_none=True)
+                prediction = self._checked_prediction(
+                    network, batch_inputs, appliance_name
+                )
+                target = batch_targets.to(self.device)
+                loss = nn.functional.mse_loss(prediction, target)
+                loss.backward()
+                try:
+                    nn.utils.clip_grad_norm_(
+                        network.parameters(),
+                        self.gradient_clip_norm,
+                        error_if_nonfinite=True,
+                    )
+                except RuntimeError as exc:
+                    raise FloatingPointError(
+                        "Model gradients became non-finite."
+                    ) from exc
+                optimizer.step()
+                total += loss.detach() * len(batch_inputs)
+                count += len(batch_inputs)
+            if not _model_state_is_finite(network):
+                raise FloatingPointError("Optimizer produced non-finite model state.")
+            score = (total / count).item()
+            if split.metadata.validation_enabled:
+                score = self._score(network, split.X_val, split.y_val, appliance_name)
+            if not math.isfinite(score):
+                raise FloatingPointError("Epoch score became non-finite.")
+            if score < best_loss:
+                best_loss = score
+                best_state = {
+                    name: value.detach().cpu().clone()
+                    for name, value in network.state_dict().items()
+                }
+            if self.verbose:
+                logger.info(
+                    "%s %s epoch %d/%d score=%.6f",
+                    self.MODEL_NAME,
+                    appliance_name,
+                    epoch + 1,
+                    self.n_epochs,
+                    score,
+                )
+        if best_state is None:
+            raise RuntimeError(f"{self.MODEL_NAME} training produced no valid state.")
+        network.load_state_dict(best_state)
+        network.to(self.device)
+
+    def partial_fit(
+        self,
+        train_main,
+        train_appliances,
+        do_preprocessing=True,
+        current_epoch=0,
+        **_,
+    ):
+        del current_epoch
+        if not self.n_epochs:
+            raise ValueError(f"{self.MODEL_NAME} partial_fit requires an epoch.")
+        previous_params = deepcopy(self.appliance_params)
+        previous_splits = deepcopy(self.last_split_metadata)
+        previous_models = _snapshot_models(self.models)
+        try:
+            with _isolated_torch_rng(self.device, self.seed):
+                inputs, targets_by_appliance = self._training_arrays(
+                    train_main, train_appliances, do_preprocessing
+                )
+                if self.models:
+                    self.require_models()
+                for appliance_name, targets in targets_by_appliance:
+                    self._fit_appliance(appliance_name, inputs, targets)
+                if self.save_model_path:
+                    self.save_model()
+        except Exception:
+            self.appliance_params = previous_params
+            self.last_split_metadata = previous_splits
+            self.models = _restore_models(previous_models)
+            raise
+
+    def _normalized_predictions(self, windows, network, appliance_name):
+        loader = DataLoader(
+            TensorDataset(torch.from_numpy(windows)),
+            batch_size=self.batch_size,
+        )
+        batches = []
+        network.eval()
+        with torch.inference_mode():
+            for (batch,) in loader:
+                prediction = self._checked_prediction(network, batch, appliance_name)
+                batches.append(prediction.detach().to(dtype=torch.float32).cpu())
+        if not batches:
+            return np.empty(0, dtype=np.float32)
+        return torch.cat(batches).numpy().reshape(-1)
+
+    def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
+        models = self.require_models(model)
+        raw_frames = list(test_main_list)
+        if not raw_frames:
+            return []
+        if do_preprocessing:
+            processed = self.call_preprocessing(raw_frames, method="test")
+            indexes = [
+                self._index(frame, len(power_vector(frame, "mains", allow_empty=True)))
+                for frame in raw_frames
+            ]
+        else:
+            processed = raw_frames
+            indexes = [self._index(frame, len(frame)) for frame in raw_frames]
+
+        results = []
+        for chunk_index, (frame, output_index) in enumerate(zip(processed, indexes)):
+            windows = window_matrix(
+                frame,
+                self.sequence_length,
+                f"mains chunk {chunk_index}",
+                allow_empty=True,
+            )
+            if len(output_index) != len(windows):
+                raise ValueError(
+                    f"mains chunk {chunk_index} index length does not match windows."
+                )
+            columns = OrderedDict()
+            for appliance_name, network in models.items():
+                normalized = self._normalized_predictions(
+                    windows, network, appliance_name
+                )
+                statistics = self._validated_appliance_stats(
+                    appliance_name, self.REQUIRED_APPLIANCE_STATS
+                )
+                with np.errstate(over="ignore", invalid="ignore"):
+                    values = np.clip(
+                        statistics["mean"]
+                        + normalized.astype(np.float64) * statistics["std"],
+                        0,
+                        None,
+                    ).astype(np.float32)
+                if not np.isfinite(values).all():
+                    raise FloatingPointError(
+                        f"Predictions for {appliance_name!r} became non-finite."
+                    )
+                columns[appliance_name] = pd.Series(values, index=output_index)
+            results.append(pd.DataFrame(columns, index=output_index))
+        return results
+
+    def _checkpoint_pattern(self):
+        prefix = self.CHECKPOINT_PREFIX
+        if not isinstance(prefix, str) or not re.fullmatch(r"[a-z0-9-]+", prefix):
+            raise TypeError("CHECKPOINT_PREFIX must contain lowercase letters/digits.")
+        return re.compile(rf"^{re.escape(prefix)}-[0-9a-f]{{32}}\.pt$")
+
+    def save_model(self, folder_name=None):
+        models = self.require_models()
+        destination = folder_name or self.save_model_path
+        if not destination:
+            raise ValueError("save_model_path is required to save models.")
+        invalid = [
+            name for name, model in models.items() if not _model_state_is_finite(model)
+        ]
+        if invalid:
+            raise FloatingPointError(
+                f"Refusing to save non-finite model state for {invalid!r}."
+            )
+        folder = Path(destination)
+        folder.mkdir(parents=True, exist_ok=True)
+        pattern = self._checkpoint_pattern()
+        weights_name = f"{self.CHECKPOINT_PREFIX}-{uuid.uuid4().hex}.pt"
+        weights_path = folder / weights_name
+        if weights_path.exists():
+            raise RuntimeError("Checkpoint generation collision.")
+        payload = OrderedDict(
+            (
+                appliance_name,
+                OrderedDict(
+                    (name, value.detach().cpu().clone())
+                    for name, value in model.state_dict().items()
+                ),
+            )
+            for appliance_name, model in models.items()
+        )
+        temporary = None
+        committed = False
+        try:
+            with tempfile.NamedTemporaryFile(
+                dir=folder,
+                prefix=f".{self.CHECKPOINT_PREFIX}-",
+                suffix=".pt",
+                delete=False,
+            ) as handle:
+                temporary = Path(handle.name)
+            torch.save(payload, temporary)
+            os.replace(temporary, weights_path)
+            temporary = None
+            metadata = build_metadata(
+                model_class=self.MODEL_NAME,
+                backend="torch",
+                sequence_length=self.sequence_length,
+                appliance_params={name: self.appliance_params[name] for name in models},
+                mains_mean=self.mains_mean,
+                mains_std=self.mains_std,
+                dependencies=collect_dependencies(
+                    ["nilmtk-contrib", "torch", "numpy", "pandas"]
+                ),
+            )
+            metadata.update(
+                model_config=self.model_config(),
+                model_order=list(models),
+                weights_file=weights_name,
+                weights_sha256=_sha256(weights_path),
+            )
+            save_metadata_atomic(folder, metadata)
+            committed = True
+        finally:
+            if temporary is not None:
+                temporary.unlink(missing_ok=True)
+            if not committed:
+                weights_path.unlink(missing_ok=True)
+        for path in folder.glob(f"{self.CHECKPOINT_PREFIX}-*.pt"):
+            if path.name != weights_name and pattern.fullmatch(path.name):
+                try:
+                    path.unlink()
+                except OSError:
+                    logger.warning("Could not remove stale checkpoint %s.", path)
+
+    def load_model(self, folder_name=None):
+        source = folder_name or self.load_model_path
+        if not source:
+            raise ValueError("pretrained_model_path is required to load models.")
+        folder = Path(source)
+        metadata = load_metadata(
+            folder,
+            expected_model_class=self.MODEL_NAME,
+            expected_backend="torch",
+        )
+        config = metadata.get("model_config")
+        if not isinstance(config, Mapping) or set(config) != set(
+            self.MODEL_CONFIG_FIELDS
+        ):
+            raise ValueError("Checkpoint has an invalid model_config.")
+        model_order = metadata.get("model_order")
+        checkpoint_params = metadata.get("appliance_params")
+        if not isinstance(checkpoint_params, Mapping):
+            raise ValueError("Checkpoint has invalid appliance_params.")
+        if (
+            not isinstance(model_order, list)
+            or not model_order
+            or not all(isinstance(name, str) for name in model_order)
+            or len(model_order) != len(set(model_order))
+            or set(model_order) != set(checkpoint_params)
+        ):
+            raise ValueError("Checkpoint has an invalid model_order.")
+        weights_name = metadata.get("weights_file")
+        if (
+            not isinstance(weights_name, str)
+            or Path(weights_name).name != weights_name
+            or not self._checkpoint_pattern().fullmatch(weights_name)
+        ):
+            raise ValueError("Checkpoint has an unsafe weights_file.")
+        expected_digest = metadata.get("weights_sha256")
+        if not isinstance(expected_digest, str) or not re.fullmatch(
+            r"[0-9a-f]{64}", expected_digest
+        ):
+            raise ValueError("Checkpoint has an invalid weights_sha256.")
+        weights_path = folder / weights_name
+        if not weights_path.is_file():
+            raise ValueError("Checkpoint weights file does not exist.")
+        if not hmac.compare_digest(_sha256(weights_path), expected_digest):
+            raise ValueError("Checkpoint weights checksum does not match metadata.")
+        payload = load_torch_payload(weights_path, self.device)
+        if not isinstance(payload, Mapping) or list(payload) != model_order:
+            raise ValueError("Checkpoint weights do not match model_order.")
+
+        candidate_params = {
+            "sequence_length": metadata["sequence_length"],
+            "n_epochs": self.n_epochs,
+            "batch_size": self.batch_size,
+            "mains_mean": metadata["mains_mean"],
+            "mains_std": metadata["mains_std"],
+            "appliance_params": metadata["appliance_params"],
+            "chunk_wise_training": self.chunk_wise_training,
+            "seed": self.seed,
+            "verbose": self.verbose,
+            "device": self.device,
+            **dict(config),
+        }
+        candidate = type(self)(candidate_params)
+        loaded = OrderedDict()
+        for appliance_name in model_order:
+            network = candidate.return_network()
+            network.load_state_dict(payload[appliance_name])
+            if not _model_state_is_finite(network):
+                raise FloatingPointError(
+                    f"Checkpoint contains non-finite state for {appliance_name!r}."
+                )
+            loaded[appliance_name] = network
+        candidate.require_models(loaded)
+
+        self.sequence_length = candidate.sequence_length
+        self.mains_mean = candidate.mains_mean
+        self.mains_std = candidate.mains_std
+        self.appliance_params = deepcopy(candidate.appliance_params)
+        for field in self.MODEL_CONFIG_FIELDS:
+            setattr(self, field, getattr(candidate, field))
+        self.require_models(candidate.models)
+
+
+__all__ = [
+    "SequenceToPointTorchDisaggregator",
+    "centered_windows",
+    "finite_number",
+    "power_vector",
+    "window_matrix",
+]

--- a/nilmtk_contrib/torch/patchtst.py
+++ b/nilmtk_contrib/torch/patchtst.py
@@ -1,0 +1,167 @@
+"""PatchTST-inspired sequence-to-point energy disaggregator."""
+
+import torch
+from torch import nn
+
+from nilmtk_contrib.torch._base import torch_defaults
+from nilmtk_contrib.torch._seq2point import (
+    SequenceToPointTorchDisaggregator,
+    finite_number,
+)
+from nilmtk_contrib.utils.params import get_param, validate_positive_int
+
+
+class PatchTSTNetwork(nn.Module):
+    """Tokenize overlapping temporal patches, then regress the center point."""
+
+    def __init__(
+        self,
+        sequence_length,
+        patch_length=16,
+        patch_stride=8,
+        d_model=64,
+        n_heads=4,
+        n_layers=3,
+        d_ff=128,
+        dropout=0.1,
+    ):
+        super().__init__()
+        for name, value in (
+            ("sequence_length", sequence_length),
+            ("patch_length", patch_length),
+            ("patch_stride", patch_stride),
+            ("d_model", d_model),
+            ("n_heads", n_heads),
+            ("n_layers", n_layers),
+            ("d_ff", d_ff),
+        ):
+            validate_positive_int(name, value)
+        if patch_length > sequence_length:
+            raise ValueError("patch_length must not exceed sequence_length.")
+        if patch_stride > patch_length:
+            raise ValueError("patch_stride must not exceed patch_length.")
+        if d_model % n_heads:
+            raise ValueError("d_model must be divisible by n_heads.")
+        dropout = finite_number("dropout", dropout, minimum=0)
+        if dropout >= 1:
+            raise ValueError("dropout must be less than 1.")
+
+        self.sequence_length = sequence_length
+        self.patch_length = patch_length
+        self.patch_stride = patch_stride
+        self.num_patches = (sequence_length - patch_length) // patch_stride + 2
+        self.patch_projection = nn.Linear(patch_length, d_model)
+        self.position = nn.Parameter(torch.empty(1, self.num_patches, d_model))
+        layer = nn.TransformerEncoderLayer(
+            d_model=d_model,
+            nhead=n_heads,
+            dim_feedforward=d_ff,
+            dropout=dropout,
+            activation="gelu",
+            batch_first=True,
+        )
+        self.encoder = nn.TransformerEncoder(layer, num_layers=n_layers)
+        self.head = nn.Sequential(
+            nn.LayerNorm(self.num_patches * d_model),
+            nn.Linear(self.num_patches * d_model, 1),
+        )
+        nn.init.normal_(self.position, mean=0.0, std=0.02)
+
+    def forward(self, inputs):
+        if not isinstance(inputs, torch.Tensor):
+            raise TypeError("PatchTSTNetwork inputs must be a torch.Tensor.")
+        expected_shape = (1, self.sequence_length)
+        if inputs.ndim != 3 or inputs.shape[1:] != expected_shape:
+            raise ValueError(
+                "PatchTSTNetwork expects input shape "
+                f"(batch, 1, {self.sequence_length}); got {tuple(inputs.shape)}."
+            )
+        if not torch.is_floating_point(inputs) or torch.is_complex(inputs):
+            raise TypeError("PatchTSTNetwork inputs must be real floating tensors.")
+        device = self.patch_projection.weight.device
+        if inputs.device != device:
+            raise ValueError(
+                f"PatchTSTNetwork input is on {inputs.device}; model is on {device}."
+            )
+        if not torch.isfinite(inputs).all():
+            raise ValueError("PatchTSTNetwork inputs must be finite.")
+
+        inputs = inputs.to(dtype=self.patch_projection.weight.dtype)
+        padded = nn.functional.pad(inputs, (0, self.patch_stride), mode="replicate")
+        patches = padded.unfold(-1, self.patch_length, self.patch_stride)
+        tokens = self.patch_projection(patches.squeeze(1)) + self.position
+        encoded = self.encoder(tokens)
+        output = self.head(encoded.flatten(start_dim=1))
+        if not torch.isfinite(output).all():
+            raise RuntimeError("PatchTSTNetwork produced non-finite output.")
+        return output
+
+
+class PatchTST(SequenceToPointTorchDisaggregator):
+    """PatchTST patch encoder adapted to one NILM estimate per mains row."""
+
+    MODEL_NAME = "PatchTST"
+    CHECKPOINT_PREFIX = "patchtst"
+    MODEL_CONFIG_FIELDS = (
+        "patch_length",
+        "patch_stride",
+        "d_model",
+        "n_heads",
+        "n_layers",
+        "d_ff",
+        "dropout",
+        "learning_rate",
+        "weight_decay",
+        "validation_fraction",
+        "validation_strategy",
+        "gradient_clip_norm",
+    )
+
+    def __init__(self, params=None):
+        super().__init__(params, defaults=torch_defaults(batch_size=128))
+        params = {} if params is None else params
+        self.patch_length = validate_positive_int(
+            "patch_length", get_param(params, "patch_length", 16)
+        )
+        self.patch_stride = validate_positive_int(
+            "patch_stride", get_param(params, "patch_stride", 8)
+        )
+        self.d_model = validate_positive_int(
+            "d_model", get_param(params, "d_model", 64)
+        )
+        self.n_heads = validate_positive_int("n_heads", get_param(params, "n_heads", 4))
+        self.n_layers = validate_positive_int(
+            "n_layers", get_param(params, "n_layers", 3)
+        )
+        self.d_ff = validate_positive_int("d_ff", get_param(params, "d_ff", 128))
+        self.dropout = finite_number(
+            "dropout", get_param(params, "dropout", 0.1), minimum=0
+        )
+        self._validate_architecture()
+        if self.load_model_path:
+            self.load_model()
+
+    def _validate_architecture(self):
+        if self.patch_length > self.sequence_length:
+            raise ValueError("patch_length must not exceed sequence_length.")
+        if self.patch_stride > self.patch_length:
+            raise ValueError("patch_stride must not exceed patch_length.")
+        if self.d_model % self.n_heads:
+            raise ValueError("d_model must be divisible by n_heads.")
+        if self.dropout >= 1:
+            raise ValueError("dropout must be less than 1.")
+
+    def return_network(self):
+        return PatchTSTNetwork(
+            sequence_length=self.sequence_length,
+            patch_length=self.patch_length,
+            patch_stride=self.patch_stride,
+            d_model=self.d_model,
+            n_heads=self.n_heads,
+            n_layers=self.n_layers,
+            d_ff=self.d_ff,
+            dropout=self.dropout,
+        ).to(self.device)
+
+
+__all__ = ["PatchTST", "PatchTSTNetwork"]

--- a/nilmtk_contrib/utils/checkpoints.py
+++ b/nilmtk_contrib/utils/checkpoints.py
@@ -7,6 +7,7 @@ import atexit
 import importlib.metadata
 import inspect
 import json
+import os
 from pathlib import Path
 import tempfile
 
@@ -109,6 +110,31 @@ def save_metadata(path, metadata):
         json.dump(metadata, handle, indent=2, sort_keys=True)
 
 
+def save_metadata_atomic(path, metadata):
+    """Atomically publish metadata as the commit marker for a checkpoint set."""
+    folder = Path(path)
+    folder.mkdir(parents=True, exist_ok=True)
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=folder,
+            prefix=f".{METADATA_FILENAME}.",
+            delete=False,
+        ) as handle:
+            json.dump(metadata, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+            temporary = Path(handle.name)
+        os.replace(temporary, folder / METADATA_FILENAME)
+        temporary = None
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
 def load_metadata(path, *, expected_model_class=None, expected_backend=None):
     """Load and validate persistence metadata."""
     metadata_path = Path(path) / METADATA_FILENAME
@@ -155,14 +181,19 @@ def save_torch_state(model, path):
 
 def load_torch_state(model, path, device, weights_only=True):
     """Load a PyTorch state dict, using weights_only where supported."""
+    state = load_torch_payload(path, device, weights_only=weights_only)
+    model.load_state_dict(state)
+    return model
+
+
+def load_torch_payload(path, device, weights_only=True):
+    """Load a tensor-only PyTorch payload onto an explicit device."""
     import torch
 
     load_kwargs = {"map_location": device}
     if "weights_only" in inspect.signature(torch.load).parameters:
         load_kwargs["weights_only"] = weights_only
-    state = torch.load(path, **load_kwargs)
-    model.load_state_dict(state)
-    return model
+    return torch.load(path, **load_kwargs)
 
 
 def save_keras_weights(model, path):

--- a/tests/model_smoke_helpers.py
+++ b/tests/model_smoke_helpers.py
@@ -44,6 +44,7 @@ TORCH_MODEL_SPECS = (
     ModelSpec("torch", "nilmtk_contrib.torch", "MSDC", "nilmtk_contrib.torch.msdc", min_sequence_length=121),
     ModelSpec("torch", "nilmtk_contrib.torch", "MSDC", "nilmtk_contrib.torch.msdc_without_crf", min_sequence_length=121),
     ModelSpec("torch", "nilmtk_contrib.torch", "NILMFormer", "nilmtk_contrib.torch.nilmformer"),
+    ModelSpec("torch", "nilmtk_contrib.torch", "PatchTST", "nilmtk_contrib.torch.patchtst"),
     ModelSpec("torch", "nilmtk_contrib.torch", "Reformer", "nilmtk_contrib.torch.reformer"),
     ModelSpec("torch", "nilmtk_contrib.torch", "ResNet", "nilmtk_contrib.torch.resnet"),
     ModelSpec("torch", "nilmtk_contrib.torch", "ResNet_classification", "nilmtk_contrib.torch.resnet_classification"),

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -13,6 +13,7 @@ from nilmtk_contrib.utils.checkpoints import (
     managed_checkpoint_path,
     save_keras_weights,
     save_metadata,
+    save_metadata_atomic,
     save_torch_state,
     temporary_checkpoint,
     unsupported_persistence,
@@ -62,6 +63,14 @@ def test_build_save_and_load_metadata(tmp_path):
     assert loaded["mains_std"] == 600
     assert loaded["dependencies"] == {"torch": "2.0.0"}
     assert "created_at" in loaded
+
+
+def test_atomic_metadata_publish_leaves_no_temporary_files(tmp_path):
+    save_metadata_atomic(tmp_path, {"generation": 1})
+    save_metadata_atomic(tmp_path, {"generation": 2})
+
+    assert json.loads((tmp_path / "metadata.json").read_text()) == {"generation": 2}
+    assert list(tmp_path.glob(".metadata.json.*")) == []
 
 
 def test_load_metadata_rejects_missing_fields(tmp_path):

--- a/tests/test_model_registry_comprehensive.py
+++ b/tests/test_model_registry_comprehensive.py
@@ -106,7 +106,7 @@ def test_model_specs_cover_every_model_module_file(repo_root):
         repo_root / "nilmtk_contrib" / "torch",
     ):
         for path in package_dir.glob("*.py"):
-            if path.name in {"__init__.py", "_base.py", "preprocessing.py"}:
+            if path.name.startswith("_") or path.name == "preprocessing.py":
                 continue
             module_name = ".".join(path.relative_to(repo_root).with_suffix("").parts)
             model_files.add(module_name)
@@ -253,6 +253,7 @@ def test_model_self_method_calls_are_defined_or_known_runtime_methods(repo_root)
         "require_models",
         "save_model",
         "set_appliance_params",
+        "_validated_appliance_stats",
     }
     offenders = []
     for model_dir in (

--- a/tests/test_patchtst.py
+++ b/tests/test_patchtst.py
@@ -1,0 +1,168 @@
+import inspect
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+torch = pytest.importorskip("torch")
+metadata_module = pytest.importorskip("nilmtk_contrib.metadata")
+engine_module = pytest.importorskip("nilmtk_contrib.torch._seq2point")
+patchtst_module = pytest.importorskip("nilmtk_contrib.torch.patchtst")
+model_catalog_by_module = metadata_module.model_catalog_by_module
+SequenceToPointTorchDisaggregator = engine_module.SequenceToPointTorchDisaggregator
+PatchTST = patchtst_module.PatchTST
+PatchTSTNetwork = patchtst_module.PatchTSTNetwork
+
+
+def _params(**overrides):
+    return {
+        "device": "cpu",
+        "sequence_length": 9,
+        "n_epochs": 1,
+        "batch_size": 4,
+        "seed": 13,
+        "mains_mean": 100.0,
+        "mains_std": 40.0,
+        "patch_length": 3,
+        "patch_stride": 2,
+        "d_model": 8,
+        "n_heads": 2,
+        "n_layers": 1,
+        "d_ff": 16,
+        "dropout": 0.0,
+    } | overrides
+
+
+def _chunks(length=18):
+    values = np.arange(length, dtype=np.float32)
+    index = pd.date_range("2026-01-01", periods=length, freq="1min", tz="UTC")
+    appliance = 30.0 + 20.0 * ((values // 3) % 2)
+    mains = 60.0 + appliance + np.sin(values)
+    return (
+        [pd.DataFrame({"power": mains}, index=index)],
+        [("fridge", [pd.DataFrame({"power": appliance}, index=index)])],
+    )
+
+
+def test_patchtst_is_a_thin_consumer_of_the_shared_engine():
+    source = Path(inspect.getfile(PatchTST)).read_text()
+
+    assert issubclass(PatchTST, SequenceToPointTorchDisaggregator)
+    assert len(source.splitlines()) < 210
+    for method in ("partial_fit", "disaggregate_chunk", "save_model", "load_model"):
+        assert f"def {method}(" not in source
+
+
+def test_network_token_count_and_output_contract():
+    network = PatchTSTNetwork(
+        sequence_length=9,
+        patch_length=3,
+        patch_stride=2,
+        d_model=8,
+        n_heads=2,
+        n_layers=1,
+        d_ff=16,
+        dropout=0.0,
+    )
+
+    output = network(torch.ones(4, 1, 9))
+
+    assert network.num_patches == 5
+    assert output.shape == (4, 1)
+    assert torch.isfinite(output).all()
+
+
+@pytest.mark.parametrize(
+    ("params", "message"),
+    [
+        ({"sequence_length": 8}, "odd"),
+        ({"patch_length": 10}, "patch_length"),
+        ({"patch_stride": 4}, "patch_stride"),
+        ({"d_model": 7}, "divisible"),
+        ({"dropout": 1.0}, "less than 1"),
+        ({"dropout": np.nan}, "finite"),
+        ({"n_heads": True}, "positive integer"),
+        ({"validation_fraction": 1.0}, "less than 1"),
+        ({"learning_rate": 0.0}, "greater than"),
+    ],
+)
+def test_invalid_configuration_fails_at_construction(params, message):
+    with pytest.raises(ValueError, match=message):
+        PatchTST(_params(**params))
+
+
+@pytest.mark.parametrize(
+    "inputs",
+    [
+        torch.ones(2, 9),
+        torch.ones(2, 1, 8),
+        torch.ones(2, 1, 9, dtype=torch.int64),
+        torch.full((2, 1, 9), float("nan")),
+    ],
+)
+def test_network_rejects_invalid_inputs(inputs):
+    network = PatchTST(_params()).return_network()
+
+    with pytest.raises((TypeError, ValueError)):
+        network(inputs)
+
+
+def test_one_epoch_real_pipeline_smoke_preserves_every_row():
+    mains, targets = _chunks()
+    model = PatchTST(_params(appliance_params={}))
+
+    model.partial_fit(mains, targets)
+    result = model.disaggregate_chunk(mains)[0]
+
+    assert result.index.equals(mains[0].index)
+    assert result.columns.tolist() == ["fridge"]
+    assert result["fridge"].dtype == np.float32
+    assert np.isfinite(result["fridge"]).all()
+
+
+def test_seeded_training_is_reproducible_without_leaking_global_rng():
+    mains, targets = _chunks()
+    first = PatchTST(_params(appliance_params={}))
+    second = PatchTST(_params(appliance_params={}))
+    state_before = torch.random.get_rng_state().clone()
+
+    first.partial_fit(mains, targets)
+    state_after_first = torch.random.get_rng_state().clone()
+    second.partial_fit(mains, targets)
+
+    assert torch.equal(state_before, state_after_first)
+    assert torch.equal(state_before, torch.random.get_rng_state())
+    for key, value in first.models["fridge"].state_dict().items():
+        assert torch.equal(value, second.models["fridge"].state_dict()[key])
+
+
+def test_checkpoint_roundtrip_restores_architecture_and_predictions(tmp_path):
+    mains, targets = _chunks()
+    model = PatchTST(
+        _params(appliance_params={}, save_model_path=str(tmp_path), d_model=12)
+    )
+    model.partial_fit(mains, targets)
+    expected = model.disaggregate_chunk(mains)[0]
+
+    loaded = PatchTST(
+        _params(
+            appliance_params={},
+            pretrained_model_path=str(tmp_path),
+            d_model=8,
+        )
+    )
+    actual = loaded.disaggregate_chunk(mains)[0]
+
+    assert loaded.d_model == 12
+    assert np.allclose(actual, expected)
+
+
+def test_public_export_and_catalog_are_lazy_and_complete():
+    import nilmtk_contrib.torch as torch_models
+
+    entry = model_catalog_by_module()["nilmtk_contrib.torch.patchtst"]
+    assert torch_models.PatchTST is PatchTST
+    assert entry.class_name == "PatchTST"
+    assert entry.exported_from == "nilmtk_contrib.torch"

--- a/tests/test_seq2point_engine.py
+++ b/tests/test_seq2point_engine.py
@@ -1,0 +1,304 @@
+import json
+from collections import OrderedDict
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+torch = pytest.importorskip("torch")
+base_module = pytest.importorskip("nilmtk_contrib.torch._base")
+engine_module = pytest.importorskip("nilmtk_contrib.torch._seq2point")
+nn = torch.nn
+torch_defaults = base_module.torch_defaults
+SequenceToPointTorchDisaggregator = engine_module.SequenceToPointTorchDisaggregator
+centered_windows = engine_module.centered_windows
+power_vector = engine_module.power_vector
+window_matrix = engine_module.window_matrix
+
+
+class TinyNetwork(nn.Module):
+    def __init__(self, sequence_length):
+        super().__init__()
+        self.linear = nn.Linear(sequence_length, 1)
+
+    def forward(self, inputs):
+        return self.linear(inputs.squeeze(1))
+
+
+class TinyDisaggregator(SequenceToPointTorchDisaggregator):
+    MODEL_NAME = "Tiny"
+    CHECKPOINT_PREFIX = "tiny"
+    MODEL_CONFIG_FIELDS = (
+        "learning_rate",
+        "weight_decay",
+        "validation_fraction",
+        "validation_strategy",
+        "gradient_clip_norm",
+    )
+
+    def __init__(self, params=None):
+        super().__init__(params, defaults=torch_defaults(sequence_length=5, n_epochs=1))
+        if self.load_model_path:
+            self.load_model()
+
+    def return_network(self):
+        return TinyNetwork(self.sequence_length).to(self.device)
+
+
+def _params(**overrides):
+    return {
+        "device": "cpu",
+        "sequence_length": 5,
+        "n_epochs": 1,
+        "batch_size": 4,
+        "seed": 7,
+        "mains_mean": 10.0,
+        "mains_std": 2.0,
+        "appliance_params": {"fridge": {"mean": 5.0, "std": 2.0}},
+    } | overrides
+
+
+def _raw(values, *, start="2026-01-01"):
+    index = pd.date_range(start, periods=len(values), freq="1min", tz="UTC")
+    return pd.DataFrame({"power": np.asarray(values, dtype=np.float32)}, index=index)
+
+
+def _zero_network(sequence_length=5, bias=0.0):
+    network = TinyNetwork(sequence_length)
+    with torch.no_grad():
+        network.linear.weight.zero_()
+        network.linear.bias.fill_(bias)
+    return network
+
+
+def test_centered_windows_preserve_one_row_per_raw_sample():
+    result = centered_windows(np.array([8.0, 10.0, 12.0]), 5, 10.0, 2.0)
+
+    assert result.shape == (3, 5)
+    assert result.dtype == np.float32
+    assert result.tolist() == [
+        [-5.0, -5.0, -1.0, 0.0, 1.0],
+        [-5.0, -1.0, 0.0, 1.0, -5.0],
+        [-1.0, 0.0, 1.0, -5.0, -5.0],
+    ]
+
+
+@pytest.mark.parametrize(
+    ("values", "error", "message"),
+    [
+        ([[1.0, 2.0], [3.0, 4.0]], ValueError, "one power column"),
+        ([1.0, np.nan], ValueError, "finite"),
+        ([1.0, np.inf], ValueError, "finite"),
+        ([True, False], TypeError, "real numeric"),
+        ([1 + 2j], TypeError, "real numeric"),
+        (["1", "2"], TypeError, "real numeric"),
+    ],
+)
+def test_power_vector_rejects_ambiguous_or_lossy_inputs(values, error, message):
+    with pytest.raises(error, match=message):
+        power_vector(np.asarray(values), "power")
+
+
+def test_window_matrix_requires_exact_finite_shape():
+    valid = window_matrix(np.ones((3, 5)), 5, "windows")
+    assert valid.shape == (3, 5)
+
+    with pytest.raises(ValueError, match="shape"):
+        window_matrix(np.ones((3, 4)), 5, "windows")
+    with pytest.raises(ValueError, match="finite"):
+        window_matrix(np.full((3, 5), np.nan), 5, "windows")
+
+
+def test_raw_inference_preserves_independent_indexes_and_empty_chunks():
+    model = TinyDisaggregator(_params())
+    model.require_models({"fridge": _zero_network(bias=1.0)})
+    first = _raw([10.0, 11.0, 12.0])
+    second = _raw([13.0, 14.0], start="2026-02-01")
+    empty = _raw([], start="2026-03-01")
+
+    results = model.disaggregate_chunk([first, second, empty])
+
+    assert [len(result) for result in results] == [3, 2, 0]
+    assert results[0].index.equals(first.index)
+    assert results[1].index.equals(second.index)
+    assert results[2].index.equals(empty.index)
+    assert results[0]["fridge"].tolist() == [7.0, 7.0, 7.0]
+
+
+def test_preprocessed_inference_consumes_windows_without_rewindowing():
+    model = TinyDisaggregator(_params())
+    model.require_models({"fridge": _zero_network()})
+    index = pd.Index(["a", "b", "c"])
+    windows = pd.DataFrame(np.ones((3, 5), dtype=np.float32), index=index)
+
+    result = model.disaggregate_chunk([windows], do_preprocessing=False)[0]
+
+    assert len(result) == 3
+    assert result.index.equals(index)
+
+
+class _BadOutput(nn.Module):
+    def __init__(self, kind):
+        super().__init__()
+        self.anchor = nn.Parameter(torch.zeros(()))
+        self.kind = kind
+
+    def forward(self, inputs):
+        if self.kind == "shape":
+            return torch.zeros((len(inputs), 2)) + self.anchor
+        if self.kind == "integer":
+            return torch.zeros((len(inputs), 1), dtype=torch.int64)
+        if self.kind == "bfloat16":
+            return (torch.zeros((len(inputs), 1)) + self.anchor).to(torch.bfloat16)
+        return torch.full((len(inputs), 1), float("inf")) + self.anchor
+
+
+@pytest.mark.parametrize(
+    ("kind", "error", "message"),
+    [
+        ("shape", ValueError, "returned shape"),
+        ("integer", TypeError, "floating"),
+        ("nonfinite", FloatingPointError, "non-finite"),
+    ],
+)
+def test_inference_fails_closed_on_invalid_model_outputs(kind, error, message):
+    model = TinyDisaggregator(_params())
+    model.require_models({"fridge": _BadOutput(kind)})
+
+    with pytest.raises(error, match=message):
+        model.disaggregate_chunk([_raw([10.0, 11.0])])
+
+
+def test_inference_accepts_bfloat16_and_publishes_float32():
+    model = TinyDisaggregator(_params())
+    model.require_models({"fridge": _BadOutput("bfloat16")})
+
+    result = model.disaggregate_chunk([_raw([10.0, 11.0])])[0]
+
+    assert result["fridge"].dtype == np.float32
+    assert np.isfinite(result["fridge"]).all()
+
+
+def test_raw_training_validates_alignment_and_trains_a_finite_model():
+    model = TinyDisaggregator(_params(appliance_params={}))
+    mains = _raw([10, 12, 14, 16, 18, 20, 22, 24])
+    target = _raw([2, 4, 6, 8, 10, 12, 14, 16])
+
+    model.partial_fit([mains], [("fridge", [target])])
+    predictions = model.disaggregate_chunk([mains])[0]
+
+    assert list(model.models) == ["fridge"]
+    assert model.last_split_metadata["fridge"].should_train
+    assert predictions.index.equals(mains.index)
+    assert np.isfinite(predictions["fridge"]).all()
+
+
+def test_raw_training_rejects_misaligned_indexes_before_mutating_state():
+    model = TinyDisaggregator(_params(appliance_params={}))
+    mains = _raw([10, 12, 14])
+    target = _raw([2, 4, 6], start="2026-02-01")
+
+    with pytest.raises(ValueError, match="aligned indexes"):
+        model.partial_fit([mains], [("fridge", [target])])
+
+    assert model.models == {}
+    assert model.appliance_params == {}
+
+
+def test_failed_multitarget_fit_rolls_back_models_stats_and_split_metadata(monkeypatch):
+    model = TinyDisaggregator(_params())
+    original = _zero_network(bias=0.25)
+    model.require_models({"fridge": original})
+    original_state = {
+        key: value.detach().clone() for key, value in original.state_dict().items()
+    }
+    model.last_split_metadata["prior"] = "kept"
+    mains = _raw([10, 12, 14, 16])
+    target = _raw([2, 4, 6, 8])
+
+    def fail_on_second(appliance_name, inputs, targets):
+        if appliance_name == "kettle":
+            raise RuntimeError("boom")
+        with torch.no_grad():
+            model.models["fridge"].linear.bias.add_(10)
+
+    monkeypatch.setattr(model, "_fit_appliance", fail_on_second)
+    with pytest.raises(RuntimeError, match="boom"):
+        model.partial_fit([mains], [("fridge", [target]), ("kettle", [target])])
+
+    assert model.last_split_metadata == {"prior": "kept"}
+    assert list(model.appliance_params) == ["fridge"]
+    for key, value in model.models["fridge"].state_dict().items():
+        assert torch.equal(value, original_state[key])
+
+
+def test_checkpoint_roundtrip_is_single_bundle_checksum_bound_and_ordered(tmp_path):
+    model = TinyDisaggregator(_params(save_model_path=str(tmp_path)))
+    model.appliance_params["kettle"] = {"mean": 10.0, "std": 3.0}
+    model.require_models(
+        OrderedDict(
+            [
+                ("fridge", _zero_network(bias=1.0)),
+                ("kettle", _zero_network(bias=2.0)),
+            ]
+        )
+    )
+    model.save_model()
+    loaded = TinyDisaggregator(
+        _params(pretrained_model_path=str(tmp_path), appliance_params={})
+    )
+
+    metadata = json.loads((tmp_path / "metadata.json").read_text())
+    assert metadata["model_order"] == ["fridge", "kettle"]
+    assert len(list(tmp_path.glob("tiny-*.pt"))) == 1
+    assert list(loaded.models) == ["fridge", "kettle"]
+    actual = loaded.disaggregate_chunk([_raw([10.0, 12.0])])[0]
+    assert actual.columns.tolist() == ["fridge", "kettle"]
+    assert actual["fridge"].tolist() == [7.0, 7.0]
+    assert actual["kettle"].tolist() == [16.0, 16.0]
+
+
+def test_checkpoint_rejects_tampered_weights_and_path_traversal(tmp_path):
+    model = TinyDisaggregator(_params(save_model_path=str(tmp_path)))
+    model.require_models({"fridge": _zero_network()})
+    model.save_model()
+    metadata_path = tmp_path / "metadata.json"
+    metadata = json.loads(metadata_path.read_text())
+    weights_path = tmp_path / metadata["weights_file"]
+    weights_path.write_bytes(weights_path.read_bytes() + b"tampered")
+
+    with pytest.raises(ValueError, match="checksum"):
+        TinyDisaggregator(_params(pretrained_model_path=str(tmp_path)))
+
+    model.save_model()
+    metadata = json.loads(metadata_path.read_text())
+    metadata["weights_file"] = "../outside.pt"
+    metadata_path.write_text(json.dumps(metadata))
+    with pytest.raises(ValueError, match="unsafe"):
+        TinyDisaggregator(_params(pretrained_model_path=str(tmp_path)))
+
+
+def test_failed_metadata_publish_removes_uncommitted_weight(tmp_path, monkeypatch):
+    model = TinyDisaggregator(_params(save_model_path=str(tmp_path)))
+    model.require_models({"fridge": _zero_network()})
+
+    def fail(*_):
+        raise OSError("metadata failure")
+
+    monkeypatch.setattr("nilmtk_contrib.torch._seq2point.save_metadata_atomic", fail)
+    with pytest.raises(OSError, match="metadata failure"):
+        model.save_model()
+
+    assert list(tmp_path.glob("tiny-*.pt")) == []
+    assert not (tmp_path / "metadata.json").exists()
+
+
+def test_model_source_owns_engine_contract_once():
+    source = Path(
+        __import__("nilmtk_contrib.torch._seq2point", fromlist=["__file__"]).__file__
+    ).read_text()
+
+    for method in ("partial_fit", "disaggregate_chunk", "save_model", "load_model"):
+        assert source.count(f"def {method}(") == 1

--- a/tests/test_torch_migration_contract.py
+++ b/tests/test_torch_migration_contract.py
@@ -29,6 +29,7 @@ DEFAULTS_BY_MODULE = {
     "nilmtk_contrib.torch.msdc": ExpectedDefaults(99, 50, 256, 1800, 600),
     "nilmtk_contrib.torch.msdc_without_crf": ExpectedDefaults(99, 50, 256, 1800, 600),
     "nilmtk_contrib.torch.nilmformer": ExpectedDefaults(99, 100, 1024, 1800, 600),
+    "nilmtk_contrib.torch.patchtst": ExpectedDefaults(99, 10, 128, 1800, 600),
     "nilmtk_contrib.torch.reformer": ExpectedDefaults(99, 10, 512, 1800, 600),
     "nilmtk_contrib.torch.resnet": ExpectedDefaults(299, 10, 512, 1800, 600),
     "nilmtk_contrib.torch.resnet_classification": ExpectedDefaults(
@@ -190,10 +191,13 @@ def test_torch_model_source_does_not_reintroduce_shared_boilerplate(spec):
         ), f"{label} remains in {source_path.name}"
 
     parameters = inspect.signature(getattr(module, spec.class_name).disaggregate_chunk)
+    method_source = inspect.getsource(
+        getattr(module, spec.class_name).disaggregate_chunk
+    )
     if "model" in parameters.parameters:
-        assert "self.require_models(model)" in source
+        assert "self.require_models(model)" in method_source
     else:
-        assert "self.require_models()" in source
+        assert "self.require_models()" in method_source
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What changed

- add a PatchTST-inspired sequence-to-point disaggregator as a 167-line model module
- introduce one reusable PyTorch sequence-to-point engine for input validation, row/index preservation, training, inference, rollback, and persistence
- publish all appliance states in one atomic, checksum-bound checkpoint bundle
- add lazy export, model catalog metadata, documentation, package-build coverage, and broad smoke registration

## Why this replaces #100

The old PatchTST branch accumulated model-local copies of generic training and checkpoint machinery. The replacement makes the algorithm file architecture-focused; ModernTCN, DLinear, and eligible existing models can reuse the same tested runtime instead of copying it.

## Failure modes covered

- raw and already-windowed input cardinality/index mismatch
- empty chunks; multiple chunks; timezone-aware indexes
- multi-column, boolean, string, complex, NaN/Inf, and float32-overflow input
- wrong-shape, integer, non-finite, and bfloat16 model output
- non-finite loss/gradient/model/checkpoint state
- multi-appliance partial-fit rollback and RNG isolation
- incomplete checkpoint publication, path traversal, checksum tampering, appliance-order mismatch, and stale bundle cleanup

## Verification

- `uv run --extra dev --extra torch ruff check .`
- `uv run --extra dev --extra torch pytest -q` — 443 passed, 79 skipped
- focused new-code coverage — 88% overall; PatchTST module 91%
- `uv build` — sdist and wheel both built; both include the new engine/model
