### PR TITLE
Add TSMixer sequence-to-point model

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ The table below lists the public model surface. "Verification" describes how the
 | ConvLSTM | PyTorch | `nilmtk_contrib.torch.ConvLSTM` | ConvLSTM-inspired NILM adaptation | Shi et al., ConvLSTM | Generic spatiotemporal architecture adapted to NILM |
 | TCN | PyTorch | `nilmtk_contrib.torch.TCN` | Generic TCN sequence-modeling baseline adapted to NILM | Bai, Kolter, and Koltun, TCN | PyTorch backend |
 | SGN | PyTorch | `nilmtk_contrib.torch.SGN` | Subtask-gated sequence-to-point adaptation; benchmark claims require NILMbench result bundles | Shin et al., SGN | Uses a raw-power-correct soft on/off gate and auxiliary classification loss |
+| TSMixer | PyTorch | `nilmtk_contrib.torch.TSMixer` | All-MLP sequence-to-point adaptation; benchmark claims require NILMbench result bundles | Chen et al., TSMixer | Mixes along time and feature dimensions without attention or recurrence |
 | TimesNet | PyTorch | `nilmtk_contrib.torch.TimesNet` | TimesNet-inspired sequence-to-point adaptation; benchmark claims require NILMbench result bundles | Wu et al., TimesNet | PyTorch backend |
 | Reformer | PyTorch | `nilmtk_contrib.torch.Reformer` | Reformer-inspired NILM adaptation | Kitaev, Kaiser, and Levskaya, Reformer | Efficient Transformer architecture adapted to NILM |
 | MSDC | PyTorch | `nilmtk_contrib.torch.MSDC` | NILM paper implementation requiring experiment validation for new claims | MSDC dual-CNN NILM paper | Canonical CRF-enabled implementation path |
@@ -320,6 +321,7 @@ NILM-specific references:
 - Luo and Wang, "ModernTCN: A Modern Pure Convolution Structure for General Time Series Analysis", ICLR 2024, https://openreview.net/forum?id=vpJMJerXHU.
 - Zeng et al., "Are Transformers Effective for Time Series Forecasting?", AAAI 2023, https://arxiv.org/abs/2205.13504.
 - Shin et al., "Subtask Gated Networks for Non-Intrusive Load Monitoring", AAAI 2019, https://doi.org/10.1609/aaai.v33i01.33011150.
+- Chen et al., "TSMixer: An All-MLP Architecture for Time Series Forecasting", TMLR 2023, https://arxiv.org/abs/2303.06053.
 - Wu et al., "TimesNet: Temporal 2D-Variation Modeling for General Time Series Analysis", ICLR 2023, https://openreview.net/forum?id=ju_Uqw384Oq.
 
 Generic architecture references:

--- a/nilmtk_contrib/metadata.py
+++ b/nilmtk_contrib/metadata.py
@@ -45,6 +45,7 @@ MODEL_CATALOG = (
     ModelCatalogEntry("Seq2Seq", "torch", "nilmtk_contrib.torch.seq2seq", "Seq2Seq", "nilmtk_contrib.torch"),
     ModelCatalogEntry("SGN", "torch", "nilmtk_contrib.torch.sgn", "SGN", "nilmtk_contrib.torch"),
     ModelCatalogEntry("TCN", "torch", "nilmtk_contrib.torch.TCN", "TCN", "nilmtk_contrib.torch"),
+    ModelCatalogEntry("TSMixer", "torch", "nilmtk_contrib.torch.tsmixer", "TSMixer", "nilmtk_contrib.torch"),
     ModelCatalogEntry("TimesNet", "torch", "nilmtk_contrib.torch.timesnet", "TimesNet", "nilmtk_contrib.torch"),
     ModelCatalogEntry("WindowGRU", "torch", "nilmtk_contrib.torch.WindowGRU", "WindowGRU", "nilmtk_contrib.torch"),
 )

