### PR TITLE
Add a required pull request CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  torch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Set up Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        run: python -m pip install uv==0.11.28
+
+      - name: Install locked dependencies
+        run: uv sync --frozen --group dev --extra torch
+
+      - name: Validate lock file
+        run: uv lock --check
+
+      - name: Lint
+        run: uv run ruff check nilmtk_contrib tests
+
+      - name: Run unit tests
+        run: uv run python -m pytest -q
+
+      - name: Smoke-test every PyTorch model
+        run: >-
+          uv run python -m pytest tests/test_model_smoke_synthetic.py
+          --run-model-smoke --model-smoke-backend torch
+          --model-smoke-epochs 1 -q
+
+      - name: Build distributions
+        run: uv build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
## What changed

Add a pinned, least-privilege GitHub Actions gate for every pull request and master push. It installs the locked PyTorch environment, checks the lock, lints, runs the full unit suite, smoke-tests every PyTorch model for one epoch, and builds both distribution artifacts.

## Why now

Current master has no pull-request workflow, so GitHub reports no checks for model PRs. This small prerequisite makes the PatchTST, ModernTCN, and DLinear merge sequence independently verifiable.

## Verification

The exact workflow commands were run locally against current master:

- lock/sync and lint passed
- unit suite: 394 passed, 76 skipped
- all-model PyTorch smoke: 16 passed, 13 non-Torch models skipped
- source distribution and wheel built successfully
