### PR TITLE
Add load-balanced NILM mixture of experts

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ The table below lists the public model surface. "Verification" describes how the
 | MSDC without CRF | PyTorch | `nilmtk_contrib.torch.msdc_without_crf.MSDC` | MSDC ablation | MSDC paper/source implementation | No-CRF ablation, not the canonical MSDC path |
 | ModernTCN | PyTorch | `nilmtk_contrib.torch.ModernTCN` | ModernTCN-inspired sequence-to-point adaptation; benchmark claims require NILMbench result bundles | Luo and Wang, ModernTCN | PyTorch backend |
 | NILMFormer | PyTorch | `nilmtk_contrib.torch.NILMFormer` | NILMFormer implementation requiring experiment validation for new claims | Petralia et al., NILMFormer | PyTorch backend |
+| NILMMoE | PyTorch | `nilmtk_contrib.torch.NILMMoE` | Experimental input-conditioned mixture; benchmark claims require NILMbench result bundles | This repository | Blends DLinear, ModernTCN, and TimesNet with a load-balanced softmax gate |
 | PatchTST | PyTorch | `nilmtk_contrib.torch.PatchTST` | PatchTST-inspired sequence-to-point adaptation; benchmark claims require NILMbench result bundles | Nie et al., PatchTST | PyTorch backend |
 
 ## Reference Papers And Codebases

