### PR TITLE
Add compact DLinear sequence-to-point model

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ The table below lists the public model surface. "Verification" describes how the
 | DSC | Classical | `nilmtk_contrib.disaggregate.DSC` | NILM paper implementation, not independently benchmark-certified in this package state | Kolter, Batra, and Ng, discriminative sparse coding | Requires `classical` extra |
 | DAE | TensorFlow | `nilmtk_contrib.disaggregate.DAE` | Neural NILM implementation requiring experiment validation for new claims | Kelly and Knottenbelt, Neural NILM | TensorFlow/Keras backend |
 | DAE | PyTorch | `nilmtk_contrib.torch.DAE` | PyTorch implementation requiring parity validation for new claims | Kelly and Knottenbelt, Neural NILM | PyTorch backend |
+| DLinear | PyTorch | `nilmtk_contrib.torch.DLinear` | DLinear-inspired sequence-to-point adaptation; benchmark claims require NILMbench result bundles | Zeng et al., DLinear | PyTorch backend |
 | RNN | TensorFlow | `nilmtk_contrib.disaggregate.RNN` | Neural NILM implementation requiring experiment validation for new claims | Kelly and Knottenbelt, Neural NILM | TensorFlow/Keras backend |
 | RNN | PyTorch | `nilmtk_contrib.torch.RNN` | PyTorch implementation requiring parity validation for new claims | Kelly and Knottenbelt, Neural NILM | PyTorch backend |
 | Seq2Point | TensorFlow | `nilmtk_contrib.disaggregate.Seq2Point` | NILM paper implementation requiring dataset-specific validation | Zhang et al., Sequence-to-Point Learning | TensorFlow/Keras backend |
@@ -315,6 +316,7 @@ NILM-specific references:
 - Petralia et al., "NILMFormer: Non-Intrusive Load Monitoring that Accounts for Non-Stationarity", arXiv:2506.05880, https://arxiv.org/abs/2506.05880.
 - Nie et al., "A Time Series is Worth 64 Words: Long-term Forecasting with Transformers", arXiv:2211.14730, https://arxiv.org/abs/2211.14730.
 - Luo and Wang, "ModernTCN: A Modern Pure Convolution Structure for General Time Series Analysis", ICLR 2024, https://openreview.net/forum?id=vpJMJerXHU.
+- Zeng et al., "Are Transformers Effective for Time Series Forecasting?", AAAI 2023, https://arxiv.org/abs/2205.13504.
 
 Generic architecture references:
 