--- a/nilmtk_contrib/torch/__init__.py
+++ b/nilmtk_contrib/torch/__init__.py
@@ -29,6 +29,7 @@ _EXPORTS = {
     "Seq2Seq": ("nilmtk_contrib.torch.seq2seq", "Seq2Seq"),
     "SGN": ("nilmtk_contrib.torch.sgn", "SGN"),
     "TCN": ("nilmtk_contrib.torch.TCN", "TCN"),
+    "TSMixer": ("nilmtk_contrib.torch.tsmixer", "TSMixer"),
     "TimesNet": ("nilmtk_contrib.torch.timesnet", "TimesNet"),
     "WindowGRU": ("nilmtk_contrib.torch.WindowGRU", "WindowGRU"),
 }

--- a/nilmtk_contrib/torch/tsmixer.py
+++ b/nilmtk_contrib/torch/tsmixer.py
@@ -1,0 +1,201 @@
+"""TSMixer-inspired sequence-to-point energy disaggregator."""
+
+from collections.abc import Mapping
+
+import torch
+from torch import nn
+
+from nilmtk_contrib.torch._base import torch_defaults
+from nilmtk_contrib.torch._seq2point import (
+    SequenceToPointTorchDisaggregator,
+    finite_number,
+)
+from nilmtk_contrib.utils.params import get_param, validate_positive_int
+
+
+def _activation(name):
+    if not isinstance(name, str):
+        raise ValueError("activation must be 'relu' or 'gelu'.")
+    normalized = name.lower()
+    if normalized == "relu":
+        return nn.ReLU()
+    if normalized == "gelu":
+        return nn.GELU()
+    raise ValueError("activation must be 'relu' or 'gelu'.")
+
+
+class TSMixerBlock(nn.Module):
+    """Mix information along the temporal and feature dimensions."""
+
+    def __init__(
+        self,
+        sequence_length,
+        channels=1,
+        ff_dim=64,
+        dropout=0.1,
+        activation="relu",
+    ):
+        super().__init__()
+        for name, value in (
+            ("sequence_length", sequence_length),
+            ("channels", channels),
+            ("ff_dim", ff_dim),
+        ):
+            validate_positive_int(name, value)
+        dropout = finite_number("dropout", dropout, minimum=0)
+        if dropout >= 1:
+            raise ValueError("dropout must be less than 1.")
+
+        normalized_shape = (sequence_length, channels)
+        self.temporal_norm = nn.LayerNorm(normalized_shape)
+        self.temporal_linear = nn.Linear(sequence_length, sequence_length)
+        self.temporal_activation = _activation(activation)
+        self.temporal_dropout = nn.Dropout(dropout)
+
+        self.feature_norm = nn.LayerNorm(normalized_shape)
+        self.feature_in = nn.Linear(channels, ff_dim)
+        self.feature_activation = _activation(activation)
+        self.feature_dropout = nn.Dropout(dropout)
+        self.feature_out = nn.Linear(ff_dim, channels)
+        self.output_dropout = nn.Dropout(dropout)
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        for layer in (self.temporal_linear, self.feature_in, self.feature_out):
+            nn.init.xavier_uniform_(layer.weight)
+            nn.init.zeros_(layer.bias)
+
+    def forward(self, inputs):
+        temporal = self.temporal_norm(inputs).transpose(1, 2)
+        temporal = self.temporal_activation(self.temporal_linear(temporal))
+        mixed = inputs + self.temporal_dropout(temporal).transpose(1, 2)
+
+        features = self.feature_norm(mixed)
+        features = self.feature_dropout(
+            self.feature_activation(self.feature_in(features))
+        )
+        features = self.output_dropout(self.feature_out(features))
+        return mixed + features
+
+
+class TSMixerNetwork(nn.Module):
+    """All-MLP mixer backbone with a centered scalar NILM head."""
+
+    def __init__(
+        self,
+        sequence_length,
+        ff_dim=64,
+        n_blocks=2,
+        dropout=0.1,
+        activation="relu",
+    ):
+        super().__init__()
+        validate_positive_int("sequence_length", sequence_length)
+        validate_positive_int("ff_dim", ff_dim)
+        validate_positive_int("n_blocks", n_blocks)
+        if sequence_length % 2 == 0:
+            raise ValueError("sequence_length must be odd.")
+        dropout = finite_number("dropout", dropout, minimum=0)
+        if dropout >= 1:
+            raise ValueError("dropout must be less than 1.")
+        _activation(activation)
+
+        self.sequence_length = sequence_length
+        self.blocks = nn.ModuleList(
+            TSMixerBlock(
+                sequence_length=sequence_length,
+                channels=1,
+                ff_dim=ff_dim,
+                dropout=dropout,
+                activation=activation,
+            )
+            for _ in range(n_blocks)
+        )
+        self.head = nn.Linear(sequence_length, 1)
+        nn.init.xavier_uniform_(self.head.weight)
+        nn.init.zeros_(self.head.bias)
+
+    def forward(self, inputs):
+        if not isinstance(inputs, torch.Tensor):
+            raise TypeError("TSMixerNetwork inputs must be a torch.Tensor.")
+        expected_shape = (1, self.sequence_length)
+        if inputs.ndim != 3 or inputs.shape[1:] != expected_shape:
+            raise ValueError(
+                "TSMixerNetwork expects input shape "
+                f"(batch, 1, {self.sequence_length}); got {tuple(inputs.shape)}."
+            )
+        if not torch.is_floating_point(inputs) or torch.is_complex(inputs):
+            raise TypeError("TSMixerNetwork inputs must be real floating tensors.")
+        device = self.head.weight.device
+        if inputs.device != device:
+            raise ValueError(
+                f"TSMixerNetwork input is on {inputs.device}; model is on {device}."
+            )
+        if not torch.isfinite(inputs).all():
+            raise ValueError("TSMixerNetwork inputs must be finite.")
+
+        encoded = inputs.to(dtype=self.head.weight.dtype).transpose(1, 2)
+        for block in self.blocks:
+            encoded = block(encoded)
+        output = self.head(encoded.transpose(1, 2)).squeeze(-1)
+        if not torch.isfinite(output).all():
+            raise RuntimeError("TSMixerNetwork produced non-finite output.")
+        return output
+
+
+class TSMixer(SequenceToPointTorchDisaggregator):
+    """TSMixer adapted to one NILM estimate per centered mains row."""
+
+    MODEL_NAME = "TSMixer"
+    CHECKPOINT_PREFIX = "tsmixer"
+    MODEL_CONFIG_FIELDS = (
+        "ff_dim",
+        "n_blocks",
+        "dropout",
+        "activation",
+        "learning_rate",
+        "weight_decay",
+        "validation_fraction",
+        "validation_strategy",
+        "gradient_clip_norm",
+    )
+
+    def __init__(self, params=None):
+        if params is None:
+            params = {}
+        if isinstance(params, Mapping):
+            params = dict(params)
+            params.setdefault("weight_decay", 1e-4)
+        super().__init__(
+            params, defaults=torch_defaults(sequence_length=299, batch_size=128)
+        )
+        self.ff_dim = validate_positive_int(
+            "ff_dim", get_param(params, "ff_dim", 64)
+        )
+        self.n_blocks = validate_positive_int(
+            "n_blocks", get_param(params, "n_blocks", 2)
+        )
+        self.dropout = finite_number(
+            "dropout", get_param(params, "dropout", 0.1), minimum=0
+        )
+        self.activation = get_param(params, "activation", "relu")
+        self._validate_architecture()
+        if self.load_model_path:
+            self.load_model()
+
+    def _validate_architecture(self):
+        if self.dropout >= 1:
+            raise ValueError("dropout must be less than 1.")
+        _activation(self.activation)
+
+    def return_network(self):
+        return TSMixerNetwork(
+            sequence_length=self.sequence_length,
+            ff_dim=self.ff_dim,
+            n_blocks=self.n_blocks,
+            dropout=self.dropout,
+            activation=self.activation,
+        ).to(self.device)
+
+
+__all__ = ["TSMixer", "TSMixerBlock", "TSMixerNetwork"]