--- a/nilmtk_contrib/metadata.py
+++ b/nilmtk_contrib/metadata.py
@@ -34,6 +34,7 @@ MODEL_CATALOG = (
     ModelCatalogEntry("MSDC without CRF", "torch", "nilmtk_contrib.torch.msdc_without_crf", "MSDC", None),
     ModelCatalogEntry("ModernTCN", "torch", "nilmtk_contrib.torch.moderntcn", "ModernTCN", "nilmtk_contrib.torch"),
     ModelCatalogEntry("NILMFormer", "torch", "nilmtk_contrib.torch.nilmformer", "NILMFormer", "nilmtk_contrib.torch"),
+    ModelCatalogEntry("NILMMoE", "torch", "nilmtk_contrib.torch.nilmmoe", "NILMMoE", "nilmtk_contrib.torch"),
     ModelCatalogEntry("PatchTST", "torch", "nilmtk_contrib.torch.patchtst", "PatchTST", "nilmtk_contrib.torch"),
     ModelCatalogEntry("Reformer", "torch", "nilmtk_contrib.torch.reformer", "Reformer", "nilmtk_contrib.torch"),
     ModelCatalogEntry("ResNet", "torch", "nilmtk_contrib.torch.resnet", "ResNet", "nilmtk_contrib.torch"),

--- a/nilmtk_contrib/torch/__init__.py
+++ b/nilmtk_contrib/torch/__init__.py
@@ -12,6 +12,7 @@ _EXPORTS = {
     "MSDC": ("nilmtk_contrib.torch.msdc", "MSDC"),
     "ModernTCN": ("nilmtk_contrib.torch.moderntcn", "ModernTCN"),
     "NILMFormer": ("nilmtk_contrib.torch.nilmformer", "NILMFormer"),
+    "NILMMoE": ("nilmtk_contrib.torch.nilmmoe", "NILMMoE"),
     "PatchTST": ("nilmtk_contrib.torch.patchtst", "PatchTST"),
     "Reformer": ("nilmtk_contrib.torch.reformer", "Reformer"),
     "ResNet": ("nilmtk_contrib.torch.resnet", "ResNet"),

--- a/nilmtk_contrib/torch/nilmmoe.py
+++ b/nilmtk_contrib/torch/nilmmoe.py
@@ -1,0 +1,298 @@
+"""Input-conditioned mixture of complementary NILM experts."""
+
+from collections.abc import Mapping
+
+import torch
+from torch import nn
+
+from nilmtk_contrib.torch._base import torch_defaults
+from nilmtk_contrib.torch._seq2point import (
+    SequenceToPointTorchDisaggregator,
+    finite_number,
+)
+from nilmtk_contrib.torch.dlinear import DLinearNetwork
+from nilmtk_contrib.torch.moderntcn import ModernTCNNetwork
+from nilmtk_contrib.torch.timesnet import TimesNetNetwork
+from nilmtk_contrib.utils.params import get_param, validate_positive_int
+
+
+EXPERT_NAMES = ("DLinear", "ModernTCN", "TimesNet")
+GATE_FEATURES = (
+    "center",
+    "mean",
+    "standard_deviation",
+    "minimum",
+    "maximum",
+    "mean_absolute_difference",
+    "end_to_start_change",
+)
+
+
+class NILMMoEGate(nn.Module):
+    """Route each normalized mains window using inspectable summary features."""
+
+    def __init__(
+        self,
+        sequence_length,
+        hidden_dim=32,
+        dropout=0.1,
+        temperature=1.0,
+    ):
+        super().__init__()
+        self.sequence_length = validate_positive_int(
+            "sequence_length", sequence_length
+        )
+        hidden_dim = validate_positive_int("hidden_dim", hidden_dim)
+        dropout = finite_number("dropout", dropout, minimum=0)
+        if dropout >= 1:
+            raise ValueError("dropout must be less than 1.")
+        self.temperature = finite_number(
+            "temperature", temperature, minimum=0, strict=True
+        )
+        self.input_layer = nn.Linear(len(GATE_FEATURES), hidden_dim)
+        self.activation = nn.GELU()
+        self.dropout = nn.Dropout(dropout)
+        self.output_layer = nn.Linear(hidden_dim, len(EXPERT_NAMES))
+        nn.init.xavier_uniform_(self.input_layer.weight)
+        nn.init.zeros_(self.input_layer.bias)
+        nn.init.xavier_uniform_(self.output_layer.weight)
+        nn.init.zeros_(self.output_layer.bias)
+
+    def summary_features(self, inputs):
+        """Return the seven normalized features used by the routing gate."""
+        if not isinstance(inputs, torch.Tensor):
+            raise TypeError("NILMMoEGate inputs must be a torch.Tensor.")
+        expected_shape = (1, self.sequence_length)
+        if inputs.ndim != 3 or inputs.shape[1:] != expected_shape:
+            raise ValueError(
+                "NILMMoEGate expects input shape "
+                f"(batch, 1, {self.sequence_length}); got {tuple(inputs.shape)}."
+            )
+        if not torch.is_floating_point(inputs) or torch.is_complex(inputs):
+            raise TypeError("NILMMoEGate inputs must be real floating tensors.")
+        device = self.input_layer.weight.device
+        if inputs.device != device:
+            raise ValueError(
+                f"NILMMoEGate input is on {inputs.device}; model is on {device}."
+            )
+        if not torch.isfinite(inputs).all():
+            raise ValueError("NILMMoEGate inputs must be finite.")
+        inputs = inputs.to(dtype=self.input_layer.weight.dtype)
+        center = inputs[:, :, self.sequence_length // 2]
+        mean = inputs.mean(dim=-1)
+        standard_deviation = inputs.std(dim=-1, unbiased=False)
+        minimum = inputs.amin(dim=-1)
+        maximum = inputs.amax(dim=-1)
+        differences = inputs.diff(dim=-1)
+        mean_absolute_difference = differences.abs().mean(dim=-1)
+        end_to_start_change = inputs[:, :, -1] - inputs[:, :, 0]
+        return torch.cat(
+            (
+                center,
+                mean,
+                standard_deviation,
+                minimum,
+                maximum,
+                mean_absolute_difference,
+                end_to_start_change,
+            ),
+            dim=1,
+        )
+
+    def forward(self, inputs):
+        features = self.summary_features(inputs)
+        logits = self.output_layer(
+            self.dropout(self.activation(self.input_layer(features)))
+        )
+        weights = torch.softmax(logits / self.temperature, dim=1)
+        if not torch.isfinite(weights).all():
+            raise RuntimeError("NILMMoE gate produced non-finite weights.")
+        return weights
+
+
+class NILMMoENetwork(nn.Module):
+    """Blend linear, convolutional, and periodic scalar experts."""
+
+    def __init__(
+        self,
+        sequence_length,
+        moving_average=25,
+        gate_hidden_dim=32,
+        gate_dropout=0.1,
+        gate_temperature=1.0,
+        expert_dropout=0.1,
+    ):
+        super().__init__()
+        self.sequence_length = validate_positive_int(
+            "sequence_length", sequence_length
+        )
+        moving_average = validate_positive_int("moving_average", moving_average)
+        if sequence_length % 2 == 0:
+            raise ValueError("sequence_length must be odd.")
+        if sequence_length < 25:
+            raise ValueError("sequence_length must be at least 25.")
+        if moving_average % 2 == 0:
+            raise ValueError("moving_average must be odd.")
+        if moving_average > sequence_length:
+            raise ValueError("moving_average must not exceed sequence_length.")
+        expert_dropout = finite_number(
+            "expert_dropout", expert_dropout, minimum=0
+        )
+        if expert_dropout >= 1:
+            raise ValueError("expert_dropout must be less than 1.")
+
+        self.experts = nn.ModuleDict(
+            {
+                "DLinear": DLinearNetwork(sequence_length, moving_average),
+                "ModernTCN": ModernTCNNetwork(
+                    sequence_length, dropout=expert_dropout
+                ),
+                "TimesNet": TimesNetNetwork(
+                    sequence_length, dropout=expert_dropout
+                ),
+            }
+        )
+        self.gate = NILMMoEGate(
+            sequence_length,
+            hidden_dim=gate_hidden_dim,
+            dropout=gate_dropout,
+            temperature=gate_temperature,
+        )
+
+    def _validate_inputs(self, inputs):
+        if not isinstance(inputs, torch.Tensor):
+            raise TypeError("NILMMoENetwork inputs must be a torch.Tensor.")
+        expected_shape = (1, self.sequence_length)
+        if inputs.ndim != 3 or inputs.shape[1:] != expected_shape:
+            raise ValueError(
+                "NILMMoENetwork expects input shape "
+                f"(batch, 1, {self.sequence_length}); got {tuple(inputs.shape)}."
+            )
+        if not torch.is_floating_point(inputs) or torch.is_complex(inputs):
+            raise TypeError("NILMMoENetwork inputs must be real floating tensors.")
+        device = self.gate.input_layer.weight.device
+        if inputs.device != device:
+            raise ValueError(
+                f"NILMMoENetwork input is on {inputs.device}; model is on {device}."
+            )
+        if not torch.isfinite(inputs).all():
+            raise ValueError("NILMMoENetwork inputs must be finite.")
+
+    def training_outputs(self, inputs):
+        """Return the mixture, individual predictions, and routing weights."""
+        self._validate_inputs(inputs)
+        inputs = inputs.to(dtype=self.gate.input_layer.weight.dtype)
+        predictions = torch.stack(
+            tuple(expert(inputs) for expert in self.experts.values()), dim=-1
+        )
+        weights = self.gate(inputs)
+        mixture = torch.sum(predictions * weights.unsqueeze(1), dim=-1)
+        if not torch.isfinite(mixture).all():
+            raise RuntimeError("NILMMoENetwork produced non-finite output.")
+        return mixture, predictions, weights
+
+    def forward(self, inputs):
+        mixture, _, _ = self.training_outputs(inputs)
+        return mixture
+
+
+class NILMMoE(SequenceToPointTorchDisaggregator):
+    """End-to-end trainable mixture of complementary NILM experts."""
+
+    MODEL_NAME = "NILMMoE"
+    CHECKPOINT_PREFIX = "nilmmoe"
+    MODEL_CONFIG_FIELDS = (
+        "moving_average",
+        "gate_hidden_dim",
+        "gate_dropout",
+        "gate_temperature",
+        "expert_dropout",
+        "load_balance_weight",
+        "learning_rate",
+        "weight_decay",
+        "validation_fraction",
+        "validation_strategy",
+        "gradient_clip_norm",
+    )
+
+    def __init__(self, params=None):
+        if params is None:
+            params = {}
+        if isinstance(params, Mapping):
+            params = dict(params)
+            params.setdefault("weight_decay", 1e-4)
+        super().__init__(
+            params, defaults=torch_defaults(sequence_length=299, batch_size=128)
+        )
+        self.moving_average = validate_positive_int(
+            "moving_average", get_param(params, "moving_average", 25)
+        )
+        self.gate_hidden_dim = validate_positive_int(
+            "gate_hidden_dim", get_param(params, "gate_hidden_dim", 32)
+        )
+        self.gate_dropout = finite_number(
+            "gate_dropout", get_param(params, "gate_dropout", 0.1), minimum=0
+        )
+        self.gate_temperature = finite_number(
+            "gate_temperature",
+            get_param(params, "gate_temperature", 1.0),
+            minimum=0,
+            strict=True,
+        )
+        self.expert_dropout = finite_number(
+            "expert_dropout", get_param(params, "expert_dropout", 0.1), minimum=0
+        )
+        self.load_balance_weight = finite_number(
+            "load_balance_weight",
+            get_param(params, "load_balance_weight", 0.01),
+            minimum=0,
+        )
+        self._validate_architecture()
+        if self.load_model_path:
+            self.load_model()
+
+    def _validate_architecture(self):
+        if self.sequence_length < 25:
+            raise ValueError("sequence_length must be at least 25.")
+        if self.moving_average % 2 == 0:
+            raise ValueError("moving_average must be odd.")
+        if self.moving_average > self.sequence_length:
+            raise ValueError("moving_average must not exceed sequence_length.")
+        for name in ("gate_dropout", "expert_dropout"):
+            if getattr(self, name) >= 1:
+                raise ValueError(f"{name} must be less than 1.")
+
+    def training_loss(self, network, batch_inputs, batch_targets, appliance_name):
+        if not isinstance(network, NILMMoENetwork):
+            raise TypeError("NILMMoE requires an NILMMoENetwork for every appliance.")
+        inputs = batch_inputs.to(self.device).unsqueeze(1)
+        prediction, expert_predictions, weights = network.training_outputs(inputs)
+        self._checked_model_output(prediction, len(batch_inputs), appliance_name)
+        for expert_prediction in expert_predictions.unbind(dim=-1):
+            self._checked_model_output(
+                expert_prediction, len(batch_inputs), appliance_name
+            )
+        target = batch_targets.to(self.device, dtype=prediction.dtype)
+        prediction_loss = nn.functional.mse_loss(prediction, target)
+        mean_routing = weights.mean(dim=0)
+        balance_loss = len(EXPERT_NAMES) * mean_routing.square().sum() - 1
+        return prediction_loss + self.load_balance_weight * balance_loss
+
+    def return_network(self):
+        return NILMMoENetwork(
+            sequence_length=self.sequence_length,
+            moving_average=self.moving_average,
+            gate_hidden_dim=self.gate_hidden_dim,
+            gate_dropout=self.gate_dropout,
+            gate_temperature=self.gate_temperature,
+            expert_dropout=self.expert_dropout,
+        ).to(self.device)
+
+
+__all__ = [
+    "EXPERT_NAMES",
+    "GATE_FEATURES",
+    "NILMMoE",
+    "NILMMoEGate",
+    "NILMMoENetwork",
+]

--- a/tests/model_smoke_helpers.py
+++ b/tests/model_smoke_helpers.py
@@ -46,6 +46,7 @@ TORCH_MODEL_SPECS = (
     ModelSpec("torch", "nilmtk_contrib.torch", "MSDC", "nilmtk_contrib.torch.msdc_without_crf", min_sequence_length=121),
     ModelSpec("torch", "nilmtk_contrib.torch", "ModernTCN", "nilmtk_contrib.torch.moderntcn"),
     ModelSpec("torch", "nilmtk_contrib.torch", "NILMFormer", "nilmtk_contrib.torch.nilmformer"),
+    ModelSpec("torch", "nilmtk_contrib.torch", "NILMMoE", "nilmtk_contrib.torch.nilmmoe"),
     ModelSpec("torch", "nilmtk_contrib.torch", "PatchTST", "nilmtk_contrib.torch.patchtst"),
     ModelSpec("torch", "nilmtk_contrib.torch", "Reformer", "nilmtk_contrib.torch.reformer"),
     ModelSpec("torch", "nilmtk_contrib.torch", "ResNet", "nilmtk_contrib.torch.resnet"),

--- a/tests/test_nilmmoe.py
+++ b/tests/test_nilmmoe.py
@@ -1,0 +1,358 @@
+import inspect
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+torch = pytest.importorskip("torch")
+metadata_module = pytest.importorskip("nilmtk_contrib.metadata")
+engine_module = pytest.importorskip("nilmtk_contrib.torch._seq2point")
+nilmmoe_module = pytest.importorskip("nilmtk_contrib.torch.nilmmoe")
+model_catalog_by_module = metadata_module.model_catalog_by_module
+SequenceToPointTorchDisaggregator = engine_module.SequenceToPointTorchDisaggregator
+EXPERT_NAMES = nilmmoe_module.EXPERT_NAMES
+GATE_FEATURES = nilmmoe_module.GATE_FEATURES
+NILMMoE = nilmmoe_module.NILMMoE
+NILMMoEGate = nilmmoe_module.NILMMoEGate
+NILMMoENetwork = nilmmoe_module.NILMMoENetwork
+
+
+def _params(**overrides):
+    return {
+        "device": "cpu",
+        "sequence_length": 25,
+        "n_epochs": 1,
+        "batch_size": 5,
+        "seed": 17,
+        "mains_mean": 100.0,
+        "mains_std": 40.0,
+        "moving_average": 25,
+        "gate_hidden_dim": 8,
+        "gate_dropout": 0.0,
+        "gate_temperature": 1.0,
+        "expert_dropout": 0.0,
+        "load_balance_weight": 0.01,
+    } | overrides
+
+
+def _chunks(length=50):
+    values = np.arange(length, dtype=np.float32)
+    index = pd.date_range("2026-01-01", periods=length, freq="1min", tz="UTC")
+    appliance = 25.0 + 30.0 * ((values // 4) % 2)
+    mains = 70.0 + appliance + 3.0 * np.sin(values / 2)
+    return (
+        [pd.DataFrame({"power": mains}, index=index)],
+        [("fridge", [pd.DataFrame({"power": appliance}, index=index)])],
+    )
+
+
+def test_nilmmoe_is_an_architecture_only_engine_consumer():
+    source = Path(inspect.getfile(NILMMoE)).read_text()
+
+    assert issubclass(NILMMoE, SequenceToPointTorchDisaggregator)
+    assert len(source.splitlines()) < 300
+    for method in ("partial_fit", "disaggregate_chunk", "save_model", "load_model"):
+        assert f"def {method}(" not in source
+
+
+def test_experts_are_complementary_reviewed_networks_in_stable_order():
+    from nilmtk_contrib.torch.dlinear import DLinearNetwork
+    from nilmtk_contrib.torch.moderntcn import ModernTCNNetwork
+    from nilmtk_contrib.torch.timesnet import TimesNetNetwork
+
+    network = NILMMoE(_params()).return_network()
+
+    assert tuple(network.experts) == EXPERT_NAMES == (
+        "DLinear",
+        "ModernTCN",
+        "TimesNet",
+    )
+    assert isinstance(network.experts["DLinear"], DLinearNetwork)
+    assert isinstance(network.experts["ModernTCN"], ModernTCNNetwork)
+    assert isinstance(network.experts["TimesNet"], TimesNetNetwork)
+
+
+def test_gate_summary_features_are_explicit_and_numerically_correct():
+    gate = NILMMoEGate(25, hidden_dim=4, dropout=0.0)
+    inputs = torch.arange(25, dtype=torch.float32).reshape(1, 1, 25)
+
+    features = gate.summary_features(inputs)
+
+    assert GATE_FEATURES == (
+        "center",
+        "mean",
+        "standard_deviation",
+        "minimum",
+        "maximum",
+        "mean_absolute_difference",
+        "end_to_start_change",
+    )
+    assert features.shape == (1, len(GATE_FEATURES))
+    assert features[0, 0].item() == 12.0
+    assert features[0, 1].item() == 12.0
+    assert features[0, 2].item() == pytest.approx(np.std(np.arange(25)))
+    assert features[0, 3:].tolist() == pytest.approx([0.0, 24.0, 1.0, 24.0])
+
+
+def test_gate_weights_are_finite_positive_and_sum_to_one():
+    gate = NILMMoEGate(25, hidden_dim=4, dropout=0.0, temperature=0.5)
+
+    weights = gate(torch.randn(6, 1, 25))
+
+    assert weights.shape == (6, len(EXPERT_NAMES))
+    assert torch.isfinite(weights).all()
+    assert (weights > 0).all()
+    assert torch.allclose(weights.sum(dim=1), torch.ones(6))
+
+
+def test_forced_gate_selects_the_requested_expert():
+    network = NILMMoE(_params()).return_network().eval()
+    inputs = torch.randn(4, 1, 25)
+    with torch.no_grad():
+        network.gate.output_layer.weight.zero_()
+        network.gate.output_layer.bias.copy_(torch.tensor([-30.0, 30.0, -30.0]))
+
+    mixture, predictions, weights = network.training_outputs(inputs)
+
+    assert torch.all(weights.argmax(dim=1) == 1)
+    assert torch.allclose(mixture, predictions[:, :, 1], atol=1e-6)
+
+
+def test_mixture_is_inside_the_expert_convex_hull():
+    network = NILMMoE(_params()).return_network().eval()
+
+    mixture, predictions, _ = network.training_outputs(torch.randn(5, 1, 25))
+
+    assert torch.all(mixture >= predictions.amin(dim=-1) - 1e-6)
+    assert torch.all(mixture <= predictions.amax(dim=-1) + 1e-6)
+
+
+def test_training_objective_adds_exact_load_balance_penalty():
+    model = NILMMoE(_params(load_balance_weight=2.0))
+    network = model.return_network().eval()
+    inputs = torch.randn(5, 25)
+    targets = torch.randn(5, 1)
+    prediction, _, weights = network.training_outputs(inputs.unsqueeze(1))
+    expected = torch.nn.functional.mse_loss(prediction, targets)
+    expected = expected + 2.0 * (
+        len(EXPERT_NAMES) * weights.mean(dim=0).square().sum() - 1
+    )
+
+    actual = model.training_loss(network, inputs, targets, "fridge")
+
+    assert torch.allclose(actual, expected)
+
+
+def test_training_objective_backpropagates_through_gate_and_every_expert():
+    model = NILMMoE(_params())
+    network = model.return_network()
+
+    loss = model.training_loss(
+        network, torch.randn(5, 25), torch.randn(5, 1), "fridge"
+    )
+    loss.backward()
+
+    assert all(
+        parameter.grad is not None and torch.isfinite(parameter.grad).all()
+        for parameter in network.parameters()
+    )
+
+
+@pytest.mark.parametrize(
+    ("params", "message"),
+    [
+        ({"sequence_length": 23}, "at least 25"),
+        ({"moving_average": 24}, "odd"),
+        ({"moving_average": 27}, "must not exceed"),
+        ({"gate_hidden_dim": True}, "positive integer"),
+        ({"gate_dropout": 1.0}, "less than 1"),
+        ({"gate_temperature": 0.0}, "greater than"),
+        ({"expert_dropout": float("nan")}, "finite"),
+        ({"expert_dropout": 1.0}, "less than 1"),
+        ({"load_balance_weight": -0.1}, "at least"),
+        ({"weight_decay": -1.0}, "at least"),
+    ],
+)
+def test_invalid_configuration_fails_at_construction(params, message):
+    with pytest.raises(ValueError, match=message):
+        NILMMoE(_params(**params))
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"sequence_length": 0},
+        {"sequence_length": 23},
+        {"sequence_length": 24},
+        {"sequence_length": 25, "moving_average": 24},
+        {"sequence_length": 25, "moving_average": 27},
+        {"sequence_length": 25, "gate_hidden_dim": True},
+        {"sequence_length": 25, "gate_dropout": 1.0},
+        {"sequence_length": 25, "gate_temperature": 0.0},
+        {"sequence_length": 25, "expert_dropout": 1.0},
+    ],
+)
+def test_network_constructor_enforces_its_public_contract(params):
+    with pytest.raises(ValueError):
+        NILMMoENetwork(**params)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"sequence_length": 0},
+        {"sequence_length": 25, "hidden_dim": True},
+        {"sequence_length": 25, "dropout": 1.0},
+        {"sequence_length": 25, "temperature": float("nan")},
+        {"sequence_length": 25, "temperature": 0.0},
+    ],
+)
+def test_gate_constructor_enforces_its_public_contract(params):
+    with pytest.raises(ValueError):
+        NILMMoEGate(**params)
+
+
+@pytest.mark.parametrize(
+    "inputs",
+    [
+        object(),
+        torch.ones(2, 25),
+        torch.ones(2, 1, 24),
+        torch.ones(2, 1, 25, dtype=torch.int64),
+        torch.full((2, 1, 25), float("inf")),
+    ],
+)
+def test_gate_rejects_invalid_inputs(inputs):
+    gate = NILMMoEGate(25)
+
+    with pytest.raises((TypeError, ValueError)):
+        gate(inputs)
+
+
+def test_gate_rejects_an_input_on_a_different_device():
+    gate = NILMMoEGate(25).to("meta")
+
+    with pytest.raises(ValueError, match="input is on cpu; model is on meta"):
+        gate(torch.ones(1, 1, 25))
+
+
+@pytest.mark.parametrize(
+    "inputs",
+    [
+        object(),
+        torch.ones(2, 25),
+        torch.ones(2, 1, 24),
+        torch.ones(2, 1, 25, dtype=torch.int64),
+        torch.full((2, 1, 25), float("nan")),
+    ],
+)
+def test_network_rejects_invalid_inputs(inputs):
+    network = NILMMoE(_params()).return_network()
+
+    with pytest.raises((TypeError, ValueError)):
+        network(inputs)
+
+
+def test_network_rejects_an_input_on_a_different_device():
+    network = NILMMoE(_params()).return_network().to("meta")
+
+    with pytest.raises(ValueError, match="input is on cpu; model is on meta"):
+        network(torch.ones(1, 1, 25))
+
+
+def test_gate_rejects_non_finite_internal_weights():
+    network = NILMMoE(_params()).return_network()
+    with torch.no_grad():
+        network.gate.output_layer.weight.fill_(float("inf"))
+
+    with pytest.raises(RuntimeError, match="gate produced non-finite"):
+        network(torch.ones(1, 1, 25))
+
+
+def test_network_rejects_non_finite_expert_mixture():
+    class NonFiniteExpert(torch.nn.Module):
+        def forward(self, inputs):
+            return inputs.new_full((len(inputs), 1), float("inf"))
+
+    network = NILMMoE(_params()).return_network()
+    network.experts["DLinear"] = NonFiniteExpert()
+
+    with pytest.raises(RuntimeError, match="produced non-finite output"):
+        network(torch.ones(1, 1, 25))
+
+
+def test_training_loss_rejects_the_wrong_network_type():
+    model = NILMMoE(_params())
+
+    with pytest.raises(TypeError, match="NILMMoENetwork"):
+        model.training_loss(torch.nn.Linear(25, 1), None, None, "fridge")
+
+
+def test_one_epoch_train_infer_smoke_preserves_every_row():
+    mains, targets = _chunks()
+    model = NILMMoE(_params(appliance_params={}))
+
+    model.partial_fit(mains, targets)
+    result = model.disaggregate_chunk(mains)[0]
+
+    assert result.index.equals(mains[0].index)
+    assert result.columns.tolist() == ["fridge"]
+    assert result["fridge"].dtype == np.float32
+    assert np.isfinite(result["fridge"]).all()
+
+
+def test_checkpoint_roundtrip_restores_gate_configuration_and_predictions(tmp_path):
+    mains, targets = _chunks()
+    model = NILMMoE(
+        _params(
+            appliance_params={},
+            save_model_path=str(tmp_path),
+            gate_hidden_dim=6,
+            gate_temperature=0.75,
+        )
+    )
+    model.partial_fit(mains, targets)
+    expected = model.disaggregate_chunk(mains)[0]
+
+    loaded = NILMMoE(
+        _params(
+            appliance_params={},
+            pretrained_model_path=str(tmp_path),
+            gate_hidden_dim=4,
+            gate_temperature=1.0,
+        )
+    )
+    actual = loaded.disaggregate_chunk(mains)[0]
+
+    assert loaded.gate_hidden_dim == 6
+    assert loaded.gate_temperature == pytest.approx(0.75)
+    assert np.allclose(actual, expected)
+
+
+def test_public_export_catalog_defaults_and_parameter_count_are_stable():
+    import nilmtk_contrib.torch as torch_models
+
+    default = NILMMoE({"device": "cpu"})
+    network = default.return_network()
+    entry = model_catalog_by_module()["nilmtk_contrib.torch.nilmmoe"]
+
+    assert torch_models.NILMMoE is NILMMoE
+    assert default.sequence_length == 299
+    assert default.batch_size == 128
+    assert default.moving_average == 25
+    assert default.gate_hidden_dim == 32
+    assert default.gate_temperature == pytest.approx(1.0)
+    assert default.load_balance_weight == pytest.approx(0.01)
+    assert default.weight_decay == pytest.approx(1e-4)
+    assert sum(parameter.numel() for parameter in network.parameters()) == 330493
+    assert entry.class_name == "NILMMoE"
+    assert entry.exported_from == "nilmtk_contrib.torch"
+
+
+def test_none_uses_documented_defaults():
+    model = NILMMoE()
+
+    assert model.sequence_length == 299
+    assert model.gate_hidden_dim == 32

