### PR TITLE
Add TimesNet on the shared sequence-to-point engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ The table below lists the public model surface. "Verification" describes how the
 | BERT | PyTorch | `nilmtk_contrib.torch.BERT` | Transformer/BERT-inspired NILM adaptation | Devlin et al., BERT | Does not claim NLP-style pretraining |
 | ConvLSTM | PyTorch | `nilmtk_contrib.torch.ConvLSTM` | ConvLSTM-inspired NILM adaptation | Shi et al., ConvLSTM | Generic spatiotemporal architecture adapted to NILM |
 | TCN | PyTorch | `nilmtk_contrib.torch.TCN` | Generic TCN sequence-modeling baseline adapted to NILM | Bai, Kolter, and Koltun, TCN | PyTorch backend |
+| TimesNet | PyTorch | `nilmtk_contrib.torch.TimesNet` | TimesNet-inspired sequence-to-point adaptation; benchmark claims require NILMbench result bundles | Wu et al., TimesNet | PyTorch backend |
 | Reformer | PyTorch | `nilmtk_contrib.torch.Reformer` | Reformer-inspired NILM adaptation | Kitaev, Kaiser, and Levskaya, Reformer | Efficient Transformer architecture adapted to NILM |
 | MSDC | PyTorch | `nilmtk_contrib.torch.MSDC` | NILM paper implementation requiring experiment validation for new claims | MSDC dual-CNN NILM paper | Canonical CRF-enabled implementation path |
 | MSDC without CRF | PyTorch | `nilmtk_contrib.torch.msdc_without_crf.MSDC` | MSDC ablation | MSDC paper/source implementation | No-CRF ablation, not the canonical MSDC path |
@@ -317,6 +318,7 @@ NILM-specific references:
 - Nie et al., "A Time Series is Worth 64 Words: Long-term Forecasting with Transformers", arXiv:2211.14730, https://arxiv.org/abs/2211.14730.
 - Luo and Wang, "ModernTCN: A Modern Pure Convolution Structure for General Time Series Analysis", ICLR 2024, https://openreview.net/forum?id=vpJMJerXHU.
 - Zeng et al., "Are Transformers Effective for Time Series Forecasting?", AAAI 2023, https://arxiv.org/abs/2205.13504.
+- Wu et al., "TimesNet: Temporal 2D-Variation Modeling for General Time Series Analysis", ICLR 2023, https://openreview.net/forum?id=ju_Uqw384Oq.
 
 Generic architecture references:
 

--- a/nilmtk_contrib/metadata.py
+++ b/nilmtk_contrib/metadata.py
@@ -44,6 +44,7 @@ MODEL_CATALOG = (
     ModelCatalogEntry("Seq2PointTorch", "torch", "nilmtk_contrib.torch.seq2point", "Seq2PointTorch", "nilmtk_contrib.torch"),
     ModelCatalogEntry("Seq2Seq", "torch", "nilmtk_contrib.torch.seq2seq", "Seq2Seq", "nilmtk_contrib.torch"),
     ModelCatalogEntry("TCN", "torch", "nilmtk_contrib.torch.TCN", "TCN", "nilmtk_contrib.torch"),
+    ModelCatalogEntry("TimesNet", "torch", "nilmtk_contrib.torch.timesnet", "TimesNet", "nilmtk_contrib.torch"),
     ModelCatalogEntry("WindowGRU", "torch", "nilmtk_contrib.torch.WindowGRU", "WindowGRU", "nilmtk_contrib.torch"),
 )
 

--- a/nilmtk_contrib/torch/__init__.py
+++ b/nilmtk_contrib/torch/__init__.py
@@ -28,6 +28,7 @@ _EXPORTS = {
     "Seq2PointTorch": ("nilmtk_contrib.torch.seq2point", "Seq2PointTorch"),
     "Seq2Seq": ("nilmtk_contrib.torch.seq2seq", "Seq2Seq"),
     "TCN": ("nilmtk_contrib.torch.TCN", "TCN"),
+    "TimesNet": ("nilmtk_contrib.torch.timesnet", "TimesNet"),
     "WindowGRU": ("nilmtk_contrib.torch.WindowGRU", "WindowGRU"),
 }
 