--- a/tests/model_smoke_helpers.py
+++ b/tests/model_smoke_helpers.py
@@ -57,6 +57,7 @@ TORCH_MODEL_SPECS = (
     ModelSpec("torch", "nilmtk_contrib.torch", "Seq2Seq", "nilmtk_contrib.torch.seq2seq"),
     ModelSpec("torch", "nilmtk_contrib.torch", "SGN", "nilmtk_contrib.torch.sgn"),
     ModelSpec("torch", "nilmtk_contrib.torch", "TCN", "nilmtk_contrib.torch.TCN"),
+    ModelSpec("torch", "nilmtk_contrib.torch", "TSMixer", "nilmtk_contrib.torch.tsmixer"),
     ModelSpec("torch", "nilmtk_contrib.torch", "TimesNet", "nilmtk_contrib.torch.timesnet"),
     ModelSpec("torch", "nilmtk_contrib.torch", "WindowGRU", "nilmtk_contrib.torch.WindowGRU"),
 )

--- a/tests/test_torch_migration_contract.py
+++ b/tests/test_torch_migration_contract.py
@@ -45,6 +45,7 @@ DEFAULTS_BY_MODULE = {
     "nilmtk_contrib.torch.seq2point": ExpectedDefaults(99, 10, 512, 1800, 600),
     "nilmtk_contrib.torch.seq2seq": ExpectedDefaults(99, 10, 512, 1800, 600),
     "nilmtk_contrib.torch.sgn": ExpectedDefaults(299, 10, 16, 1800, 600),
+    "nilmtk_contrib.torch.tsmixer": ExpectedDefaults(299, 10, 128, 1800, 600),
     "nilmtk_contrib.torch.timesnet": ExpectedDefaults(299, 10, 128, 1800, 600),
 }
 

