### PR TITLE
Add target-aware network configuration hook

### DIFF
--- a/nilmtk_contrib/torch/_seq2point.py
+++ b/nilmtk_contrib/torch/_seq2point.py
@@ -241,6 +241,14 @@ class SequenceToPointTorchDisaggregator(TorchDisaggregator):
     def return_network(self):
         raise NotImplementedError
 
+    def configure_network(self, network, appliance_name):
+        """Configure a network with target-specific state before use.
+
+        Subclasses may override this idempotent hook when an architecture needs
+        the appliance normalization statistics during its forward pass.
+        """
+        del network, appliance_name
+
     def model_config(self):
         fields = self.MODEL_CONFIG_FIELDS
         if (
@@ -494,6 +502,7 @@ class SequenceToPointTorchDisaggregator(TorchDisaggregator):
         if network is None:
             network = self.return_network()
             self.models[appliance_name] = network
+        self.configure_network(network, appliance_name)
         loader = DataLoader(
             TensorDataset(
                 torch.from_numpy(split.X_train), torch.from_numpy(split.y_train)
@@ -610,6 +619,8 @@ class SequenceToPointTorchDisaggregator(TorchDisaggregator):
         raw_frames = list(test_main_list)
         if not raw_frames:
             return []
+        for appliance_name, network in models.items():
+            self.configure_network(network, appliance_name)
         if do_preprocessing:
             processed = self.call_preprocessing(raw_frames, method="test")
             indexes = [

--- a/tests/test_seq2point_engine.py
+++ b/tests/test_seq2point_engine.py
@@ -59,6 +59,29 @@ class L1TinyDisaggregator(TinyDisaggregator):
         return nn.functional.l1_loss(prediction, target)
 
 
+class TargetAwareTinyDisaggregator(TinyDisaggregator):
+    def __init__(self, params=None):
+        self.configuration_calls = []
+        super().__init__(params)
+
+    def configure_network(self, network, appliance_name):
+        statistics = self._validated_appliance_stats(
+            appliance_name, self.REQUIRED_APPLIANCE_STATS
+        )
+        network.target_statistics = (statistics["mean"], statistics["std"])
+        self.configuration_calls.append(appliance_name)
+
+    def training_loss(self, network, batch_inputs, batch_targets, appliance_name):
+        statistics = self.appliance_params[appliance_name]
+        assert network.target_statistics == (
+            statistics["mean"],
+            statistics["std"],
+        )
+        return super().training_loss(
+            network, batch_inputs, batch_targets, appliance_name
+        )
+
+
 def _params(**overrides):
     return {
         "device": "cpu",
@@ -218,6 +241,20 @@ def test_training_loss_hook_reuses_the_engine_lifecycle():
     assert {name for name, _ in model.loss_calls} == {"fridge"}
     assert sum(size for _, size in model.loss_calls) > 0
     assert model.last_split_metadata["fridge"].should_train
+
+
+def test_target_aware_network_hook_runs_before_training_and_inference():
+    model = TargetAwareTinyDisaggregator(_params())
+    mains = _raw([10, 12, 14, 16, 18, 20, 22, 24])
+    target = _raw([2, 4, 6, 8, 10, 12, 14, 16])
+
+    model.partial_fit([mains], [("fridge", [target])])
+    predictions = model.disaggregate_chunk([mains])[0]
+    assert model.disaggregate_chunk([]) == []
+
+    assert model.configuration_calls == ["fridge", "fridge"]
+    assert predictions.index.equals(mains.index)
+    assert np.isfinite(predictions["fridge"]).all()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add one idempotent configure_network hook before training and non-empty inference
- let architectures consume appliance normalization statistics without duplicating engine lifecycle code
- leave every existing model unchanged through a no-op default
- test ordering before training/inference and ensure empty inference has no configuration side effect

This is the normalization prerequisite for SGN. Its raw-power gate must map an off probability to zero watts, not to zero in normalized space (which decodes to the appliance mean).

## Verification

- focused engine/catalog contracts: 238 passed before final empty-input case; final engine file: 29 passed
- full suite: 543 passed, 88 skipped
- all-model one-epoch PyTorch smoke gate: 20 passed, 13 skipped
- ruff, formatting, and diff checks clean
- lockfile check clean; source distribution and wheel built successfully