### PR TITLE
Add raw-power-correct Subtask Gated Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ The table below lists the public model surface. "Verification" describes how the
 | BERT | PyTorch | `nilmtk_contrib.torch.BERT` | Transformer/BERT-inspired NILM adaptation | Devlin et al., BERT | Does not claim NLP-style pretraining |
 | ConvLSTM | PyTorch | `nilmtk_contrib.torch.ConvLSTM` | ConvLSTM-inspired NILM adaptation | Shi et al., ConvLSTM | Generic spatiotemporal architecture adapted to NILM |
 | TCN | PyTorch | `nilmtk_contrib.torch.TCN` | Generic TCN sequence-modeling baseline adapted to NILM | Bai, Kolter, and Koltun, TCN | PyTorch backend |
+| SGN | PyTorch | `nilmtk_contrib.torch.SGN` | Subtask-gated sequence-to-point adaptation; benchmark claims require NILMbench result bundles | Shin et al., SGN | Uses a raw-power-correct soft on/off gate and auxiliary classification loss |
 | TimesNet | PyTorch | `nilmtk_contrib.torch.TimesNet` | TimesNet-inspired sequence-to-point adaptation; benchmark claims require NILMbench result bundles | Wu et al., TimesNet | PyTorch backend |
 | Reformer | PyTorch | `nilmtk_contrib.torch.Reformer` | Reformer-inspired NILM adaptation | Kitaev, Kaiser, and Levskaya, Reformer | Efficient Transformer architecture adapted to NILM |
 | MSDC | PyTorch | `nilmtk_contrib.torch.MSDC` | NILM paper implementation requiring experiment validation for new claims | MSDC dual-CNN NILM paper | Canonical CRF-enabled implementation path |
@@ -318,6 +319,7 @@ NILM-specific references:
 - Nie et al., "A Time Series is Worth 64 Words: Long-term Forecasting with Transformers", arXiv:2211.14730, https://arxiv.org/abs/2211.14730.
 - Luo and Wang, "ModernTCN: A Modern Pure Convolution Structure for General Time Series Analysis", ICLR 2024, https://openreview.net/forum?id=vpJMJerXHU.
 - Zeng et al., "Are Transformers Effective for Time Series Forecasting?", AAAI 2023, https://arxiv.org/abs/2205.13504.
+- Shin et al., "Subtask Gated Networks for Non-Intrusive Load Monitoring", AAAI 2019, https://doi.org/10.1609/aaai.v33i01.33011150.
 - Wu et al., "TimesNet: Temporal 2D-Variation Modeling for General Time Series Analysis", ICLR 2023, https://openreview.net/forum?id=ju_Uqw384Oq.
 
 Generic architecture references:

--- a/nilmtk_contrib/metadata.py
+++ b/nilmtk_contrib/metadata.py
@@ -43,6 +43,7 @@ MODEL_CATALOG = (
     ModelCatalogEntry("RNN_attention_classification", "torch", "nilmtk_contrib.torch.rnn_attention_classification", "RNN_attention_classification", "nilmtk_contrib.torch"),
     ModelCatalogEntry("Seq2PointTorch", "torch", "nilmtk_contrib.torch.seq2point", "Seq2PointTorch", "nilmtk_contrib.torch"),
     ModelCatalogEntry("Seq2Seq", "torch", "nilmtk_contrib.torch.seq2seq", "Seq2Seq", "nilmtk_contrib.torch"),
+    ModelCatalogEntry("SGN", "torch", "nilmtk_contrib.torch.sgn", "SGN", "nilmtk_contrib.torch"),
     ModelCatalogEntry("TCN", "torch", "nilmtk_contrib.torch.TCN", "TCN", "nilmtk_contrib.torch"),
     ModelCatalogEntry("TimesNet", "torch", "nilmtk_contrib.torch.timesnet", "TimesNet", "nilmtk_contrib.torch"),
     ModelCatalogEntry("WindowGRU", "torch", "nilmtk_contrib.torch.WindowGRU", "WindowGRU", "nilmtk_contrib.torch"),

--- a/nilmtk_contrib/torch/__init__.py
+++ b/nilmtk_contrib/torch/__init__.py
@@ -27,6 +27,7 @@ _EXPORTS = {
     ),
     "Seq2PointTorch": ("nilmtk_contrib.torch.seq2point", "Seq2PointTorch"),
     "Seq2Seq": ("nilmtk_contrib.torch.seq2seq", "Seq2Seq"),
+    "SGN": ("nilmtk_contrib.torch.sgn", "SGN"),
     "TCN": ("nilmtk_contrib.torch.TCN", "TCN"),
     "TimesNet": ("nilmtk_contrib.torch.timesnet", "TimesNet"),
     "WindowGRU": ("nilmtk_contrib.torch.WindowGRU", "WindowGRU"),

--- a/nilmtk_contrib/torch/sgn.py
+++ b/nilmtk_contrib/torch/sgn.py
@@ -1,0 +1,234 @@
+"""Subtask-gated sequence-to-point energy disaggregator."""
+
+from collections.abc import Mapping
+
+import torch
+from torch import nn
+
+from nilmtk_contrib.torch._base import torch_defaults
+from nilmtk_contrib.torch._seq2point import (
+    SequenceToPointTorchDisaggregator,
+    finite_number,
+)
+from nilmtk_contrib.utils.params import get_param, validate_positive_int
+
+
+PAPER_KERNEL_SIZES = (10, 8, 6, 5, 5, 5)
+PAPER_FILTERS = (30, 30, 40, 50, 50, 50)
+PAPER_ON_POWER_THRESHOLD = 15.0
+
+
+class SGNTower(nn.Module):
+    """One paper-shaped CNN subnetwork with a scalar adaptation head."""
+
+    def __init__(self, sequence_length, hidden_dim=1024, dropout=0.0):
+        super().__init__()
+        sequence_length = validate_positive_int("sequence_length", sequence_length)
+        hidden_dim = validate_positive_int("hidden_dim", hidden_dim)
+        dropout = finite_number("dropout", dropout, minimum=0)
+        if dropout >= 1:
+            raise ValueError("dropout must be less than 1.")
+        reduced_length = sequence_length - sum(
+            kernel_size - 1 for kernel_size in PAPER_KERNEL_SIZES
+        )
+        if reduced_length < 1:
+            raise ValueError(
+                f"sequence_length must be at least {1 + sequence_length - reduced_length}."
+            )
+
+        channels = (1, *PAPER_FILTERS[:-1])
+        self.convolutions = nn.ModuleList(
+            nn.Conv1d(in_channels, out_channels, kernel_size)
+            for in_channels, out_channels, kernel_size in zip(
+                channels, PAPER_FILTERS, PAPER_KERNEL_SIZES, strict=True
+            )
+        )
+        self.feature_dropout = nn.Dropout(dropout)
+        self.hidden = nn.Linear(PAPER_FILTERS[-1] * reduced_length, hidden_dim)
+        self.hidden_dropout = nn.Dropout(dropout)
+        self.output = nn.Linear(hidden_dim, 1)
+        self._initialize_weights()
+
+    def _initialize_weights(self):
+        for layer in (*self.convolutions, self.hidden):
+            nn.init.kaiming_normal_(layer.weight, nonlinearity="relu")
+            nn.init.zeros_(layer.bias)
+        nn.init.kaiming_normal_(self.output.weight, nonlinearity="linear")
+        nn.init.zeros_(self.output.bias)
+
+    def forward(self, inputs):
+        encoded = inputs
+        for convolution in self.convolutions:
+            encoded = torch.relu(convolution(encoded))
+        encoded = self.feature_dropout(encoded).flatten(1)
+        encoded = self.hidden_dropout(torch.relu(self.hidden(encoded)))
+        return self.output(encoded)
+
+
+class SGNNetwork(nn.Module):
+    """Independent regression and on/off towers joined by a soft gate."""
+
+    def __init__(
+        self,
+        sequence_length,
+        hidden_dim=1024,
+        dropout=0.0,
+    ):
+        super().__init__()
+        sequence_length = validate_positive_int("sequence_length", sequence_length)
+        if sequence_length % 2 == 0:
+            raise ValueError("sequence_length must be odd.")
+        minimum_length = 1 + sum(size - 1 for size in PAPER_KERNEL_SIZES)
+        if sequence_length < minimum_length:
+            raise ValueError(f"sequence_length must be at least {minimum_length}.")
+        self.sequence_length = sequence_length
+        self.regression_tower = SGNTower(sequence_length, hidden_dim, dropout)
+        self.classification_tower = SGNTower(sequence_length, hidden_dim, dropout)
+        self.register_buffer("target_mean", torch.tensor(float("nan")))
+        self.register_buffer("target_std", torch.tensor(float("nan")))
+
+    def configure_target(self, mean, std):
+        """Store the affine target transform used by the raw-power gate."""
+        mean = finite_number("target mean", mean)
+        std = finite_number("target std", std, minimum=0, strict=True)
+        self.target_mean.copy_(self.target_mean.new_tensor(mean))
+        self.target_std.copy_(self.target_std.new_tensor(std))
+
+    def _validate_inputs(self, inputs):
+        if not isinstance(inputs, torch.Tensor):
+            raise TypeError("SGNNetwork inputs must be a torch.Tensor.")
+        expected_shape = (1, self.sequence_length)
+        if inputs.ndim != 3 or inputs.shape[1:] != expected_shape:
+            raise ValueError(
+                "SGNNetwork expects input shape "
+                f"(batch, 1, {self.sequence_length}); got {tuple(inputs.shape)}."
+            )
+        if not torch.is_floating_point(inputs) or torch.is_complex(inputs):
+            raise TypeError("SGNNetwork inputs must be real floating tensors.")
+        device = self.target_mean.device
+        if inputs.device != device:
+            raise ValueError(
+                f"SGNNetwork input is on {inputs.device}; model is on {device}."
+            )
+        if not torch.isfinite(inputs).all():
+            raise ValueError("SGNNetwork inputs must be finite.")
+        if not torch.isfinite(self.target_mean) or not torch.isfinite(self.target_std):
+            raise RuntimeError("SGNNetwork target normalization is not configured.")
+
+    def training_outputs(self, inputs):
+        """Return gated prediction, ungated regression, and on/off logits."""
+        self._validate_inputs(inputs)
+        inputs = inputs.to(dtype=self.target_mean.dtype)
+        regression = self.regression_tower(inputs)
+        logits = self.classification_tower(inputs)
+        probability = torch.sigmoid(logits)
+        off_normalized = -self.target_mean / self.target_std
+        gated = off_normalized + probability * (regression - off_normalized)
+        if not all(
+            torch.isfinite(output).all() for output in (gated, regression, logits)
+        ):
+            raise RuntimeError("SGNNetwork produced non-finite output.")
+        return gated, regression, logits
+
+    def forward(self, inputs):
+        gated, _, _ = self.training_outputs(inputs)
+        return gated
+
+
+class SGN(SequenceToPointTorchDisaggregator):
+    """Subtask Gated Network adapted to centered scalar NILM estimates."""
+
+    MODEL_NAME = "SGN"
+    CHECKPOINT_PREFIX = "sgn"
+    MODEL_CONFIG_FIELDS = (
+        "hidden_dim",
+        "dropout",
+        "classification_weight",
+        "on_power_threshold",
+        "learning_rate",
+        "weight_decay",
+        "validation_fraction",
+        "validation_strategy",
+        "gradient_clip_norm",
+    )
+
+    def __init__(self, params=None):
+        if params is None:
+            params = {}
+        if isinstance(params, Mapping):
+            params = dict(params)
+            params.setdefault("learning_rate", 1e-4)
+        super().__init__(
+            params, defaults=torch_defaults(sequence_length=299, batch_size=16)
+        )
+        self.hidden_dim = validate_positive_int(
+            "hidden_dim", get_param(params, "hidden_dim", 1024)
+        )
+        self.dropout = finite_number(
+            "dropout", get_param(params, "dropout", 0.0), minimum=0
+        )
+        if self.dropout >= 1:
+            raise ValueError("dropout must be less than 1.")
+        self.classification_weight = finite_number(
+            "classification_weight",
+            get_param(params, "classification_weight", 1.0),
+            minimum=0,
+            strict=True,
+        )
+        threshold = get_param(params, "on_power_threshold", None)
+        self.on_power_threshold = (
+            None
+            if threshold is None
+            else finite_number("on_power_threshold", threshold, minimum=0)
+        )
+        minimum_length = 1 + sum(size - 1 for size in PAPER_KERNEL_SIZES)
+        if self.sequence_length < minimum_length:
+            raise ValueError(f"sequence_length must be at least {minimum_length}.")
+        if self.load_model_path:
+            self.load_model()
+
+    def _threshold_for(self, appliance_name):
+        if self.on_power_threshold is not None:
+            return self.on_power_threshold
+        statistics = self._validated_appliance_stats(
+            appliance_name, self.REQUIRED_APPLIANCE_STATS
+        )
+        for key in ("on_power_threshold", "threshold"):
+            if key in statistics:
+                return finite_number(
+                    f"{appliance_name!r} {key}", statistics[key], minimum=0
+                )
+        return PAPER_ON_POWER_THRESHOLD
+
+    def configure_network(self, network, appliance_name):
+        if not isinstance(network, SGNNetwork):
+            raise TypeError("SGN requires an SGNNetwork for every appliance.")
+        statistics = self._validated_appliance_stats(
+            appliance_name, self.REQUIRED_APPLIANCE_STATS
+        )
+        network.configure_target(statistics["mean"], statistics["std"])
+
+    def training_loss(self, network, batch_inputs, batch_targets, appliance_name):
+        inputs = batch_inputs.to(self.device).unsqueeze(1)
+        gated, regression, logits = network.training_outputs(inputs)
+        for output in (gated, regression, logits):
+            self._checked_model_output(output, len(batch_inputs), appliance_name)
+        target = batch_targets.to(self.device, dtype=gated.dtype)
+        statistics = self._validated_appliance_stats(
+            appliance_name, self.REQUIRED_APPLIANCE_STATS
+        )
+        raw_target = target * statistics["std"] + statistics["mean"]
+        on_target = (raw_target > self._threshold_for(appliance_name)).to(gated.dtype)
+        output_loss = nn.functional.mse_loss(gated, target)
+        on_loss = nn.functional.binary_cross_entropy_with_logits(logits, on_target)
+        return output_loss + self.classification_weight * on_loss
+
+    def return_network(self):
+        return SGNNetwork(
+            sequence_length=self.sequence_length,
+            hidden_dim=self.hidden_dim,
+            dropout=self.dropout,
+        ).to(self.device)
+
+
+__all__ = ["SGN", "SGNNetwork", "SGNTower"]

--- a/tests/model_smoke_helpers.py
+++ b/tests/model_smoke_helpers.py
@@ -55,6 +55,7 @@ TORCH_MODEL_SPECS = (
     ModelSpec("torch", "nilmtk_contrib.torch", "RNN_attention_classification", "nilmtk_contrib.torch.rnn_attention_classification"),
     ModelSpec("torch", "nilmtk_contrib.torch", "Seq2PointTorch", "nilmtk_contrib.torch.seq2point"),
     ModelSpec("torch", "nilmtk_contrib.torch", "Seq2Seq", "nilmtk_contrib.torch.seq2seq"),
+    ModelSpec("torch", "nilmtk_contrib.torch", "SGN", "nilmtk_contrib.torch.sgn"),
     ModelSpec("torch", "nilmtk_contrib.torch", "TCN", "nilmtk_contrib.torch.TCN"),
     ModelSpec("torch", "nilmtk_contrib.torch", "TimesNet", "nilmtk_contrib.torch.timesnet"),
     ModelSpec("torch", "nilmtk_contrib.torch", "WindowGRU", "nilmtk_contrib.torch.WindowGRU"),

--- a/tests/test_model_registry_comprehensive.py
+++ b/tests/test_model_registry_comprehensive.py
@@ -250,10 +250,12 @@ def test_model_self_method_calls_are_defined_or_known_runtime_methods(repo_root)
         "load_model",
         "modules",
         "named_parameters",
+        "register_buffer",
         "require_models",
         "save_model",
         "set_appliance_params",
         "_validated_appliance_stats",
+        "_checked_model_output",
     }
     offenders = []
     for model_dir in (

--- a/tests/test_sgn.py
+++ b/tests/test_sgn.py
@@ -1,0 +1,248 @@
+import inspect
+import math
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+torch = pytest.importorskip("torch")
+metadata_module = pytest.importorskip("nilmtk_contrib.metadata")
+engine_module = pytest.importorskip("nilmtk_contrib.torch._seq2point")
+sgn_module = pytest.importorskip("nilmtk_contrib.torch.sgn")
+nn = torch.nn
+model_catalog_by_module = metadata_module.model_catalog_by_module
+SequenceToPointTorchDisaggregator = engine_module.SequenceToPointTorchDisaggregator
+PAPER_FILTERS = sgn_module.PAPER_FILTERS
+PAPER_KERNEL_SIZES = sgn_module.PAPER_KERNEL_SIZES
+SGN = sgn_module.SGN
+SGNNetwork = sgn_module.SGNNetwork
+SGNTower = sgn_module.SGNTower
+
+
+class _FixedTower(nn.Module):
+    def __init__(self, values):
+        super().__init__()
+        self.values = nn.Parameter(torch.tensor(values, dtype=torch.float32))
+
+    def forward(self, inputs):
+        return self.values[: len(inputs)].reshape(-1, 1)
+
+
+def _params(**overrides):
+    return {
+        "device": "cpu",
+        "sequence_length": 39,
+        "n_epochs": 1,
+        "batch_size": 8,
+        "seed": 23,
+        "mains_mean": 100.0,
+        "mains_std": 40.0,
+        "hidden_dim": 8,
+        "dropout": 0.0,
+        "appliance_params": {"fridge": {"mean": 10.0, "std": 5.0}},
+    } | overrides
+
+
+def _chunks(length=78):
+    time = np.arange(length, dtype=np.float32)
+    appliance = 30.0 * ((time // 6) % 2)
+    mains = 70.0 + appliance + 4.0 * np.sin(time / 3)
+    index = pd.date_range("2026-01-01", periods=length, freq="1min", tz="UTC")
+    return (
+        [pd.DataFrame({"power": mains}, index=index)],
+        [("fridge", [pd.DataFrame({"power": appliance}, index=index)])],
+    )
+
+
+def test_sgn_is_an_architecture_only_engine_consumer():
+    source = Path(inspect.getfile(SGN)).read_text()
+
+    assert issubclass(SGN, SequenceToPointTorchDisaggregator)
+    assert len(source.splitlines()) < 320
+    for method in ("partial_fit", "disaggregate_chunk", "save_model", "load_model"):
+        assert f"def {method}(" not in source
+
+
+def test_tower_uses_the_paper_kernel_and_filter_schedule():
+    tower = SGNTower(sequence_length=39, hidden_dim=8)
+
+    assert tuple(layer.kernel_size[0] for layer in tower.convolutions) == (
+        PAPER_KERNEL_SIZES
+    )
+    assert tuple(layer.out_channels for layer in tower.convolutions) == PAPER_FILTERS
+    assert tower(torch.ones(2, 1, 39)).shape == (2, 1)
+
+
+def test_gate_operates_in_raw_power_despite_normalized_training_targets():
+    network = SGNNetwork(sequence_length=39, hidden_dim=4)
+    network.regression_tower = _FixedTower([1.0, 2.0])
+    network.classification_tower = _FixedTower([0.0, math.log(1 / 3)])
+    network.configure_target(mean=100.0, std=20.0)
+
+    gated, regression, logits = network.training_outputs(torch.zeros(2, 1, 39))
+    decoded = 100.0 + 20.0 * gated
+    expected = torch.sigmoid(logits) * (100.0 + 20.0 * regression)
+
+    assert torch.allclose(decoded, expected)
+    assert decoded[:, 0].tolist() == pytest.approx([60.0, 35.0])
+
+
+def test_network_requires_target_normalization_before_forward():
+    network = SGNNetwork(sequence_length=39, hidden_dim=4)
+
+    with pytest.raises(RuntimeError, match="not configured"):
+        network(torch.ones(2, 1, 39))
+
+
+@pytest.mark.parametrize(
+    ("mean", "std"),
+    [
+        (float("nan"), 1.0),
+        (0.0, 0.0),
+        (0.0, -1.0),
+        (True, 1.0),
+    ],
+)
+def test_network_rejects_invalid_target_normalization(mean, std):
+    network = SGNNetwork(sequence_length=39, hidden_dim=4)
+
+    with pytest.raises(ValueError):
+        network.configure_target(mean, std)
+
+
+@pytest.mark.parametrize(
+    "inputs",
+    [
+        object(),
+        torch.ones(2, 39),
+        torch.ones(2, 1, 37),
+        torch.ones(2, 1, 39, dtype=torch.int64),
+        torch.full((2, 1, 39), float("nan")),
+    ],
+)
+def test_network_rejects_invalid_inputs(inputs):
+    network = SGNNetwork(sequence_length=39, hidden_dim=4)
+    network.configure_target(10.0, 5.0)
+
+    with pytest.raises((TypeError, ValueError)):
+        network(inputs)
+
+
+def test_joint_loss_uses_raw_threshold_labels_and_both_subtasks():
+    model = SGN(_params(on_power_threshold=15.0))
+    network = model.return_network()
+    network.regression_tower = _FixedTower([0.0, 2.0])
+    network.classification_tower = _FixedTower([-2.0, 2.0])
+    model.configure_network(network, "fridge")
+    inputs = torch.ones(2, model.sequence_length)
+    targets = torch.tensor([[0.0], [2.0]])
+
+    actual = model.training_loss(network, inputs, targets, "fridge")
+    gated, _, logits = network.training_outputs(inputs.unsqueeze(1))
+    expected = nn.functional.mse_loss(gated, targets)
+    expected += nn.functional.binary_cross_entropy_with_logits(
+        logits, torch.tensor([[0.0], [1.0]])
+    )
+    actual.backward()
+
+    assert torch.allclose(actual, expected)
+    assert network.regression_tower.values.grad is not None
+    assert network.classification_tower.values.grad is not None
+
+
+def test_threshold_precedence_is_explicit_then_metadata_then_paper_default():
+    explicit = SGN(_params(on_power_threshold=20.0))
+    metadata = SGN(
+        _params(appliance_params={"fridge": {"mean": 10, "std": 5, "threshold": 60}})
+    )
+    default = SGN(_params())
+
+    assert explicit._threshold_for("fridge") == 20.0
+    assert metadata._threshold_for("fridge") == 60.0
+    assert default._threshold_for("fridge") == 15.0
+
+
+@pytest.mark.parametrize(
+    ("params", "message"),
+    [
+        ({"sequence_length": 33}, "at least"),
+        ({"hidden_dim": 0}, "positive integer"),
+        ({"dropout": 1.0}, "less than 1"),
+        ({"classification_weight": 0.0}, "greater than"),
+        ({"on_power_threshold": -1.0}, "at least"),
+    ],
+)
+def test_invalid_configuration_fails_at_construction(params, message):
+    with pytest.raises(ValueError, match=message):
+        SGN(_params(**params))
+
+
+def test_configuration_rejects_an_incompatible_network():
+    model = SGN(_params())
+
+    with pytest.raises(TypeError, match="SGNNetwork"):
+        model.configure_network(nn.Linear(2, 1), "fridge")
+
+
+def test_one_epoch_train_infer_smoke_preserves_rows_and_trains_both_towers():
+    mains, targets = _chunks()
+    model = SGN(_params(appliance_params={}))
+
+    model.partial_fit(mains, targets)
+    result = model.disaggregate_chunk(mains)[0]
+    network = model.models["fridge"]
+
+    assert result.index.equals(mains[0].index)
+    assert result.columns.tolist() == ["fridge"]
+    assert result["fridge"].dtype == np.float32
+    assert np.isfinite(result["fridge"]).all()
+    assert torch.isfinite(network.target_mean)
+    assert torch.isfinite(network.target_std)
+    assert all(
+        parameter.grad is not None and torch.isfinite(parameter.grad).all()
+        for parameter in network.parameters()
+    )
+
+
+def test_checkpoint_roundtrip_restores_architecture_and_predictions(tmp_path):
+    mains, targets = _chunks()
+    model = SGN(
+        _params(
+            appliance_params={},
+            save_model_path=str(tmp_path),
+            hidden_dim=10,
+        )
+    )
+    model.partial_fit(mains, targets)
+    expected = model.disaggregate_chunk(mains)[0]
+
+    loaded = SGN(
+        _params(
+            appliance_params={},
+            pretrained_model_path=str(tmp_path),
+            hidden_dim=4,
+        )
+    )
+    actual = loaded.disaggregate_chunk(mains)[0]
+
+    assert loaded.hidden_dim == 10
+    assert np.allclose(actual, expected)
+
+
+def test_public_export_catalog_and_paper_defaults_are_complete():
+    import nilmtk_contrib.torch as torch_models
+
+    default = SGN({"device": "cpu"})
+    entry = model_catalog_by_module()["nilmtk_contrib.torch.sgn"]
+
+    assert torch_models.SGN is SGN
+    assert default.sequence_length == 299
+    assert default.batch_size == 16
+    assert default.learning_rate == pytest.approx(1e-4)
+    assert default.hidden_dim == 1024
+    assert default.classification_weight == 1.0
+    assert default.on_power_threshold is None
+    assert entry.class_name == "SGN"
+    assert entry.exported_from == "nilmtk_contrib.torch"

--- a/tests/test_torch_migration_contract.py
+++ b/tests/test_torch_migration_contract.py
@@ -44,6 +44,7 @@ DEFAULTS_BY_MODULE = {
     ),
     "nilmtk_contrib.torch.seq2point": ExpectedDefaults(99, 10, 512, 1800, 600),
     "nilmtk_contrib.torch.seq2seq": ExpectedDefaults(99, 10, 512, 1800, 600),
+    "nilmtk_contrib.torch.sgn": ExpectedDefaults(299, 10, 16, 1800, 600),
     "nilmtk_contrib.torch.timesnet": ExpectedDefaults(299, 10, 128, 1800, 600),
 }
 


### PR DESCRIPTION
## Summary

- add an SGN sequence-to-point adaptation with independent paper-shaped regression and on/off CNN towers
- implement the paper objective L_output + L_on and its soft probability gate
- apply the gate in raw-power space even though contrib targets use affine normalization
- prefer an explicit threshold, then appliance metadata, then the paper 15 W fallback
- reuse the shared training-loss, target-configuration, inference, checkpoint, and partial-chunk lifecycle

Primary reference: Shin et al., Subtask Gated Networks for Non-Intrusive Load Monitoring, AAAI 2019: https://doi.org/10.1609/aaai.v33i01.33011150

This is explicitly documented as a centered scalar adaptation because the paper predicts output sequences.

## Verification

- 24 dedicated tests; 94.96% module coverage
- focused engine/catalog/registry suite: 246 passed
- full suite: 575 passed, 91 skipped
- all-model one-epoch PyTorch smoke gate: 21 passed, 13 skipped
- exact raw-power gate identity and raw-threshold classification labels tested
- both towers receive finite gradients; one-epoch train/infer and checkpoint roundtrip pass
- ruff, formatting, lockfile, and diff checks clean
- source distribution and wheel built; isolated wheel public import/configuration verified

## Scope

This PR adds the contrib model only. TimesNet and SGN real REDD T0 benchmark integration will follow together in one NILMbench campaign image after this merges.