--- a/tests/test_torch_migration_contract.py
+++ b/tests/test_torch_migration_contract.py
@@ -31,6 +31,7 @@ DEFAULTS_BY_MODULE = {
     "nilmtk_contrib.torch.msdc_without_crf": ExpectedDefaults(99, 50, 256, 1800, 600),
     "nilmtk_contrib.torch.moderntcn": ExpectedDefaults(299, 10, 128, 1800, 600),
     "nilmtk_contrib.torch.nilmformer": ExpectedDefaults(99, 100, 1024, 1800, 600),
+    "nilmtk_contrib.torch.nilmmoe": ExpectedDefaults(299, 10, 128, 1800, 600),
     "nilmtk_contrib.torch.patchtst": ExpectedDefaults(99, 10, 128, 1800, 600),
     "nilmtk_contrib.torch.reformer": ExpectedDefaults(99, 10, 512, 1800, 600),
     "nilmtk_contrib.torch.resnet": ExpectedDefaults(299, 10, 512, 1800, 600),


### PR DESCRIPTION
## Idea

Add NILMMoE, an end-to-end input-conditioned mixture of three complementary reviewed sequence-to-point networks:

- DLinear for trend and level
- ModernTCN for local and multi-scale events
- TimesNet for periodic structure

A small gate routes every normalized mains window using seven inspectable features: center, mean, standard deviation, minimum, maximum, mean absolute difference, and end-to-start change. Softmax weights make the output a convex combination of the three expert predictions. A batch-level load-balancing penalty discourages silent gate collapse.

This is an experimental repository model, not a literature-performance claim. Any accuracy claim remains blocked until immutable NILMbench result bundles are published.

## Engineering

- reuses the shared sequence-to-point training, validation, inference, rollback, and checkpoint engine
- composes the existing reviewed network classes instead of copying them
- keeps lifecycle boilerplate out of the 298-line architecture module
- stores gate and objective settings in checksum-bound checkpoint metadata
- exposes individual expert predictions and routing weights for inspection

## Verification

- 51 dedicated tests passed with 100% coverage of nilmmoe.py
- full suite: 683 passed, 97 optional-dependency skips
- all PyTorch model smoke: 23 passed, 13 non-PyTorch skips
- focused Ruff and git diff checks passed
- wheel and sdist built successfully
- isolated installed-wheel import, catalog lookup, three-expert forward pass, and normalized routing check passed

## Robustness covered

- exact gate feature calculations and stable expert order
- positive finite weights summing to one
- forced selection of each expert and convex-hull output guarantee
- exact load-balancing objective and gradient flow through every expert and gate parameter
- invalid configs, shapes, dtypes, devices, non-finite inputs, routing weights, and expert mixtures
- one-epoch row-preserving NILMTK train/infer smoke
- checkpoint round-trip restores gate configuration and predictions
- public export, model catalog, shared-runtime defaults, and frozen parameter count