--- a/tests/test_tsmixer.py
+++ b/tests/test_tsmixer.py
@@ -1,0 +1,259 @@
+import inspect
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+torch = pytest.importorskip("torch")
+metadata_module = pytest.importorskip("nilmtk_contrib.metadata")
+engine_module = pytest.importorskip("nilmtk_contrib.torch._seq2point")
+tsmixer_module = pytest.importorskip("nilmtk_contrib.torch.tsmixer")
+model_catalog_by_module = metadata_module.model_catalog_by_module
+SequenceToPointTorchDisaggregator = engine_module.SequenceToPointTorchDisaggregator
+TSMixer = tsmixer_module.TSMixer
+TSMixerBlock = tsmixer_module.TSMixerBlock
+TSMixerNetwork = tsmixer_module.TSMixerNetwork
+
+
+def _params(**overrides):
+    return {
+        "device": "cpu",
+        "sequence_length": 9,
+        "n_epochs": 1,
+        "batch_size": 4,
+        "seed": 17,
+        "mains_mean": 100.0,
+        "mains_std": 40.0,
+        "ff_dim": 8,
+        "n_blocks": 2,
+        "dropout": 0.0,
+        "activation": "relu",
+    } | overrides
+
+
+def _chunks(length=18):
+    values = np.arange(length, dtype=np.float32)
+    index = pd.date_range("2026-01-01", periods=length, freq="1min", tz="UTC")
+    appliance = 25.0 + 30.0 * ((values // 3) % 2)
+    mains = 70.0 + appliance + 3.0 * np.sin(values / 2)
+    return (
+        [pd.DataFrame({"power": mains}, index=index)],
+        [("fridge", [pd.DataFrame({"power": appliance}, index=index)])],
+    )
+
+
+def test_tsmixer_is_an_architecture_only_engine_consumer():
+    source = Path(inspect.getfile(TSMixer)).read_text()
+
+    assert issubclass(TSMixer, SequenceToPointTorchDisaggregator)
+    assert len(source.splitlines()) < 240
+    for method in ("partial_fit", "disaggregate_chunk", "save_model", "load_model"):
+        assert f"def {method}(" not in source
+
+
+def test_block_matches_the_published_time_then_feature_mixing_shape():
+    block = TSMixerBlock(
+        sequence_length=9,
+        channels=3,
+        ff_dim=7,
+        dropout=0.0,
+        activation="gelu",
+    )
+    inputs = torch.randn(4, 9, 3)
+
+    output = block(inputs)
+
+    assert output.shape == inputs.shape
+    assert block.temporal_linear.in_features == 9
+    assert block.temporal_linear.out_features == 9
+    assert block.feature_in.in_features == 3
+    assert block.feature_in.out_features == 7
+    assert block.feature_out.in_features == 7
+    assert block.feature_out.out_features == 3
+
+
+def test_network_is_all_mlp_without_attention_convolution_or_recurrence():
+    network = TSMixer(_params()).return_network()
+    forbidden = (
+        torch.nn.modules.conv._ConvNd,
+        torch.nn.RNNBase,
+        torch.nn.MultiheadAttention,
+    )
+
+    assert not any(isinstance(module, forbidden) for module in network.modules())
+    assert sum(isinstance(module, torch.nn.Linear) for module in network.modules()) == 7
+
+
+@pytest.mark.parametrize("activation", ["relu", "ReLU", "gelu", "GELU"])
+def test_supported_activations_preserve_shape_and_backpropagate(activation):
+    network = TSMixer(_params(activation=activation)).return_network()
+    output = network(torch.randn(3, 1, 9))
+    output.sum().backward()
+
+    assert output.shape == (3, 1)
+    assert all(
+        parameter.grad is not None and torch.isfinite(parameter.grad).all()
+        for parameter in network.parameters()
+    )
+
+
+def test_network_accepts_real_float64_and_returns_parameter_dtype():
+    network = TSMixer(_params()).return_network()
+
+    output = network(torch.ones(2, 1, 9, dtype=torch.float64))
+
+    assert output.dtype == network.head.weight.dtype == torch.float32
+
+
+@pytest.mark.parametrize(
+    ("params", "message"),
+    [
+        ({"sequence_length": 8}, "odd"),
+        ({"ff_dim": 0}, "positive integer"),
+        ({"ff_dim": True}, "positive integer"),
+        ({"n_blocks": 0}, "positive integer"),
+        ({"dropout": -0.1}, "at least"),
+        ({"dropout": 1.0}, "less than 1"),
+        ({"activation": "swish"}, "relu.*gelu"),
+        ({"activation": None}, "relu.*gelu"),
+        ({"weight_decay": -1.0}, "at least"),
+    ],
+)
+def test_invalid_configuration_fails_at_construction(params, message):
+    with pytest.raises(ValueError, match=message):
+        TSMixer(_params(**params))
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"sequence_length": 0},
+        {"sequence_length": 8},
+        {"sequence_length": 9, "ff_dim": True},
+        {"sequence_length": 9, "n_blocks": 0},
+        {"sequence_length": 9, "dropout": float("nan")},
+        {"sequence_length": 9, "dropout": 1.0},
+        {"sequence_length": 9, "activation": object()},
+    ],
+)
+def test_network_constructor_enforces_its_public_contract(params):
+    with pytest.raises(ValueError):
+        TSMixerNetwork(**params)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"sequence_length": 0},
+        {"sequence_length": 9, "channels": 0},
+        {"sequence_length": 9, "ff_dim": True},
+        {"sequence_length": 9, "dropout": float("inf")},
+        {"sequence_length": 9, "dropout": 1.0},
+        {"sequence_length": 9, "activation": "tanh"},
+    ],
+)
+def test_block_constructor_enforces_its_public_contract(params):
+    with pytest.raises(ValueError):
+        TSMixerBlock(**params)
+
+
+@pytest.mark.parametrize(
+    "inputs",
+    [
+        object(),
+        torch.ones(2, 9),
+        torch.ones(2, 1, 8),
+        torch.ones(2, 1, 9, dtype=torch.int64),
+        torch.full((2, 1, 9), float("nan")),
+    ],
+)
+def test_network_rejects_invalid_inputs(inputs):
+    network = TSMixer(_params()).return_network()
+
+    with pytest.raises((TypeError, ValueError)):
+        network(inputs)
+
+
+def test_network_rejects_an_input_on_a_different_device():
+    network = TSMixer(_params()).return_network().to("meta")
+
+    with pytest.raises(ValueError, match="input is on cpu; model is on meta"):
+        network(torch.ones(1, 1, 9))
+
+
+def test_network_rejects_non_finite_internal_output():
+    network = TSMixer(_params()).return_network()
+    with torch.no_grad():
+        network.head.weight.fill_(float("inf"))
+
+    with pytest.raises(RuntimeError, match="non-finite output"):
+        network(torch.ones(1, 1, 9))
+
+
+def test_one_epoch_train_infer_smoke_preserves_every_row():
+    mains, targets = _chunks()
+    model = TSMixer(_params(appliance_params={}))
+
+    model.partial_fit(mains, targets)
+    result = model.disaggregate_chunk(mains)[0]
+
+    assert result.index.equals(mains[0].index)
+    assert result.columns.tolist() == ["fridge"]
+    assert result["fridge"].dtype == np.float32
+    assert np.isfinite(result["fridge"]).all()
+
+
+def test_checkpoint_roundtrip_restores_architecture_and_predictions(tmp_path):
+    mains, targets = _chunks()
+    model = TSMixer(
+        _params(
+            appliance_params={},
+            save_model_path=str(tmp_path),
+            ff_dim=6,
+            activation="gelu",
+        )
+    )
+    model.partial_fit(mains, targets)
+    expected = model.disaggregate_chunk(mains)[0]
+
+    loaded = TSMixer(
+        _params(
+            appliance_params={},
+            pretrained_model_path=str(tmp_path),
+            ff_dim=4,
+            activation="relu",
+        )
+    )
+    actual = loaded.disaggregate_chunk(mains)[0]
+
+    assert loaded.ff_dim == 6
+    assert loaded.activation == "gelu"
+    assert np.allclose(actual, expected)
+
+
+def test_public_export_catalog_defaults_and_parameter_count_are_stable():
+    import nilmtk_contrib.torch as torch_models
+
+    default = TSMixer({"device": "cpu"})
+    network = default.return_network()
+    entry = model_catalog_by_module()["nilmtk_contrib.torch.tsmixer"]
+
+    assert torch_models.TSMixer is TSMixer
+    assert default.sequence_length == 299
+    assert default.batch_size == 128
+    assert default.ff_dim == 64
+    assert default.n_blocks == 2
+    assert default.activation == "relu"
+    assert default.weight_decay == pytest.approx(1e-4)
+    assert sum(parameter.numel() for parameter in network.parameters()) == 182478
+    assert entry.class_name == "TSMixer"
+    assert entry.exported_from == "nilmtk_contrib.torch"
+
+
+def test_none_uses_documented_defaults():
+    model = TSMixer()
+
+    assert model.sequence_length == 299
+    assert model.ff_dim == 64


