### PR TITLE
Add a validated auxiliary training-loss hook

### DIFF
--- a/nilmtk_contrib/torch/_seq2point.py
+++ b/nilmtk_contrib/torch/_seq2point.py
@@ -396,14 +396,13 @@ class SequenceToPointTorchDisaggregator(TorchDisaggregator):
             targets_by_appliance.append((appliance_name, np.concatenate(targets)))
         return np.concatenate(main_chunks), targets_by_appliance
 
-    def _checked_prediction(self, network, batch, appliance_name):
-        prediction = network(batch.to(self.device).unsqueeze(1))
+    def _checked_model_output(self, prediction, batch_size, appliance_name):
         if not isinstance(prediction, torch.Tensor):
             raise TypeError(f"Model for {appliance_name!r} must return a torch.Tensor.")
-        if prediction.shape != (len(batch), 1):
+        if prediction.shape != (batch_size, 1):
             raise ValueError(
                 f"Model for {appliance_name!r} returned shape "
-                f"{tuple(prediction.shape)}; expected ({len(batch)}, 1)."
+                f"{tuple(prediction.shape)}; expected ({batch_size}, 1)."
             )
         if not torch.is_floating_point(prediction) or torch.is_complex(prediction):
             raise TypeError(
@@ -419,6 +418,42 @@ class SequenceToPointTorchDisaggregator(TorchDisaggregator):
                 f"Model for {appliance_name!r} returned non-finite values."
             )
         return prediction
+
+    def _checked_prediction(self, network, batch, appliance_name):
+        prediction = network(batch.to(self.device).unsqueeze(1))
+        return self._checked_model_output(prediction, len(batch), appliance_name)
+
+    def training_loss(self, network, batch_inputs, batch_targets, appliance_name):
+        """Return the scalar optimization objective for one training batch.
+
+        Architecture subclasses may override this hook for auxiliary objectives
+        while retaining the engine's optimization, rollback, and persistence
+        contracts.  Custom hooks must validate any additional network outputs.
+        """
+        prediction = self._checked_prediction(network, batch_inputs, appliance_name)
+        target = batch_targets.to(self.device)
+        return nn.functional.mse_loss(prediction, target)
+
+    def _checked_training_loss(
+        self, network, batch_inputs, batch_targets, appliance_name
+    ):
+        loss = self.training_loss(network, batch_inputs, batch_targets, appliance_name)
+        if not isinstance(loss, torch.Tensor):
+            raise TypeError("training_loss must return a torch.Tensor.")
+        if loss.shape != ():
+            raise ValueError("training_loss must return a scalar tensor.")
+        if not torch.is_floating_point(loss) or torch.is_complex(loss):
+            raise TypeError("training_loss must return a real floating tensor.")
+        if loss.device != self.device:
+            raise ValueError(
+                f"training_loss returned a value on {loss.device}; "
+                f"expected {self.device}."
+            )
+        if not torch.isfinite(loss):
+            raise FloatingPointError("Training loss became non-finite.")
+        if not loss.requires_grad:
+            raise ValueError("training_loss must participate in autograd.")
+        return loss
 
     def _score(self, network, inputs, targets, appliance_name):
         loader = DataLoader(
@@ -480,11 +515,9 @@ class SequenceToPointTorchDisaggregator(TorchDisaggregator):
             count = 0
             for batch_inputs, batch_targets in loader:
                 optimizer.zero_grad(set_to_none=True)
-                prediction = self._checked_prediction(
-                    network, batch_inputs, appliance_name
+                loss = self._checked_training_loss(
+                    network, batch_inputs, batch_targets, appliance_name
                 )
-                target = batch_targets.to(self.device)
-                loss = nn.functional.mse_loss(prediction, target)
                 loss.backward()
                 try:
                     nn.utils.clip_grad_norm_(

--- a/tests/test_seq2point_engine.py
+++ b/tests/test_seq2point_engine.py
@@ -47,6 +47,18 @@ class TinyDisaggregator(SequenceToPointTorchDisaggregator):
         return TinyNetwork(self.sequence_length).to(self.device)
 
 
+class L1TinyDisaggregator(TinyDisaggregator):
+    def __init__(self, params=None):
+        self.loss_calls = []
+        super().__init__(params)
+
+    def training_loss(self, network, batch_inputs, batch_targets, appliance_name):
+        self.loss_calls.append((appliance_name, len(batch_inputs)))
+        prediction = self._checked_prediction(network, batch_inputs, appliance_name)
+        target = batch_targets.to(self.device)
+        return nn.functional.l1_loss(prediction, target)
+
+
 def _params(**overrides):
     return {
         "device": "cpu",
@@ -193,6 +205,49 @@ def test_raw_training_validates_alignment_and_trains_a_finite_model():
     assert model.last_split_metadata["fridge"].should_train
     assert predictions.index.equals(mains.index)
     assert np.isfinite(predictions["fridge"]).all()
+
+
+def test_training_loss_hook_reuses_the_engine_lifecycle():
+    model = L1TinyDisaggregator(_params(appliance_params={}))
+    mains = _raw([10, 12, 14, 16, 18, 20, 22, 24])
+    target = _raw([2, 4, 6, 8, 10, 12, 14, 16])
+
+    model.partial_fit([mains], [("fridge", [target])])
+
+    assert model.loss_calls
+    assert {name for name, _ in model.loss_calls} == {"fridge"}
+    assert sum(size for _, size in model.loss_calls) > 0
+    assert model.last_split_metadata["fridge"].should_train
+
+
+@pytest.mark.parametrize(
+    ("result", "error", "message"),
+    [
+        (object(), TypeError, "torch.Tensor"),
+        (torch.ones(1, requires_grad=True), ValueError, "scalar"),
+        (torch.ones((), dtype=torch.int64), TypeError, "real floating"),
+        (
+            torch.full((), float("inf"), requires_grad=True),
+            FloatingPointError,
+            "non-finite",
+        ),
+        (torch.ones(()), ValueError, "autograd"),
+        (
+            torch.ones((), device="meta", requires_grad=True),
+            ValueError,
+            "expected cpu",
+        ),
+    ],
+)
+def test_training_loss_hook_fails_closed(result, error, message, monkeypatch):
+    model = TinyDisaggregator(_params())
+    network = model.return_network()
+    inputs = torch.ones(2, model.sequence_length)
+    targets = torch.ones(2, 1)
+    monkeypatch.setattr(model, "training_loss", lambda *_: result)
+
+    with pytest.raises(error, match=message):
+        model._checked_training_loss(network, inputs, targets, "fridge")
 
 
 def test_raw_training_rejects_misaligned_indexes_before_mutating_state():


### PR DESCRIPTION
## Summary

- add one generic training_loss extension point to the shared sequence-to-point engine
- preserve MSE as the default objective for every existing model
- extract reusable output validation so multitask architectures can validate their primary prediction without a second forward pass
- fail closed when a custom loss has the wrong type, shape, dtype, device, finiteness, or autograd state

This is intentionally separate from the SGN model PR so the shared runtime change can be reviewed and merged on its own.

## Verification

- focused engine/catalog contracts: 237 passed
- full suite: 542 passed, 88 skipped
- all-model one-epoch PyTorch smoke gate: 20 passed, 13 skipped
- dedicated hook tests cover custom-objective success and six invalid-output classes
- ruff and diff checks clean
- lockfile check clean; source distribution and wheel built successfully