### PR TITLE
Add ModernTCN on the sequence-to-point engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ The table below lists the public model surface. "Verification" describes how the
 | Reformer | PyTorch | `nilmtk_contrib.torch.Reformer` | Reformer-inspired NILM adaptation | Kitaev, Kaiser, and Levskaya, Reformer | Efficient Transformer architecture adapted to NILM |
 | MSDC | PyTorch | `nilmtk_contrib.torch.MSDC` | NILM paper implementation requiring experiment validation for new claims | MSDC dual-CNN NILM paper | Canonical CRF-enabled implementation path |
 | MSDC without CRF | PyTorch | `nilmtk_contrib.torch.msdc_without_crf.MSDC` | MSDC ablation | MSDC paper/source implementation | No-CRF ablation, not the canonical MSDC path |
+| ModernTCN | PyTorch | `nilmtk_contrib.torch.ModernTCN` | ModernTCN-inspired sequence-to-point adaptation; benchmark claims require NILMbench result bundles | Luo and Wang, ModernTCN | PyTorch backend |
 | NILMFormer | PyTorch | `nilmtk_contrib.torch.NILMFormer` | NILMFormer implementation requiring experiment validation for new claims | Petralia et al., NILMFormer | PyTorch backend |
 | PatchTST | PyTorch | `nilmtk_contrib.torch.PatchTST` | PatchTST-inspired sequence-to-point adaptation; benchmark claims require NILMbench result bundles | Nie et al., PatchTST | PyTorch backend |
 
@@ -313,6 +314,7 @@ NILM-specific references:
 - MSDC, "Exploiting Multi-State Power Consumption in Non-intrusive Load Monitoring based on A Dual-CNN Model", arXiv:2302.05565, https://arxiv.org/abs/2302.05565.
 - Petralia et al., "NILMFormer: Non-Intrusive Load Monitoring that Accounts for Non-Stationarity", arXiv:2506.05880, https://arxiv.org/abs/2506.05880.
 - Nie et al., "A Time Series is Worth 64 Words: Long-term Forecasting with Transformers", arXiv:2211.14730, https://arxiv.org/abs/2211.14730.
+- Luo and Wang, "ModernTCN: A Modern Pure Convolution Structure for General Time Series Analysis", ICLR 2024, https://openreview.net/forum?id=vpJMJerXHU.
 
 Generic architecture references:
 