--- a/nilmtk_contrib/torch/timesnet.py
+++ b/nilmtk_contrib/torch/timesnet.py
@@ -1,0 +1,262 @@
+"""TimesNet-inspired sequence-to-point energy disaggregator."""
+
+from collections.abc import Mapping
+
+import torch
+from torch import nn
+
+from nilmtk_contrib.torch._base import torch_defaults
+from nilmtk_contrib.torch._seq2point import (
+    SequenceToPointTorchDisaggregator,
+    finite_number,
+)
+from nilmtk_contrib.utils.params import get_param, validate_positive_int
+
+
+def dominant_periods(inputs, top_k):
+    """Return FFT-selected periods and per-sample frequency amplitudes."""
+    if not isinstance(inputs, torch.Tensor):
+        raise TypeError("dominant_periods inputs must be a torch.Tensor.")
+    if inputs.ndim != 3 or inputs.shape[1] < 3:
+        raise ValueError("dominant_periods expects shape (batch, time>=3, channels).")
+    if not torch.is_floating_point(inputs) or torch.is_complex(inputs):
+        raise TypeError("dominant_periods inputs must be real floating tensors.")
+    if not torch.isfinite(inputs).all():
+        raise ValueError("dominant_periods inputs must be finite.")
+    top_k = validate_positive_int("top_k", top_k)
+    available = inputs.shape[1] // 2
+    if top_k > available:
+        raise ValueError(f"top_k must not exceed {available} for this sequence.")
+
+    spectrum = torch.fft.rfft(inputs, dim=1)
+    mean_amplitude = spectrum.abs().mean(dim=(0, 2))
+    frequency_indices = torch.topk(mean_amplitude[1:], top_k).indices.add(1).detach()
+    periods = torch.div(
+        inputs.shape[1], frequency_indices, rounding_mode="floor"
+    ).clamp_min(1)
+    sample_amplitudes = spectrum.abs().mean(dim=-1)[:, frequency_indices]
+    return periods, sample_amplitudes
+
+
+class InceptionBlock2D(nn.Module):
+    """Average parallel odd 2D kernels without changing the temporal grid."""
+
+    def __init__(self, in_channels, out_channels, num_kernels):
+        super().__init__()
+        for name, value in (
+            ("in_channels", in_channels),
+            ("out_channels", out_channels),
+            ("num_kernels", num_kernels),
+        ):
+            validate_positive_int(name, value)
+        self.kernels = nn.ModuleList(
+            nn.Conv2d(
+                in_channels,
+                out_channels,
+                kernel_size=2 * index + 1,
+                padding=index,
+            )
+            for index in range(num_kernels)
+        )
+        for kernel in self.kernels:
+            nn.init.kaiming_normal_(kernel.weight, nonlinearity="relu")
+            nn.init.zeros_(kernel.bias)
+
+    def forward(self, inputs):
+        return torch.stack([kernel(inputs) for kernel in self.kernels], dim=-1).mean(
+            dim=-1
+        )
+
+
+class TimesBlock(nn.Module):
+    """Model adaptive intra-period and inter-period variation in 2D."""
+
+    def __init__(self, sequence_length, d_model, d_ff, top_k, num_kernels):
+        super().__init__()
+        self.sequence_length = validate_positive_int("sequence_length", sequence_length)
+        self.top_k = validate_positive_int("top_k", top_k)
+        if self.top_k > self.sequence_length // 2:
+            raise ValueError("top_k exceeds the non-DC frequency count.")
+        self.convolution = nn.Sequential(
+            InceptionBlock2D(d_model, d_ff, num_kernels),
+            nn.GELU(),
+            InceptionBlock2D(d_ff, d_model, num_kernels),
+        )
+
+    def forward(self, inputs):
+        periods, amplitudes = dominant_periods(inputs, self.top_k)
+        batch, length, channels = inputs.shape
+        variations = []
+        for period_value in periods:
+            period = int(period_value.item())
+            padded_length = ((length + period - 1) // period) * period
+            if padded_length != length:
+                padding = inputs.new_zeros(batch, padded_length - length, channels)
+                values = torch.cat((inputs, padding), dim=1)
+            else:
+                values = inputs
+            grid = values.reshape(batch, padded_length // period, period, channels)
+            grid = grid.permute(0, 3, 1, 2).contiguous()
+            encoded = self.convolution(grid)
+            encoded = encoded.permute(0, 2, 3, 1).reshape(
+                batch, padded_length, channels
+            )
+            variations.append(encoded[:, :length])
+        stacked = torch.stack(variations, dim=-1)
+        weights = torch.softmax(amplitudes, dim=1)[:, None, None, :]
+        return inputs + torch.sum(stacked * weights, dim=-1)
+
+
+class TimesNetNetwork(nn.Module):
+    """TimesNet backbone with a centered scalar NILM regression head."""
+
+    def __init__(
+        self,
+        sequence_length,
+        d_model=32,
+        d_ff=64,
+        n_blocks=2,
+        top_k=3,
+        num_kernels=3,
+        dropout=0.1,
+    ):
+        super().__init__()
+        for name, value in (
+            ("sequence_length", sequence_length),
+            ("d_model", d_model),
+            ("d_ff", d_ff),
+            ("n_blocks", n_blocks),
+            ("top_k", top_k),
+            ("num_kernels", num_kernels),
+        ):
+            validate_positive_int(name, value)
+        if sequence_length % 2 == 0:
+            raise ValueError("sequence_length must be odd.")
+        if sequence_length < 3:
+            raise ValueError("sequence_length must be at least 3.")
+        if top_k > sequence_length // 2:
+            raise ValueError("top_k exceeds the non-DC frequency count.")
+        dropout = finite_number("dropout", dropout, minimum=0)
+        if dropout >= 1:
+            raise ValueError("dropout must be less than 1.")
+
+        self.sequence_length = sequence_length
+        self.embedding = nn.Conv1d(
+            1, d_model, kernel_size=3, padding=1, padding_mode="circular"
+        )
+        self.embedding_dropout = nn.Dropout(dropout)
+        self.blocks = nn.ModuleList(
+            TimesBlock(sequence_length, d_model, d_ff, top_k, num_kernels)
+            for _ in range(n_blocks)
+        )
+        self.norms = nn.ModuleList(nn.LayerNorm(d_model) for _ in range(n_blocks))
+        self.head = nn.Sequential(nn.Dropout(dropout), nn.Linear(2 * d_model, 1))
+        nn.init.kaiming_normal_(self.embedding.weight, nonlinearity="linear")
+        nn.init.zeros_(self.embedding.bias)
+        nn.init.xavier_uniform_(self.head[-1].weight)
+        nn.init.zeros_(self.head[-1].bias)
+
+    def forward(self, inputs):
+        if not isinstance(inputs, torch.Tensor):
+            raise TypeError("TimesNetNetwork inputs must be a torch.Tensor.")
+        expected_shape = (1, self.sequence_length)
+        if inputs.ndim != 3 or inputs.shape[1:] != expected_shape:
+            raise ValueError(
+                "TimesNetNetwork expects input shape "
+                f"(batch, 1, {self.sequence_length}); got {tuple(inputs.shape)}."
+            )
+        if not torch.is_floating_point(inputs) or torch.is_complex(inputs):
+            raise TypeError("TimesNetNetwork inputs must be real floating tensors.")
+        device = self.embedding.weight.device
+        if inputs.device != device:
+            raise ValueError(
+                f"TimesNetNetwork input is on {inputs.device}; model is on {device}."
+            )
+        if not torch.isfinite(inputs).all():
+            raise ValueError("TimesNetNetwork inputs must be finite.")
+
+        inputs = inputs.to(dtype=self.embedding.weight.dtype)
+        encoded = self.embedding_dropout(self.embedding(inputs).transpose(1, 2))
+        for block, norm in zip(self.blocks, self.norms, strict=True):
+            encoded = norm(block(encoded))
+        center = encoded[:, self.sequence_length // 2]
+        pooled = encoded.mean(dim=1)
+        output = self.head(torch.cat((center, pooled), dim=1))
+        if not torch.isfinite(output).all():
+            raise RuntimeError("TimesNetNetwork produced non-finite output.")
+        return output
+
+
+class TimesNet(SequenceToPointTorchDisaggregator):
+    """TimesNet adapted to one NILM estimate per centered mains row."""
+
+    MODEL_NAME = "TimesNet"
+    CHECKPOINT_PREFIX = "timesnet"
+    MODEL_CONFIG_FIELDS = (
+        "d_model",
+        "d_ff",
+        "n_blocks",
+        "top_k",
+        "num_kernels",
+        "dropout",
+        "learning_rate",
+        "weight_decay",
+        "validation_fraction",
+        "validation_strategy",
+        "gradient_clip_norm",
+    )
+
+    def __init__(self, params=None):
+        if params is None:
+            params = {}
+        if isinstance(params, Mapping):
+            params = dict(params)
+            params.setdefault("weight_decay", 1e-4)
+        super().__init__(
+            params, defaults=torch_defaults(sequence_length=299, batch_size=128)
+        )
+        self.d_model = validate_positive_int(
+            "d_model", get_param(params, "d_model", 32)
+        )
+        self.d_ff = validate_positive_int("d_ff", get_param(params, "d_ff", 64))
+        self.n_blocks = validate_positive_int(
+            "n_blocks", get_param(params, "n_blocks", 2)
+        )
+        self.top_k = validate_positive_int("top_k", get_param(params, "top_k", 3))
+        self.num_kernels = validate_positive_int(
+            "num_kernels", get_param(params, "num_kernels", 3)
+        )
+        self.dropout = finite_number(
+            "dropout", get_param(params, "dropout", 0.1), minimum=0
+        )
+        self._validate_architecture()
+        if self.load_model_path:
+            self.load_model()
+
+    def _validate_architecture(self):
+        if self.sequence_length < 3:
+            raise ValueError("sequence_length must be at least 3.")
+        if self.top_k > self.sequence_length // 2:
+            raise ValueError("top_k exceeds the non-DC frequency count.")
+        if self.dropout >= 1:
+            raise ValueError("dropout must be less than 1.")
+
+    def return_network(self):
+        return TimesNetNetwork(
+            sequence_length=self.sequence_length,
+            d_model=self.d_model,
+            d_ff=self.d_ff,
+            n_blocks=self.n_blocks,
+            top_k=self.top_k,
+            num_kernels=self.num_kernels,
+            dropout=self.dropout,
+        ).to(self.device)
+
+
+__all__ = [
+    "InceptionBlock2D",
+    "TimesBlock",
+    "TimesNet",
+    "TimesNetNetwork",
+    "dominant_periods",
+]

--- a/tests/model_smoke_helpers.py
+++ b/tests/model_smoke_helpers.py
@@ -56,6 +56,7 @@ TORCH_MODEL_SPECS = (
     ModelSpec("torch", "nilmtk_contrib.torch", "Seq2PointTorch", "nilmtk_contrib.torch.seq2point"),
     ModelSpec("torch", "nilmtk_contrib.torch", "Seq2Seq", "nilmtk_contrib.torch.seq2seq"),
     ModelSpec("torch", "nilmtk_contrib.torch", "TCN", "nilmtk_contrib.torch.TCN"),
+    ModelSpec("torch", "nilmtk_contrib.torch", "TimesNet", "nilmtk_contrib.torch.timesnet"),
     ModelSpec("torch", "nilmtk_contrib.torch", "WindowGRU", "nilmtk_contrib.torch.WindowGRU"),
 )
 

--- a/tests/test_timesnet.py
+++ b/tests/test_timesnet.py
@@ -1,0 +1,215 @@
+import inspect
+import math
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+torch = pytest.importorskip("torch")
+metadata_module = pytest.importorskip("nilmtk_contrib.metadata")
+engine_module = pytest.importorskip("nilmtk_contrib.torch._seq2point")
+timesnet_module = pytest.importorskip("nilmtk_contrib.torch.timesnet")
+model_catalog_by_module = metadata_module.model_catalog_by_module
+SequenceToPointTorchDisaggregator = engine_module.SequenceToPointTorchDisaggregator
+TimesNet = timesnet_module.TimesNet
+TimesNetNetwork = timesnet_module.TimesNetNetwork
+InceptionBlock2D = timesnet_module.InceptionBlock2D
+dominant_periods = timesnet_module.dominant_periods
+
+
+def _params(**overrides):
+    return {
+        "device": "cpu",
+        "sequence_length": 9,
+        "n_epochs": 1,
+        "batch_size": 4,
+        "seed": 17,
+        "mains_mean": 100.0,
+        "mains_std": 40.0,
+        "d_model": 4,
+        "d_ff": 8,
+        "n_blocks": 1,
+        "top_k": 2,
+        "num_kernels": 2,
+        "dropout": 0.0,
+    } | overrides
+
+
+def _chunks(length=18):
+    values = np.arange(length, dtype=np.float32)
+    index = pd.date_range("2026-01-01", periods=length, freq="1min", tz="UTC")
+    appliance = 25.0 + 30.0 * ((values // 3) % 2)
+    mains = 70.0 + appliance + 3.0 * np.sin(values / 2)
+    return (
+        [pd.DataFrame({"power": mains}, index=index)],
+        [("fridge", [pd.DataFrame({"power": appliance}, index=index)])],
+    )
+
+
+def test_timesnet_is_an_architecture_only_engine_consumer():
+    source = Path(inspect.getfile(TimesNet)).read_text()
+
+    assert issubclass(TimesNet, SequenceToPointTorchDisaggregator)
+    assert len(source.splitlines()) < 300
+    for method in ("partial_fit", "disaggregate_chunk", "save_model", "load_model"):
+        assert f"def {method}(" not in source
+
+
+def test_fft_period_selection_finds_a_clean_three_sample_cycle():
+    time = torch.arange(9, dtype=torch.float32)
+    signal = torch.sin(2 * math.pi * time / 3).reshape(1, 9, 1)
+
+    periods, amplitudes = dominant_periods(signal, top_k=2)
+
+    assert periods[0].item() == 3
+    assert amplitudes.shape == (1, 2)
+    assert amplitudes[0, 0] > amplitudes[0, 1]
+
+
+@pytest.mark.parametrize(
+    "inputs",
+    [
+        object(),
+        torch.ones(2, 9),
+        torch.ones(1, 2, 1),
+        torch.ones(1, 9, 1, dtype=torch.int64),
+        torch.full((1, 9, 1), float("nan")),
+    ],
+)
+def test_fft_period_selection_rejects_invalid_inputs(inputs):
+    with pytest.raises((TypeError, ValueError)):
+        dominant_periods(inputs, top_k=2)
+
+
+@pytest.mark.parametrize("top_k", [True, 5])
+def test_fft_period_selection_rejects_invalid_top_k(top_k):
+    with pytest.raises(ValueError):
+        dominant_periods(torch.ones(1, 9, 1), top_k=top_k)
+
+
+def test_inception_uses_parallel_odd_shape_preserving_kernels():
+    block = InceptionBlock2D(4, 8, num_kernels=3)
+    inputs = torch.ones(2, 4, 3, 5)
+
+    assert [kernel.kernel_size for kernel in block.kernels] == [(1, 1), (3, 3), (5, 5)]
+    assert block(inputs).shape == (2, 8, 3, 5)
+
+
+def test_network_preserves_shape_and_backpropagates_through_every_parameter():
+    network = TimesNet(_params()).return_network()
+    output = network(torch.ones(3, 1, 9))
+    output.sum().backward()
+
+    assert output.shape == (3, 1)
+    assert all(
+        parameter.grad is not None and torch.isfinite(parameter.grad).all()
+        for parameter in network.parameters()
+    )
+
+
+def test_constant_input_has_finite_frequency_aggregation():
+    network = TimesNet(_params()).return_network()
+
+    output = network(torch.ones(4, 1, 9))
+
+    assert torch.isfinite(output).all()
+
+
+@pytest.mark.parametrize(
+    ("params", "message"),
+    [
+        ({"sequence_length": 8}, "odd"),
+        ({"sequence_length": 1}, "at least 3"),
+        ({"top_k": 5}, "non-DC"),
+        ({"top_k": True}, "positive integer"),
+        ({"num_kernels": 0}, "positive integer"),
+        ({"d_model": 3.5}, "positive integer"),
+        ({"dropout": 1.0}, "less than 1"),
+        ({"weight_decay": -1.0}, "at least"),
+    ],
+)
+def test_invalid_configuration_fails_at_construction(params, message):
+    with pytest.raises(ValueError, match=message):
+        TimesNet(_params(**params))
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"sequence_length": 1},
+        {"sequence_length": 8},
+        {"sequence_length": 9, "top_k": 5},
+        {"sequence_length": 9, "d_model": True},
+        {"sequence_length": 9, "dropout": 1.0},
+    ],
+)
+def test_network_constructor_enforces_its_public_contract(params):
+    with pytest.raises(ValueError):
+        TimesNetNetwork(**params)
+
+
+@pytest.mark.parametrize(
+    "inputs",
+    [
+        object(),
+        torch.ones(2, 9),
+        torch.ones(2, 1, 8),
+        torch.ones(2, 1, 9, dtype=torch.int64),
+        torch.full((2, 1, 9), float("nan")),
+    ],
+)
+def test_network_rejects_invalid_inputs(inputs):
+    network = TimesNet(_params()).return_network()
+
+    with pytest.raises((TypeError, ValueError)):
+        network(inputs)
+
+
+def test_one_epoch_train_infer_smoke_preserves_every_row():
+    mains, targets = _chunks()
+    model = TimesNet(_params(appliance_params={}))
+
+    model.partial_fit(mains, targets)
+    result = model.disaggregate_chunk(mains)[0]
+
+    assert result.index.equals(mains[0].index)
+    assert result.columns.tolist() == ["fridge"]
+    assert result["fridge"].dtype == np.float32
+    assert np.isfinite(result["fridge"]).all()
+
+
+def test_checkpoint_roundtrip_restores_architecture_and_predictions(tmp_path):
+    mains, targets = _chunks()
+    model = TimesNet(
+        _params(appliance_params={}, save_model_path=str(tmp_path), d_model=6)
+    )
+    model.partial_fit(mains, targets)
+    expected = model.disaggregate_chunk(mains)[0]
+
+    loaded = TimesNet(
+        _params(
+            appliance_params={},
+            pretrained_model_path=str(tmp_path),
+            d_model=4,
+        )
+    )
+    actual = loaded.disaggregate_chunk(mains)[0]
+
+    assert loaded.d_model == 6
+    assert np.allclose(actual, expected)
+
+
+def test_public_export_catalog_and_defaults_are_complete():
+    import nilmtk_contrib.torch as torch_models
+
+    default = TimesNet({"device": "cpu"})
+    entry = model_catalog_by_module()["nilmtk_contrib.torch.timesnet"]
+    assert torch_models.TimesNet is TimesNet
+    assert default.sequence_length == 299
+    assert default.batch_size == 128
+    assert default.top_k == 3
+    assert default.weight_decay == pytest.approx(1e-4)
+    assert entry.class_name == "TimesNet"
+    assert entry.exported_from == "nilmtk_contrib.torch"

--- a/tests/test_torch_migration_contract.py
+++ b/tests/test_torch_migration_contract.py
@@ -44,6 +44,7 @@ DEFAULTS_BY_MODULE = {
     ),
     "nilmtk_contrib.torch.seq2point": ExpectedDefaults(99, 10, 512, 1800, 600),
     "nilmtk_contrib.torch.seq2seq": ExpectedDefaults(99, 10, 512, 1800, 600),
+    "nilmtk_contrib.torch.timesnet": ExpectedDefaults(299, 10, 128, 1800, 600),
 }
 
 EXTREMA_MODULES = {


### PR DESCRIPTION
## Summary

- add a compact TimesNet-inspired sequence-to-point architecture using FFT-selected periods and 2D variation modeling
- reuse the shared PyTorch training, inference, checkpoint, and partial-chunk engine
- export and catalog the model, document its adaptation status, and include it in the all-model smoke gate

Reference: Wu et al., TimesNet: Temporal 2D-Variation Modeling for General Time Series Analysis, ICLR 2023: https://openreview.net/forum?id=ju_Uqw384Oq

## Verification

- 33 dedicated tests; 97.14% module coverage
- 250 focused architecture/engine/catalog tests passed before the final hardening additions
- full suite: 535 passed, 88 skipped
- all-model one-epoch PyTorch smoke gate: 20 passed, 13 skipped
- ruff clean; lockfile check clean
- source distribution and wheel built; isolated wheel public import verified

## Scope

This PR adds only the contrib model. Real REDD T0 benchmark integration and result bundles will follow separately after this PR is merged.