### PR DESCRIPTION
## What

- add a PyTorch TSMixer adaptation on the shared sequence-to-point runtime
- retain the published time-mixing then feature-mixing residual structure using only MLPs
- map each symmetric mains window to its centered appliance target
- expose the model through lazy exports, the model catalog, README, and all-model smoke registry
- add a compact 201-line architecture with no training, inference, or checkpoint boilerplate

Reference: Chen et al., TSMixer: An All-MLP Architecture for Time Series Forecasting, TMLR 2023, https://arxiv.org/abs/2303.06053
Official implementation: https://github.com/google-research/google-research/tree/master/tsmixer

## Verification

- 41 dedicated tests passed with 100% coverage of tsmixer.py
- full suite: 624 passed, 94 optional-dependency skips
- all PyTorch model smoke: 22 passed, 13 non-PyTorch skips
- focused Ruff checks and git diff checks passed
- wheel and sdist built successfully
- isolated installed-wheel import, catalog lookup, construction, and forward pass passed

## Robustness covered

- invalid shapes, dtypes, devices, non-finite inputs and outputs
- invalid sequence lengths, dimensions, activations, dropout, and weight decay
- gradient flow through every parameter for ReLU and GELU
- row-preserving one-epoch NILMTK train/infer smoke
- checkpoint round-trip restores architecture and predictions
- public export, catalog, defaults, shared-runtime contract, and frozen parameter count