--- a/nilmtk_contrib/metadata.py
+++ b/nilmtk_contrib/metadata.py
@@ -31,6 +31,7 @@ MODEL_CATALOG = (
     ModelCatalogEntry("DAE", "torch", "nilmtk_contrib.torch.dae", "DAE", "nilmtk_contrib.torch"),
     ModelCatalogEntry("MSDC", "torch", "nilmtk_contrib.torch.msdc", "MSDC", "nilmtk_contrib.torch"),
     ModelCatalogEntry("MSDC without CRF", "torch", "nilmtk_contrib.torch.msdc_without_crf", "MSDC", None),
+    ModelCatalogEntry("ModernTCN", "torch", "nilmtk_contrib.torch.moderntcn", "ModernTCN", "nilmtk_contrib.torch"),
     ModelCatalogEntry("NILMFormer", "torch", "nilmtk_contrib.torch.nilmformer", "NILMFormer", "nilmtk_contrib.torch"),
     ModelCatalogEntry("PatchTST", "torch", "nilmtk_contrib.torch.patchtst", "PatchTST", "nilmtk_contrib.torch"),
     ModelCatalogEntry("Reformer", "torch", "nilmtk_contrib.torch.reformer", "Reformer", "nilmtk_contrib.torch"),

--- a/nilmtk_contrib/torch/__init__.py
+++ b/nilmtk_contrib/torch/__init__.py
@@ -9,6 +9,7 @@ _EXPORTS = {
     "ConvLSTM": ("nilmtk_contrib.torch.conv_lstm", "ConvLSTM"),
     "DAE": ("nilmtk_contrib.torch.dae", "DAE"),
     "MSDC": ("nilmtk_contrib.torch.msdc", "MSDC"),
+    "ModernTCN": ("nilmtk_contrib.torch.moderntcn", "ModernTCN"),
     "NILMFormer": ("nilmtk_contrib.torch.nilmformer", "NILMFormer"),
     "PatchTST": ("nilmtk_contrib.torch.patchtst", "PatchTST"),
     "Reformer": ("nilmtk_contrib.torch.reformer", "Reformer"),

--- a/nilmtk_contrib/torch/moderntcn.py
+++ b/nilmtk_contrib/torch/moderntcn.py
@@ -1,0 +1,269 @@
+"""Compact ModernTCN-inspired sequence-to-point energy disaggregator.
+
+This original NILM adaptation follows ModernTCN's patching, parallel
+large/small depthwise kernels, channel mixing, and residual design. It predicts
+the appliance value at the center of each aggregate-power window rather than a
+future value of the input series.
+"""
+
+from collections.abc import Mapping
+
+import torch
+from torch import nn
+
+from nilmtk_contrib.torch._base import torch_defaults
+from nilmtk_contrib.torch._seq2point import (
+    SequenceToPointTorchDisaggregator,
+    finite_number,
+)
+from nilmtk_contrib.utils.params import get_param, validate_positive_int
+
+
+class ModernTCNBlock(nn.Module):
+    """Residual multi-scale depthwise temporal convolution and channel mixer."""
+
+    def __init__(
+        self,
+        d_model,
+        d_ff,
+        large_kernel_size,
+        small_kernel_size,
+        dropout,
+    ):
+        super().__init__()
+        self.large_kernel = nn.Conv1d(
+            d_model,
+            d_model,
+            kernel_size=large_kernel_size,
+            padding=large_kernel_size // 2,
+            groups=d_model,
+            bias=False,
+        )
+        self.small_kernel = nn.Conv1d(
+            d_model,
+            d_model,
+            kernel_size=small_kernel_size,
+            padding=small_kernel_size // 2,
+            groups=d_model,
+            bias=False,
+        )
+        self.norm = nn.LayerNorm(d_model)
+        self.channel_mixer = nn.Sequential(
+            nn.Conv1d(d_model, d_ff, kernel_size=1),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Conv1d(d_ff, d_model, kernel_size=1),
+            nn.Dropout(dropout),
+        )
+
+    def forward(self, inputs):
+        mixed = self.large_kernel(inputs) + self.small_kernel(inputs)
+        mixed = self.norm(mixed.transpose(1, 2)).transpose(1, 2)
+        return inputs + self.channel_mixer(mixed)
+
+
+class ModernTCNNetwork(nn.Module):
+    """One-stage ModernTCN backbone with a centered scalar regression head."""
+
+    def __init__(
+        self,
+        sequence_length,
+        patch_length=16,
+        patch_stride=8,
+        d_model=64,
+        d_ff=128,
+        n_blocks=2,
+        large_kernel_size=51,
+        small_kernel_size=5,
+        dropout=0.1,
+    ):
+        super().__init__()
+        for name, value in (
+            ("sequence_length", sequence_length),
+            ("patch_length", patch_length),
+            ("patch_stride", patch_stride),
+            ("d_model", d_model),
+            ("d_ff", d_ff),
+            ("n_blocks", n_blocks),
+            ("large_kernel_size", large_kernel_size),
+            ("small_kernel_size", small_kernel_size),
+        ):
+            validate_positive_int(name, value)
+        if sequence_length % 2 == 0:
+            raise ValueError("sequence_length must be odd.")
+        if patch_length > sequence_length:
+            raise ValueError("patch_length must not exceed sequence_length.")
+        if patch_stride > patch_length:
+            raise ValueError("patch_stride must not exceed patch_length.")
+        for name, value in (
+            ("large_kernel_size", large_kernel_size),
+            ("small_kernel_size", small_kernel_size),
+        ):
+            if value % 2 == 0:
+                raise ValueError(f"{name} must be odd to preserve token alignment.")
+        if small_kernel_size > large_kernel_size:
+            raise ValueError("small_kernel_size must not exceed large_kernel_size.")
+        dropout = finite_number("dropout", dropout, minimum=0)
+        if dropout >= 1:
+            raise ValueError("dropout must be less than 1.")
+
+        self.sequence_length = sequence_length
+        self.patch_length = patch_length
+        self.patch_stride = patch_stride
+        remainder = (sequence_length - patch_length) % patch_stride
+        self.end_padding = (patch_stride - remainder) % patch_stride
+        padded_length = sequence_length + self.end_padding
+        self.num_patches = (padded_length - patch_length) // patch_stride + 1
+        patch_centers = (
+            torch.arange(self.num_patches, dtype=torch.float64) * patch_stride
+            + (patch_length - 1) / 2
+        )
+        sequence_center = (sequence_length - 1) / 2
+        self.center_patch_index = int(
+            torch.argmin(torch.abs(patch_centers - sequence_center)).item()
+        )
+
+        self.patch_embedding = nn.Conv1d(
+            1, d_model, kernel_size=patch_length, stride=patch_stride
+        )
+        self.blocks = nn.Sequential(
+            *[
+                ModernTCNBlock(
+                    d_model,
+                    d_ff,
+                    large_kernel_size,
+                    small_kernel_size,
+                    dropout,
+                )
+                for _ in range(n_blocks)
+            ]
+        )
+        self.final_norm = nn.LayerNorm(d_model)
+        self.head = nn.Sequential(nn.Dropout(dropout), nn.Linear(2 * d_model, 1))
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        for module in self.modules():
+            if isinstance(module, nn.Conv1d):
+                nn.init.kaiming_normal_(module.weight, nonlinearity="linear")
+                if module.bias is not None:
+                    nn.init.zeros_(module.bias)
+        nn.init.xavier_uniform_(self.head[-1].weight)
+        nn.init.zeros_(self.head[-1].bias)
+
+    def forward(self, inputs):
+        if not isinstance(inputs, torch.Tensor):
+            raise TypeError("ModernTCNNetwork inputs must be a torch.Tensor.")
+        expected_shape = (1, self.sequence_length)
+        if inputs.ndim != 3 or inputs.shape[1:] != expected_shape:
+            raise ValueError(
+                "ModernTCNNetwork expects input shape "
+                f"(batch, 1, {self.sequence_length}); got {tuple(inputs.shape)}."
+            )
+        if not torch.is_floating_point(inputs) or torch.is_complex(inputs):
+            raise TypeError("ModernTCNNetwork inputs must be real floating tensors.")
+        device = self.patch_embedding.weight.device
+        if inputs.device != device:
+            raise ValueError(
+                f"ModernTCNNetwork input is on {inputs.device}; model is on {device}."
+            )
+        if not torch.isfinite(inputs).all():
+            raise ValueError("ModernTCNNetwork inputs must be finite.")
+
+        inputs = inputs.to(dtype=self.patch_embedding.weight.dtype)
+        if self.end_padding:
+            inputs = nn.functional.pad(inputs, (0, self.end_padding), mode="replicate")
+        encoded = self.blocks(self.patch_embedding(inputs))
+        encoded = self.final_norm(encoded.transpose(1, 2)).transpose(1, 2)
+        center = encoded[:, :, self.center_patch_index]
+        pooled = encoded.mean(dim=-1)
+        output = self.head(torch.cat((center, pooled), dim=1))
+        if not torch.isfinite(output).all():
+            raise RuntimeError("ModernTCNNetwork produced non-finite output.")
+        return output
+
+
+class ModernTCN(SequenceToPointTorchDisaggregator):
+    """ModernTCN adapted to one NILM estimate per centered mains row."""
+
+    MODEL_NAME = "ModernTCN"
+    CHECKPOINT_PREFIX = "moderntcn"
+    MODEL_CONFIG_FIELDS = (
+        "patch_length",
+        "patch_stride",
+        "d_model",
+        "d_ff",
+        "n_blocks",
+        "large_kernel_size",
+        "small_kernel_size",
+        "dropout",
+        "learning_rate",
+        "weight_decay",
+        "validation_fraction",
+        "validation_strategy",
+        "gradient_clip_norm",
+    )
+
+    def __init__(self, params=None):
+        if params is None:
+            params = {}
+        if isinstance(params, Mapping):
+            params = dict(params)
+            params.setdefault("weight_decay", 1e-4)
+        super().__init__(
+            params, defaults=torch_defaults(sequence_length=299, batch_size=128)
+        )
+        self.patch_length = validate_positive_int(
+            "patch_length", get_param(params, "patch_length", 16)
+        )
+        self.patch_stride = validate_positive_int(
+            "patch_stride", get_param(params, "patch_stride", 8)
+        )
+        self.d_model = validate_positive_int(
+            "d_model", get_param(params, "d_model", 64)
+        )
+        self.d_ff = validate_positive_int("d_ff", get_param(params, "d_ff", 128))
+        self.n_blocks = validate_positive_int(
+            "n_blocks", get_param(params, "n_blocks", 2)
+        )
+        self.large_kernel_size = validate_positive_int(
+            "large_kernel_size", get_param(params, "large_kernel_size", 51)
+        )
+        self.small_kernel_size = validate_positive_int(
+            "small_kernel_size", get_param(params, "small_kernel_size", 5)
+        )
+        self.dropout = finite_number(
+            "dropout", get_param(params, "dropout", 0.1), minimum=0
+        )
+        self._validate_architecture()
+        if self.load_model_path:
+            self.load_model()
+
+    def _validate_architecture(self):
+        if self.patch_length > self.sequence_length:
+            raise ValueError("patch_length must not exceed sequence_length.")
+        if self.patch_stride > self.patch_length:
+            raise ValueError("patch_stride must not exceed patch_length.")
+        for name in ("large_kernel_size", "small_kernel_size"):
+            if getattr(self, name) % 2 == 0:
+                raise ValueError(f"{name} must be odd to preserve token alignment.")
+        if self.small_kernel_size > self.large_kernel_size:
+            raise ValueError("small_kernel_size must not exceed large_kernel_size.")
+        if self.dropout >= 1:
+            raise ValueError("dropout must be less than 1.")
+
+    def return_network(self):
+        return ModernTCNNetwork(
+            sequence_length=self.sequence_length,
+            patch_length=self.patch_length,
+            patch_stride=self.patch_stride,
+            d_model=self.d_model,
+            d_ff=self.d_ff,
+            n_blocks=self.n_blocks,
+            large_kernel_size=self.large_kernel_size,
+            small_kernel_size=self.small_kernel_size,
+            dropout=self.dropout,
+        ).to(self.device)
+
+
+__all__ = ["ModernTCN", "ModernTCNBlock", "ModernTCNNetwork"]

--- a/tests/model_smoke_helpers.py
+++ b/tests/model_smoke_helpers.py
@@ -43,6 +43,7 @@ TORCH_MODEL_SPECS = (
     ModelSpec("torch", "nilmtk_contrib.torch", "DAE", "nilmtk_contrib.torch.dae"),
     ModelSpec("torch", "nilmtk_contrib.torch", "MSDC", "nilmtk_contrib.torch.msdc", min_sequence_length=121),
     ModelSpec("torch", "nilmtk_contrib.torch", "MSDC", "nilmtk_contrib.torch.msdc_without_crf", min_sequence_length=121),
+    ModelSpec("torch", "nilmtk_contrib.torch", "ModernTCN", "nilmtk_contrib.torch.moderntcn"),
     ModelSpec("torch", "nilmtk_contrib.torch", "NILMFormer", "nilmtk_contrib.torch.nilmformer"),
     ModelSpec("torch", "nilmtk_contrib.torch", "PatchTST", "nilmtk_contrib.torch.patchtst"),
     ModelSpec("torch", "nilmtk_contrib.torch", "Reformer", "nilmtk_contrib.torch.reformer"),

--- a/tests/test_moderntcn.py
+++ b/tests/test_moderntcn.py
@@ -1,0 +1,170 @@
+import inspect
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+torch = pytest.importorskip("torch")
+metadata_module = pytest.importorskip("nilmtk_contrib.metadata")
+engine_module = pytest.importorskip("nilmtk_contrib.torch._seq2point")
+moderntcn_module = pytest.importorskip("nilmtk_contrib.torch.moderntcn")
+model_catalog_by_module = metadata_module.model_catalog_by_module
+SequenceToPointTorchDisaggregator = engine_module.SequenceToPointTorchDisaggregator
+ModernTCN = moderntcn_module.ModernTCN
+ModernTCNBlock = moderntcn_module.ModernTCNBlock
+ModernTCNNetwork = moderntcn_module.ModernTCNNetwork
+
+
+def _params(**overrides):
+    return {
+        "device": "cpu",
+        "sequence_length": 9,
+        "n_epochs": 1,
+        "batch_size": 4,
+        "seed": 17,
+        "mains_mean": 100.0,
+        "mains_std": 40.0,
+        "patch_length": 3,
+        "patch_stride": 2,
+        "d_model": 8,
+        "d_ff": 16,
+        "n_blocks": 1,
+        "large_kernel_size": 5,
+        "small_kernel_size": 3,
+        "dropout": 0.0,
+    } | overrides
+
+
+def _chunks(length=18):
+    values = np.arange(length, dtype=np.float32)
+    index = pd.date_range("2026-01-01", periods=length, freq="1min", tz="UTC")
+    appliance = 25.0 + 30.0 * ((values // 3) % 2)
+    mains = 70.0 + appliance + 3.0 * np.sin(values / 2)
+    return (
+        [pd.DataFrame({"power": mains}, index=index)],
+        [("fridge", [pd.DataFrame({"power": appliance}, index=index)])],
+    )
+
+
+def test_moderntcn_is_an_architecture_only_engine_consumer():
+    source = Path(inspect.getfile(ModernTCN)).read_text()
+
+    assert issubclass(ModernTCN, SequenceToPointTorchDisaggregator)
+    assert len(source.splitlines()) < 300
+    for method in ("partial_fit", "disaggregate_chunk", "save_model", "load_model"):
+        assert f"def {method}(" not in source
+
+
+def test_network_uses_depthwise_multiscale_kernels_and_center_features():
+    network = ModernTCN(_params()).return_network()
+    block = network.blocks[0]
+
+    assert isinstance(block, ModernTCNBlock)
+    assert block.large_kernel.groups == 8
+    assert block.small_kernel.groups == 8
+    assert block.large_kernel.kernel_size == (5,)
+    assert block.small_kernel.kernel_size == (3,)
+    assert network.num_patches == 4
+    assert network.center_patch_index == 1
+    assert network(torch.ones(4, 1, 9)).shape == (4, 1)
+
+
+def test_network_end_padding_covers_nondivisible_patch_grid():
+    network = ModernTCNNetwork(
+        sequence_length=11,
+        patch_length=4,
+        patch_stride=3,
+        d_model=4,
+        d_ff=8,
+        n_blocks=1,
+        large_kernel_size=5,
+        small_kernel_size=3,
+        dropout=0.0,
+    )
+
+    assert network.end_padding == 2
+    assert network.num_patches == 4
+    assert torch.isfinite(network(torch.ones(2, 1, 11))).all()
+
+
+@pytest.mark.parametrize(
+    ("params", "message"),
+    [
+        ({"sequence_length": 8}, "odd"),
+        ({"patch_length": 10}, "patch_length"),
+        ({"patch_stride": 4}, "patch_stride"),
+        ({"large_kernel_size": 4}, "must be odd"),
+        ({"small_kernel_size": 7}, "must not exceed"),
+        ({"dropout": 1.0}, "less than 1"),
+        ({"dropout": np.nan}, "finite"),
+        ({"n_blocks": True}, "positive integer"),
+        ({"weight_decay": -1.0}, "at least"),
+    ],
+)
+def test_invalid_configuration_fails_at_construction(params, message):
+    with pytest.raises(ValueError, match=message):
+        ModernTCN(_params(**params))
+
+
+@pytest.mark.parametrize(
+    "inputs",
+    [
+        torch.ones(2, 9),
+        torch.ones(2, 1, 8),
+        torch.ones(2, 1, 9, dtype=torch.int64),
+        torch.full((2, 1, 9), float("nan")),
+    ],
+)
+def test_network_rejects_invalid_inputs(inputs):
+    network = ModernTCN(_params()).return_network()
+
+    with pytest.raises((TypeError, ValueError)):
+        network(inputs)
+
+
+def test_one_epoch_train_infer_smoke_preserves_every_row():
+    mains, targets = _chunks()
+    model = ModernTCN(_params(appliance_params={}))
+
+    model.partial_fit(mains, targets)
+    result = model.disaggregate_chunk(mains)[0]
+
+    assert result.index.equals(mains[0].index)
+    assert result.columns.tolist() == ["fridge"]
+    assert result["fridge"].dtype == np.float32
+    assert np.isfinite(result["fridge"]).all()
+
+
+def test_checkpoint_roundtrip_restores_architecture_and_predictions(tmp_path):
+    mains, targets = _chunks()
+    model = ModernTCN(
+        _params(appliance_params={}, save_model_path=str(tmp_path), d_model=12)
+    )
+    model.partial_fit(mains, targets)
+    expected = model.disaggregate_chunk(mains)[0]
+
+    loaded = ModernTCN(
+        _params(
+            appliance_params={},
+            pretrained_model_path=str(tmp_path),
+            d_model=8,
+        )
+    )
+    actual = loaded.disaggregate_chunk(mains)[0]
+
+    assert loaded.d_model == 12
+    assert np.allclose(actual, expected)
+
+
+def test_public_export_catalog_and_defaults_are_complete():
+    import nilmtk_contrib.torch as torch_models
+
+    default = ModernTCN({"device": "cpu"})
+    entry = model_catalog_by_module()["nilmtk_contrib.torch.moderntcn"]
+    assert torch_models.ModernTCN is ModernTCN
+    assert default.sequence_length == 299
+    assert default.weight_decay == pytest.approx(1e-4)
+    assert entry.class_name == "ModernTCN"
+    assert entry.exported_from == "nilmtk_contrib.torch"

--- a/tests/test_torch_migration_contract.py
+++ b/tests/test_torch_migration_contract.py
@@ -28,6 +28,7 @@ DEFAULTS_BY_MODULE = {
     "nilmtk_contrib.torch.dae": ExpectedDefaults(99, 10, 512, 1000, 600),
     "nilmtk_contrib.torch.msdc": ExpectedDefaults(99, 50, 256, 1800, 600),
     "nilmtk_contrib.torch.msdc_without_crf": ExpectedDefaults(99, 50, 256, 1800, 600),
+    "nilmtk_contrib.torch.moderntcn": ExpectedDefaults(299, 10, 128, 1800, 600),
     "nilmtk_contrib.torch.nilmformer": ExpectedDefaults(99, 100, 1024, 1800, 600),
     "nilmtk_contrib.torch.patchtst": ExpectedDefaults(99, 10, 128, 1800, 600),
     "nilmtk_contrib.torch.reformer": ExpectedDefaults(99, 10, 512, 1800, 600),


### PR DESCRIPTION
## What changed

- add an original, compact ModernTCN-inspired sequence-to-point NILM adaptation
- keep the model PR architecture-focused by inheriting the merged engine for validation, row/index preservation, training, rollback, inference, and checksum-bound checkpoints
- add lazy export, catalog metadata, paper citation, all-model smoke registration, and checkpoint/smoke tests

## Architecture

Aggregate-power windows are patched, encoded with residual parallel large/small depthwise temporal kernels and pointwise channel mixing, then summarized through the center patch plus global pooled features for scalar appliance regression.

## Verification

- model module: 269 lines (old prototype: 864)
- 19 dedicated tests; 92% focused module coverage
- full suite: 470 passed, 82 skipped
- all-PyTorch one-epoch gate: 18 passed, 13 non-Torch models skipped
- repository lint clean
- source distribution and wheel both built and include `moderntcn.py`