--- a/nilmtk_contrib/metadata.py
+++ b/nilmtk_contrib/metadata.py
@@ -29,6 +29,7 @@ MODEL_CATALOG = (
     ModelCatalogEntry("BERT", "torch", "nilmtk_contrib.torch.bert", "BERT", "nilmtk_contrib.torch"),
     ModelCatalogEntry("ConvLSTM", "torch", "nilmtk_contrib.torch.conv_lstm", "ConvLSTM", "nilmtk_contrib.torch"),
     ModelCatalogEntry("DAE", "torch", "nilmtk_contrib.torch.dae", "DAE", "nilmtk_contrib.torch"),
+    ModelCatalogEntry("DLinear", "torch", "nilmtk_contrib.torch.dlinear", "DLinear", "nilmtk_contrib.torch"),
     ModelCatalogEntry("MSDC", "torch", "nilmtk_contrib.torch.msdc", "MSDC", "nilmtk_contrib.torch"),
     ModelCatalogEntry("MSDC without CRF", "torch", "nilmtk_contrib.torch.msdc_without_crf", "MSDC", None),
     ModelCatalogEntry("ModernTCN", "torch", "nilmtk_contrib.torch.moderntcn", "ModernTCN", "nilmtk_contrib.torch"),

--- a/nilmtk_contrib/torch/__init__.py
+++ b/nilmtk_contrib/torch/__init__.py
@@ -8,6 +8,7 @@ _EXPORTS = {
     "BERT": ("nilmtk_contrib.torch.bert", "BERT"),
     "ConvLSTM": ("nilmtk_contrib.torch.conv_lstm", "ConvLSTM"),
     "DAE": ("nilmtk_contrib.torch.dae", "DAE"),
+    "DLinear": ("nilmtk_contrib.torch.dlinear", "DLinear"),
     "MSDC": ("nilmtk_contrib.torch.msdc", "MSDC"),
     "ModernTCN": ("nilmtk_contrib.torch.moderntcn", "ModernTCN"),
     "NILMFormer": ("nilmtk_contrib.torch.nilmformer", "NILMFormer"),

--- a/nilmtk_contrib/torch/dlinear.py
+++ b/nilmtk_contrib/torch/dlinear.py
@@ -1,0 +1,125 @@
+"""DLinear-inspired sequence-to-point energy disaggregator."""
+
+import torch
+from torch import nn
+
+from nilmtk_contrib.torch._base import torch_defaults
+from nilmtk_contrib.torch._seq2point import SequenceToPointTorchDisaggregator
+from nilmtk_contrib.utils.params import get_param, validate_positive_int
+
+
+class SeriesDecomposition(nn.Module):
+    """Split a series into moving-average trend and seasonal residual."""
+
+    def __init__(self, moving_average):
+        super().__init__()
+        validate_positive_int("moving_average", moving_average)
+        if moving_average % 2 == 0:
+            raise ValueError("moving_average must be odd to preserve alignment.")
+        self.moving_average = moving_average
+        self.pool = nn.AvgPool1d(kernel_size=moving_average, stride=1)
+
+    def forward(self, inputs):
+        padding = self.moving_average // 2
+        padded = nn.functional.pad(inputs, (padding, padding), mode="replicate")
+        trend = self.pool(padded)
+        return inputs - trend, trend
+
+
+class DLinearNetwork(nn.Module):
+    """Decompose one input window and regress its centered appliance value."""
+
+    def __init__(self, sequence_length, moving_average=25):
+        super().__init__()
+        validate_positive_int("sequence_length", sequence_length)
+        validate_positive_int("moving_average", moving_average)
+        if sequence_length % 2 == 0:
+            raise ValueError("sequence_length must be odd.")
+        if moving_average % 2 == 0:
+            raise ValueError("moving_average must be odd to preserve alignment.")
+        if moving_average > sequence_length:
+            raise ValueError("moving_average must not exceed sequence_length.")
+
+        self.sequence_length = sequence_length
+        self.moving_average = moving_average
+        self.decomposition = SeriesDecomposition(moving_average)
+        self.seasonal_linear = nn.Linear(sequence_length, 1)
+        self.trend_linear = nn.Linear(sequence_length, 1)
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        initial_weight = 1.0 / self.sequence_length
+        nn.init.constant_(self.seasonal_linear.weight, initial_weight)
+        nn.init.constant_(self.trend_linear.weight, initial_weight)
+        nn.init.zeros_(self.seasonal_linear.bias)
+        nn.init.zeros_(self.trend_linear.bias)
+
+    def forward(self, inputs):
+        if not isinstance(inputs, torch.Tensor):
+            raise TypeError("DLinearNetwork inputs must be a torch.Tensor.")
+        expected_shape = (1, self.sequence_length)
+        if inputs.ndim != 3 or inputs.shape[1:] != expected_shape:
+            raise ValueError(
+                "DLinearNetwork expects input shape "
+                f"(batch, 1, {self.sequence_length}); got {tuple(inputs.shape)}."
+            )
+        if not torch.is_floating_point(inputs) or torch.is_complex(inputs):
+            raise TypeError("DLinearNetwork inputs must be real floating tensors.")
+        device = self.seasonal_linear.weight.device
+        if inputs.device != device:
+            raise ValueError(
+                f"DLinearNetwork input is on {inputs.device}; model is on {device}."
+            )
+        if not torch.isfinite(inputs).all():
+            raise ValueError("DLinearNetwork inputs must be finite.")
+
+        inputs = inputs.to(dtype=self.seasonal_linear.weight.dtype)
+        seasonal, trend = self.decomposition(inputs)
+        output = self.seasonal_linear(seasonal.squeeze(1)) + self.trend_linear(
+            trend.squeeze(1)
+        )
+        if not torch.isfinite(output).all():
+            raise RuntimeError("DLinearNetwork produced non-finite output.")
+        return output
+
+
+class DLinear(SequenceToPointTorchDisaggregator):
+    """DLinear adapted to one NILM estimate per centered mains row."""
+
+    MODEL_NAME = "DLinear"
+    CHECKPOINT_PREFIX = "dlinear"
+    MODEL_CONFIG_FIELDS = (
+        "moving_average",
+        "learning_rate",
+        "weight_decay",
+        "validation_fraction",
+        "validation_strategy",
+        "gradient_clip_norm",
+    )
+
+    def __init__(self, params=None):
+        super().__init__(
+            params, defaults=torch_defaults(sequence_length=299, batch_size=128)
+        )
+        params = {} if params is None else params
+        self.moving_average = validate_positive_int(
+            "moving_average", get_param(params, "moving_average", 25)
+        )
+        self._validate_architecture()
+        if self.load_model_path:
+            self.load_model()
+
+    def _validate_architecture(self):
+        if self.moving_average % 2 == 0:
+            raise ValueError("moving_average must be odd to preserve alignment.")
+        if self.moving_average > self.sequence_length:
+            raise ValueError("moving_average must not exceed sequence_length.")
+
+    def return_network(self):
+        return DLinearNetwork(
+            sequence_length=self.sequence_length,
+            moving_average=self.moving_average,
+        ).to(self.device)
+
+
+__all__ = ["DLinear", "DLinearNetwork", "SeriesDecomposition"]

--- a/tests/model_smoke_helpers.py
+++ b/tests/model_smoke_helpers.py
@@ -41,6 +41,7 @@ TORCH_MODEL_SPECS = (
     ModelSpec("torch", "nilmtk_contrib.torch", "BERT", "nilmtk_contrib.torch.bert"),
     ModelSpec("torch", "nilmtk_contrib.torch", "ConvLSTM", "nilmtk_contrib.torch.conv_lstm"),
     ModelSpec("torch", "nilmtk_contrib.torch", "DAE", "nilmtk_contrib.torch.dae"),
+    ModelSpec("torch", "nilmtk_contrib.torch", "DLinear", "nilmtk_contrib.torch.dlinear"),
     ModelSpec("torch", "nilmtk_contrib.torch", "MSDC", "nilmtk_contrib.torch.msdc", min_sequence_length=121),
     ModelSpec("torch", "nilmtk_contrib.torch", "MSDC", "nilmtk_contrib.torch.msdc_without_crf", min_sequence_length=121),
     ModelSpec("torch", "nilmtk_contrib.torch", "ModernTCN", "nilmtk_contrib.torch.moderntcn"),

--- a/tests/test_dlinear.py
+++ b/tests/test_dlinear.py
@@ -1,0 +1,151 @@
+import inspect
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+torch = pytest.importorskip("torch")
+metadata_module = pytest.importorskip("nilmtk_contrib.metadata")
+engine_module = pytest.importorskip("nilmtk_contrib.torch._seq2point")
+dlinear_module = pytest.importorskip("nilmtk_contrib.torch.dlinear")
+model_catalog_by_module = metadata_module.model_catalog_by_module
+SequenceToPointTorchDisaggregator = engine_module.SequenceToPointTorchDisaggregator
+DLinear = dlinear_module.DLinear
+DLinearNetwork = dlinear_module.DLinearNetwork
+SeriesDecomposition = dlinear_module.SeriesDecomposition
+
+
+def _params(**overrides):
+    return {
+        "device": "cpu",
+        "sequence_length": 9,
+        "moving_average": 3,
+        "n_epochs": 1,
+        "batch_size": 4,
+        "seed": 17,
+        "mains_mean": 100.0,
+        "mains_std": 40.0,
+    } | overrides
+
+
+def _chunks(length=18):
+    values = np.arange(length, dtype=np.float32)
+    index = pd.date_range("2026-01-01", periods=length, freq="1min", tz="UTC")
+    appliance = 25.0 + 30.0 * ((values // 3) % 2)
+    mains = 70.0 + appliance + 3.0 * np.sin(values / 2)
+    return (
+        [pd.DataFrame({"power": mains}, index=index)],
+        [("fridge", [pd.DataFrame({"power": appliance}, index=index)])],
+    )
+
+
+def test_dlinear_is_an_architecture_only_engine_consumer():
+    source = Path(inspect.getfile(DLinear)).read_text()
+
+    assert issubclass(DLinear, SequenceToPointTorchDisaggregator)
+    assert len(source.splitlines()) < 180
+    for method in ("partial_fit", "disaggregate_chunk", "save_model", "load_model"):
+        assert f"def {method}(" not in source
+
+
+def test_decomposition_reconstructs_input_and_preserves_constant_edges():
+    decomposition = SeriesDecomposition(3)
+    values = torch.tensor([[[1.0, 3.0, 2.0, 6.0, 4.0]]])
+    seasonal, trend = decomposition(values)
+
+    assert torch.allclose(seasonal + trend, values)
+    constant = torch.full((2, 1, 5), 7.0)
+    constant_seasonal, constant_trend = decomposition(constant)
+    assert torch.allclose(constant_seasonal, torch.zeros_like(constant))
+    assert torch.allclose(constant_trend, constant)
+
+
+def test_network_has_separate_linear_trend_and_seasonal_paths():
+    network = DLinearNetwork(sequence_length=9, moving_average=3)
+
+    assert network.seasonal_linear.in_features == 9
+    assert network.trend_linear.in_features == 9
+    assert sum(parameter.numel() for parameter in network.parameters()) == 20
+    assert network(torch.ones(4, 1, 9)).shape == (4, 1)
+    assert torch.allclose(network(torch.ones(1, 1, 9)), torch.ones(1, 1))
+
+
+@pytest.mark.parametrize(
+    ("params", "message"),
+    [
+        ({"sequence_length": 8}, "odd"),
+        ({"moving_average": 4}, "must be odd"),
+        ({"moving_average": 11}, "must not exceed"),
+        ({"moving_average": True}, "positive integer"),
+        ({"learning_rate": 0.0}, "greater than"),
+        ({"validation_fraction": 1.0}, "less than 1"),
+    ],
+)
+def test_invalid_configuration_fails_at_construction(params, message):
+    with pytest.raises(ValueError, match=message):
+        DLinear(_params(**params))
+
+
+@pytest.mark.parametrize(
+    "inputs",
+    [
+        torch.ones(2, 9),
+        torch.ones(2, 1, 8),
+        torch.ones(2, 1, 9, dtype=torch.int64),
+        torch.full((2, 1, 9), float("nan")),
+    ],
+)
+def test_network_rejects_invalid_inputs(inputs):
+    network = DLinear(_params()).return_network()
+
+    with pytest.raises((TypeError, ValueError)):
+        network(inputs)
+
+
+def test_one_epoch_train_infer_smoke_preserves_every_row():
+    mains, targets = _chunks()
+    model = DLinear(_params(appliance_params={}))
+
+    model.partial_fit(mains, targets)
+    result = model.disaggregate_chunk(mains)[0]
+
+    assert result.index.equals(mains[0].index)
+    assert result.columns.tolist() == ["fridge"]
+    assert result["fridge"].dtype == np.float32
+    assert np.isfinite(result["fridge"]).all()
+
+
+def test_checkpoint_roundtrip_restores_architecture_and_predictions(tmp_path):
+    mains, targets = _chunks()
+    model = DLinear(
+        _params(appliance_params={}, save_model_path=str(tmp_path), moving_average=5)
+    )
+    model.partial_fit(mains, targets)
+    expected = model.disaggregate_chunk(mains)[0]
+
+    loaded = DLinear(
+        _params(
+            appliance_params={},
+            pretrained_model_path=str(tmp_path),
+            moving_average=3,
+        )
+    )
+    actual = loaded.disaggregate_chunk(mains)[0]
+
+    assert loaded.moving_average == 5
+    assert np.allclose(actual, expected)
+
+
+def test_public_export_catalog_and_defaults_are_complete():
+    import nilmtk_contrib.torch as torch_models
+
+    default = DLinear({"device": "cpu"})
+    entry = model_catalog_by_module()["nilmtk_contrib.torch.dlinear"]
+    assert torch_models.DLinear is DLinear
+    assert default.sequence_length == 299
+    assert default.batch_size == 128
+    assert default.moving_average == 25
+    assert entry.class_name == "DLinear"
+    assert entry.exported_from == "nilmtk_contrib.torch"

--- a/tests/test_torch_migration_contract.py
+++ b/tests/test_torch_migration_contract.py
@@ -26,6 +26,7 @@ DEFAULTS_BY_MODULE = {
     "nilmtk_contrib.torch.bert": ExpectedDefaults(99, 10, 512, 1800, 600),
     "nilmtk_contrib.torch.conv_lstm": ExpectedDefaults(99, 10, 512, 1800, 600),
     "nilmtk_contrib.torch.dae": ExpectedDefaults(99, 10, 512, 1000, 600),
+    "nilmtk_contrib.torch.dlinear": ExpectedDefaults(299, 10, 128, 1800, 600),
     "nilmtk_contrib.torch.msdc": ExpectedDefaults(99, 50, 256, 1800, 600),
     "nilmtk_contrib.torch.msdc_without_crf": ExpectedDefaults(99, 50, 256, 1800, 600),
     "nilmtk_contrib.torch.moderntcn": ExpectedDefaults(299, 10, 128, 1800, 600),


### PR DESCRIPTION
## Summary

- add a compact DLinear-inspired univariate sequence-to-point model
- reuse the shared PyTorch engine for preprocessing, training, inference, and atomic checkpoints
- register the lazy public export, model catalog metadata, documentation, and global smoke coverage
- preserve exact input row counts and pandas indexes through centered inference

The adaptation follows the DLinear trend/seasonal decomposition and separate linear paths, while changing the forecasting head to one centered NILM appliance estimate per mains window.

## Verification

- `uv lock --check`
- `uv run ruff check nilmtk_contrib tests`
- `uv run pytest -q tests/test_dlinear.py --cov=nilmtk_contrib.torch.dlinear --cov-report=term-missing --cov-fail-under=90` — 16 passed, 91% coverage
- focused engine/migration/registry gate — 238 passed
- `uv run python -m pytest -q` — 494 passed, 85 skipped
- all-PyTorch one-epoch synthetic smoke — 19 passed, 13 skipped
- `uv build` — source and wheel distributions built; both include DLinear

## Scope

This PR only adds DLinear. NILMbench registration and real REDD/A100 result bundles will follow after this merges.