### PR TITLE
Add conservative ResidualMoE

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ The table below lists the public model surface. "Verification" describes how the
 | NILMFormer | PyTorch | `nilmtk_contrib.torch.NILMFormer` | NILMFormer implementation requiring experiment validation for new claims | Petralia et al., NILMFormer | PyTorch backend |
 | NILMMoE | PyTorch | `nilmtk_contrib.torch.NILMMoE` | Experimental input-conditioned mixture; benchmark claims require NILMbench result bundles | This repository | Blends DLinear, ModernTCN, and TimesNet with a load-balanced softmax gate |
 | PatchTST | PyTorch | `nilmtk_contrib.torch.PatchTST` | PatchTST-inspired sequence-to-point adaptation; benchmark claims require NILMbench result bundles | Nie et al., PatchTST | PyTorch backend |
+| ResidualMoE | PyTorch | `nilmtk_contrib.torch.ResidualMoE` | Experimental conservative residual mixture; benchmark claims require NILMbench result bundles | This repository | Starts exactly at TimesNet and learns a bounded signed correction from PatchTST and ModernTCN |
 
 ## Reference Papers And Codebases
 

--- a/nilmtk_contrib/metadata.py
+++ b/nilmtk_contrib/metadata.py
@@ -37,6 +37,7 @@ MODEL_CATALOG = (
     ModelCatalogEntry("NILMMoE", "torch", "nilmtk_contrib.torch.nilmmoe", "NILMMoE", "nilmtk_contrib.torch"),
     ModelCatalogEntry("PatchTST", "torch", "nilmtk_contrib.torch.patchtst", "PatchTST", "nilmtk_contrib.torch"),
     ModelCatalogEntry("Reformer", "torch", "nilmtk_contrib.torch.reformer", "Reformer", "nilmtk_contrib.torch"),
+    ModelCatalogEntry("ResidualMoE", "torch", "nilmtk_contrib.torch.residual_moe", "ResidualMoE", "nilmtk_contrib.torch"),
     ModelCatalogEntry("ResNet", "torch", "nilmtk_contrib.torch.resnet", "ResNet", "nilmtk_contrib.torch"),
     ModelCatalogEntry("ResNet_classification", "torch", "nilmtk_contrib.torch.resnet_classification", "ResNet_classification", "nilmtk_contrib.torch"),
     ModelCatalogEntry("RNN", "torch", "nilmtk_contrib.torch.rnn", "RNN", "nilmtk_contrib.torch"),

--- a/nilmtk_contrib/torch/__init__.py
+++ b/nilmtk_contrib/torch/__init__.py
@@ -15,6 +15,7 @@ _EXPORTS = {
     "NILMMoE": ("nilmtk_contrib.torch.nilmmoe", "NILMMoE"),
     "PatchTST": ("nilmtk_contrib.torch.patchtst", "PatchTST"),
     "Reformer": ("nilmtk_contrib.torch.reformer", "Reformer"),
+    "ResidualMoE": ("nilmtk_contrib.torch.residual_moe", "ResidualMoE"),
     "ResNet": ("nilmtk_contrib.torch.resnet", "ResNet"),
     "ResNet_classification": (
         "nilmtk_contrib.torch.resnet_classification",

--- a/nilmtk_contrib/torch/_window_features.py
+++ b/nilmtk_contrib/torch/_window_features.py
@@ -1,0 +1,52 @@
+"""Shared, inspectable features for routing normalized NILM windows."""
+
+import torch
+
+
+WINDOW_FEATURE_NAMES = (
+    "center",
+    "mean",
+    "standard_deviation",
+    "minimum",
+    "maximum",
+    "mean_absolute_difference",
+    "end_to_start_change",
+)
+
+
+def window_summary_features(inputs, *, sequence_length, reference, owner):
+    """Validate one-channel windows and return seven summary features."""
+    if not isinstance(inputs, torch.Tensor):
+        raise TypeError(f"{owner} inputs must be a torch.Tensor.")
+    expected_shape = (1, sequence_length)
+    if inputs.ndim != 3 or inputs.shape[1:] != expected_shape:
+        raise ValueError(
+            f"{owner} expects input shape "
+            f"(batch, 1, {sequence_length}); got {tuple(inputs.shape)}."
+        )
+    if not torch.is_floating_point(inputs) or torch.is_complex(inputs):
+        raise TypeError(f"{owner} inputs must be real floating tensors.")
+    if inputs.device != reference.device:
+        raise ValueError(
+            f"{owner} input is on {inputs.device}; model is on {reference.device}."
+        )
+    if not torch.isfinite(inputs).all():
+        raise ValueError(f"{owner} inputs must be finite.")
+
+    inputs = inputs.to(dtype=reference.dtype)
+    differences = inputs.diff(dim=-1)
+    return torch.cat(
+        (
+            inputs[:, :, sequence_length // 2],
+            inputs.mean(dim=-1),
+            inputs.std(dim=-1, unbiased=False),
+            inputs.amin(dim=-1),
+            inputs.amax(dim=-1),
+            differences.abs().mean(dim=-1),
+            inputs[:, :, -1] - inputs[:, :, 0],
+        ),
+        dim=1,
+    )
+
+
+__all__ = ["WINDOW_FEATURE_NAMES", "window_summary_features"]

--- a/nilmtk_contrib/torch/nilmmoe.py
+++ b/nilmtk_contrib/torch/nilmmoe.py
@@ -10,6 +10,10 @@ from nilmtk_contrib.torch._seq2point import (
     SequenceToPointTorchDisaggregator,
     finite_number,
 )
+from nilmtk_contrib.torch._window_features import (
+    WINDOW_FEATURE_NAMES,
+    window_summary_features,
+)
 from nilmtk_contrib.torch.dlinear import DLinearNetwork
 from nilmtk_contrib.torch.moderntcn import ModernTCNNetwork
 from nilmtk_contrib.torch.timesnet import TimesNetNetwork
@@ -17,15 +21,7 @@ from nilmtk_contrib.utils.params import get_param, validate_positive_int
 
 
 EXPERT_NAMES = ("DLinear", "ModernTCN", "TimesNet")
-GATE_FEATURES = (
-    "center",
-    "mean",
-    "standard_deviation",
-    "minimum",
-    "maximum",
-    "mean_absolute_difference",
-    "end_to_start_change",
-)
+GATE_FEATURES = WINDOW_FEATURE_NAMES
 
 
 class NILMMoEGate(nn.Module):
@@ -60,43 +56,11 @@ class NILMMoEGate(nn.Module):
 
     def summary_features(self, inputs):
         """Return the seven normalized features used by the routing gate."""
-        if not isinstance(inputs, torch.Tensor):
-            raise TypeError("NILMMoEGate inputs must be a torch.Tensor.")
-        expected_shape = (1, self.sequence_length)
-        if inputs.ndim != 3 or inputs.shape[1:] != expected_shape:
-            raise ValueError(
-                "NILMMoEGate expects input shape "
-                f"(batch, 1, {self.sequence_length}); got {tuple(inputs.shape)}."
-            )
-        if not torch.is_floating_point(inputs) or torch.is_complex(inputs):
-            raise TypeError("NILMMoEGate inputs must be real floating tensors.")
-        device = self.input_layer.weight.device
-        if inputs.device != device:
-            raise ValueError(
-                f"NILMMoEGate input is on {inputs.device}; model is on {device}."
-            )
-        if not torch.isfinite(inputs).all():
-            raise ValueError("NILMMoEGate inputs must be finite.")
-        inputs = inputs.to(dtype=self.input_layer.weight.dtype)
-        center = inputs[:, :, self.sequence_length // 2]
-        mean = inputs.mean(dim=-1)
-        standard_deviation = inputs.std(dim=-1, unbiased=False)
-        minimum = inputs.amin(dim=-1)
-        maximum = inputs.amax(dim=-1)
-        differences = inputs.diff(dim=-1)
-        mean_absolute_difference = differences.abs().mean(dim=-1)
-        end_to_start_change = inputs[:, :, -1] - inputs[:, :, 0]
-        return torch.cat(
-            (
-                center,
-                mean,
-                standard_deviation,
-                minimum,
-                maximum,
-                mean_absolute_difference,
-                end_to_start_change,
-            ),
-            dim=1,
+        return window_summary_features(
+            inputs,
+            sequence_length=self.sequence_length,
+            reference=self.input_layer.weight,
+            owner="NILMMoEGate",
         )
 
     def forward(self, inputs):

--- a/nilmtk_contrib/torch/residual_moe.py
+++ b/nilmtk_contrib/torch/residual_moe.py
@@ -1,0 +1,268 @@
+"""Conservative residual mixture of strong NILM sequence-to-point experts."""
+
+from collections.abc import Mapping
+from typing import NamedTuple
+
+import torch
+from torch import nn
+
+from nilmtk_contrib.torch._base import torch_defaults
+from nilmtk_contrib.torch._seq2point import (
+    SequenceToPointTorchDisaggregator,
+    finite_number,
+)
+from nilmtk_contrib.torch._window_features import (
+    WINDOW_FEATURE_NAMES,
+    window_summary_features,
+)
+from nilmtk_contrib.torch.moderntcn import ModernTCNNetwork
+from nilmtk_contrib.torch.patchtst import PatchTSTNetwork
+from nilmtk_contrib.torch.timesnet import TimesNetNetwork
+from nilmtk_contrib.utils.params import get_param, validate_positive_int
+
+
+ANCHOR_NAME = "TimesNet"
+SPECIALIST_NAMES = ("PatchTST", "ModernTCN")
+
+
+class ResidualMoEOutputs(NamedTuple):
+    """Inspectable predictions and routing decisions from ``ResidualMoENetwork``."""
+
+    prediction: torch.Tensor
+    anchor_prediction: torch.Tensor
+    specialist_predictions: torch.Tensor
+    specialist_weights: torch.Tensor
+    correction_amplitude: torch.Tensor
+
+
+class ResidualRouter(nn.Module):
+    """Choose a specialist residual and its bounded signed amplitude."""
+
+    def __init__(
+        self,
+        sequence_length,
+        hidden_dim=32,
+        dropout=0.1,
+        residual_limit=0.25,
+    ):
+        super().__init__()
+        self.sequence_length = validate_positive_int(
+            "sequence_length", sequence_length
+        )
+        if self.sequence_length < 2:
+            raise ValueError("sequence_length must be at least 2.")
+        hidden_dim = validate_positive_int("hidden_dim", hidden_dim)
+        dropout = finite_number("dropout", dropout, minimum=0)
+        if dropout >= 1:
+            raise ValueError("dropout must be less than 1.")
+        self.residual_limit = finite_number(
+            "residual_limit", residual_limit, minimum=0, strict=True
+        )
+        if self.residual_limit > 1:
+            raise ValueError("residual_limit must not exceed 1.")
+
+        self.input_layer = nn.Linear(len(WINDOW_FEATURE_NAMES), hidden_dim)
+        self.activation = nn.GELU()
+        self.dropout = nn.Dropout(dropout)
+        self.weight_layer = nn.Linear(hidden_dim, len(SPECIALIST_NAMES))
+        self.amplitude_layer = nn.Linear(hidden_dim, 1)
+        nn.init.xavier_uniform_(self.input_layer.weight)
+        nn.init.zeros_(self.input_layer.bias)
+        nn.init.xavier_uniform_(self.weight_layer.weight)
+        nn.init.zeros_(self.weight_layer.bias)
+        nn.init.zeros_(self.amplitude_layer.weight)
+        nn.init.zeros_(self.amplitude_layer.bias)
+
+    def summary_features(self, inputs):
+        """Return the normalized window features used by the router."""
+        return window_summary_features(
+            inputs,
+            sequence_length=self.sequence_length,
+            reference=self.input_layer.weight,
+            owner="ResidualRouter",
+        )
+
+    def forward(self, inputs):
+        hidden = self.dropout(self.activation(self.input_layer(self.summary_features(inputs))))
+        weights = torch.softmax(self.weight_layer(hidden), dim=1)
+        amplitude = self.residual_limit * torch.tanh(self.amplitude_layer(hidden))
+        if not torch.isfinite(weights).all() or not torch.isfinite(amplitude).all():
+            raise RuntimeError("ResidualMoE router produced non-finite outputs.")
+        return weights, amplitude
+
+
+class ResidualMoENetwork(nn.Module):
+    """Start from TimesNet and apply a bounded, input-conditioned correction."""
+
+    def __init__(
+        self,
+        sequence_length,
+        gate_hidden_dim=32,
+        gate_dropout=0.1,
+        residual_limit=0.25,
+        expert_dropout=0.1,
+    ):
+        super().__init__()
+        self.sequence_length = validate_positive_int(
+            "sequence_length", sequence_length
+        )
+        if self.sequence_length % 2 == 0:
+            raise ValueError("sequence_length must be odd.")
+        if self.sequence_length < 25:
+            raise ValueError("sequence_length must be at least 25.")
+        expert_dropout = finite_number("expert_dropout", expert_dropout, minimum=0)
+        if expert_dropout >= 1:
+            raise ValueError("expert_dropout must be less than 1.")
+
+        self.anchor = TimesNetNetwork(
+            self.sequence_length,
+            dropout=expert_dropout,
+        )
+        self.specialists = nn.ModuleDict(
+            {
+                "PatchTST": PatchTSTNetwork(
+                    self.sequence_length,
+                    dropout=expert_dropout,
+                ),
+                "ModernTCN": ModernTCNNetwork(
+                    self.sequence_length,
+                    dropout=expert_dropout,
+                ),
+            }
+        )
+        self.router = ResidualRouter(
+            self.sequence_length,
+            hidden_dim=gate_hidden_dim,
+            dropout=gate_dropout,
+            residual_limit=residual_limit,
+        )
+
+    def training_outputs(self, inputs):
+        """Return the prediction, experts, and complete routing decision."""
+        weights, amplitude = self.router(inputs)
+        anchor_prediction = self.anchor(inputs)
+        specialist_predictions = torch.stack(
+            tuple(specialist(inputs) for specialist in self.specialists.values()),
+            dim=-1,
+        )
+        specialist_residuals = specialist_predictions - anchor_prediction.unsqueeze(-1)
+        selected_residual = torch.sum(
+            specialist_residuals * weights.unsqueeze(1), dim=-1
+        )
+        prediction = anchor_prediction + amplitude * selected_residual
+        outputs = ResidualMoEOutputs(
+            prediction,
+            anchor_prediction,
+            specialist_predictions,
+            weights,
+            amplitude,
+        )
+        if not all(torch.isfinite(output).all() for output in outputs):
+            raise RuntimeError("ResidualMoENetwork produced non-finite outputs.")
+        return outputs
+
+    def forward(self, inputs):
+        return self.training_outputs(inputs).prediction
+
+
+class ResidualMoE(SequenceToPointTorchDisaggregator):
+    """TimesNet anchored residual mixture with independently trained specialists."""
+
+    MODEL_NAME = "ResidualMoE"
+    CHECKPOINT_PREFIX = "residual-moe"
+    MODEL_CONFIG_FIELDS = (
+        "gate_hidden_dim",
+        "gate_dropout",
+        "residual_limit",
+        "expert_dropout",
+        "auxiliary_weight",
+        "learning_rate",
+        "weight_decay",
+        "validation_fraction",
+        "validation_strategy",
+        "gradient_clip_norm",
+    )
+
+    def __init__(self, params=None):
+        if params is None:
+            params = {}
+        if isinstance(params, Mapping):
+            params = dict(params)
+            params.setdefault("weight_decay", 1e-4)
+        super().__init__(
+            params, defaults=torch_defaults(sequence_length=299, batch_size=128)
+        )
+        self.gate_hidden_dim = validate_positive_int(
+            "gate_hidden_dim", get_param(params, "gate_hidden_dim", 32)
+        )
+        self.gate_dropout = finite_number(
+            "gate_dropout", get_param(params, "gate_dropout", 0.1), minimum=0
+        )
+        self.residual_limit = finite_number(
+            "residual_limit",
+            get_param(params, "residual_limit", 0.25),
+            minimum=0,
+            strict=True,
+        )
+        self.expert_dropout = finite_number(
+            "expert_dropout", get_param(params, "expert_dropout", 0.1), minimum=0
+        )
+        self.auxiliary_weight = finite_number(
+            "auxiliary_weight",
+            get_param(params, "auxiliary_weight", 0.1),
+            minimum=0,
+        )
+        self._validate_architecture()
+        if self.load_model_path:
+            self.load_model()
+
+    def _validate_architecture(self):
+        if self.sequence_length < 25:
+            raise ValueError("sequence_length must be at least 25.")
+        for name in ("gate_dropout", "expert_dropout"):
+            if getattr(self, name) >= 1:
+                raise ValueError(f"{name} must be less than 1.")
+        if self.residual_limit > 1:
+            raise ValueError("residual_limit must not exceed 1.")
+
+    def training_loss(self, network, batch_inputs, batch_targets, appliance_name):
+        if not isinstance(network, ResidualMoENetwork):
+            raise TypeError(
+                "ResidualMoE requires a ResidualMoENetwork for every appliance."
+            )
+        inputs = batch_inputs.to(self.device).unsqueeze(1)
+        outputs = network.training_outputs(inputs)
+        for output in (
+            outputs.prediction,
+            outputs.anchor_prediction,
+            *outputs.specialist_predictions.unbind(dim=-1),
+        ):
+            self._checked_model_output(output, len(batch_inputs), appliance_name)
+        target = batch_targets.to(self.device, dtype=outputs.prediction.dtype)
+        prediction_loss = nn.functional.mse_loss(outputs.prediction, target)
+        specialist_loss = torch.stack(
+            tuple(
+                nn.functional.mse_loss(prediction, target)
+                for prediction in outputs.specialist_predictions.unbind(dim=-1)
+            )
+        ).mean()
+        return prediction_loss + self.auxiliary_weight * specialist_loss
+
+    def return_network(self):
+        return ResidualMoENetwork(
+            sequence_length=self.sequence_length,
+            gate_hidden_dim=self.gate_hidden_dim,
+            gate_dropout=self.gate_dropout,
+            residual_limit=self.residual_limit,
+            expert_dropout=self.expert_dropout,
+        ).to(self.device)
+
+
+__all__ = [
+    "ANCHOR_NAME",
+    "SPECIALIST_NAMES",
+    "ResidualMoE",
+    "ResidualMoENetwork",
+    "ResidualMoEOutputs",
+    "ResidualRouter",
+]

--- a/tests/model_smoke_helpers.py
+++ b/tests/model_smoke_helpers.py
@@ -49,6 +49,7 @@ TORCH_MODEL_SPECS = (
     ModelSpec("torch", "nilmtk_contrib.torch", "NILMMoE", "nilmtk_contrib.torch.nilmmoe"),
     ModelSpec("torch", "nilmtk_contrib.torch", "PatchTST", "nilmtk_contrib.torch.patchtst"),
     ModelSpec("torch", "nilmtk_contrib.torch", "Reformer", "nilmtk_contrib.torch.reformer"),
+    ModelSpec("torch", "nilmtk_contrib.torch", "ResidualMoE", "nilmtk_contrib.torch.residual_moe"),
     ModelSpec("torch", "nilmtk_contrib.torch", "ResNet", "nilmtk_contrib.torch.resnet"),
     ModelSpec("torch", "nilmtk_contrib.torch", "ResNet_classification", "nilmtk_contrib.torch.resnet_classification"),
     ModelSpec("torch", "nilmtk_contrib.torch", "RNN", "nilmtk_contrib.torch.rnn"),

--- a/tests/test_residual_moe.py
+++ b/tests/test_residual_moe.py
@@ -1,0 +1,393 @@
+import inspect
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+torch = pytest.importorskip("torch")
+metadata_module = pytest.importorskip("nilmtk_contrib.metadata")
+engine_module = pytest.importorskip("nilmtk_contrib.torch._seq2point")
+residual_module = pytest.importorskip("nilmtk_contrib.torch.residual_moe")
+model_catalog_by_module = metadata_module.model_catalog_by_module
+SequenceToPointTorchDisaggregator = engine_module.SequenceToPointTorchDisaggregator
+ANCHOR_NAME = residual_module.ANCHOR_NAME
+SPECIALIST_NAMES = residual_module.SPECIALIST_NAMES
+ResidualMoE = residual_module.ResidualMoE
+ResidualMoENetwork = residual_module.ResidualMoENetwork
+ResidualMoEOutputs = residual_module.ResidualMoEOutputs
+ResidualRouter = residual_module.ResidualRouter
+
+
+def _params(**overrides):
+    return {
+        "device": "cpu",
+        "sequence_length": 25,
+        "n_epochs": 1,
+        "batch_size": 5,
+        "seed": 17,
+        "mains_mean": 100.0,
+        "mains_std": 40.0,
+        "gate_hidden_dim": 8,
+        "gate_dropout": 0.0,
+        "residual_limit": 0.25,
+        "expert_dropout": 0.0,
+        "auxiliary_weight": 0.1,
+    } | overrides
+
+
+def _chunks(length=50):
+    values = np.arange(length, dtype=np.float32)
+    index = pd.date_range("2026-01-01", periods=length, freq="1min", tz="UTC")
+    appliance = 25.0 + 30.0 * ((values // 4) % 2)
+    mains = 70.0 + appliance + 3.0 * np.sin(values / 2)
+    return (
+        [pd.DataFrame({"power": mains}, index=index)],
+        [("fridge", [pd.DataFrame({"power": appliance}, index=index)])],
+    )
+
+
+def test_residual_moe_is_an_architecture_only_engine_consumer():
+    source = Path(inspect.getfile(ResidualMoE)).read_text()
+
+    assert issubclass(ResidualMoE, SequenceToPointTorchDisaggregator)
+    assert len(source.splitlines()) < 300
+    for method in ("partial_fit", "disaggregate_chunk", "save_model", "load_model"):
+        assert f"def {method}(" not in source
+
+
+def test_anchor_and_specialists_are_strong_reviewed_networks_in_stable_order():
+    from nilmtk_contrib.torch.moderntcn import ModernTCNNetwork
+    from nilmtk_contrib.torch.patchtst import PatchTSTNetwork
+    from nilmtk_contrib.torch.timesnet import TimesNetNetwork
+
+    network = ResidualMoE(_params()).return_network()
+
+    assert ANCHOR_NAME == "TimesNet"
+    assert SPECIALIST_NAMES == ("PatchTST", "ModernTCN")
+    assert isinstance(network.anchor, TimesNetNetwork)
+    assert tuple(network.specialists) == SPECIALIST_NAMES
+    assert isinstance(network.specialists["PatchTST"], PatchTSTNetwork)
+    assert isinstance(network.specialists["ModernTCN"], ModernTCNNetwork)
+
+
+def test_router_summary_features_are_shared_and_numerically_correct():
+    from nilmtk_contrib.torch._window_features import WINDOW_FEATURE_NAMES
+
+    router = ResidualRouter(25, hidden_dim=4, dropout=0.0)
+    inputs = torch.arange(25, dtype=torch.float32).reshape(1, 1, 25)
+
+    features = router.summary_features(inputs)
+
+    assert WINDOW_FEATURE_NAMES == (
+        "center",
+        "mean",
+        "standard_deviation",
+        "minimum",
+        "maximum",
+        "mean_absolute_difference",
+        "end_to_start_change",
+    )
+    assert features.shape == (1, len(WINDOW_FEATURE_NAMES))
+    assert features[0, 0].item() == 12.0
+    assert features[0, 1].item() == 12.0
+    assert features[0, 2].item() == pytest.approx(np.std(np.arange(25)))
+    assert features[0, 3:].tolist() == pytest.approx([0.0, 24.0, 1.0, 24.0])
+
+
+def test_training_outputs_are_inspectable_normalized_and_bounded():
+    network = ResidualMoE(_params()).return_network().eval()
+
+    outputs = network.training_outputs(torch.randn(6, 1, 25))
+
+    assert isinstance(outputs, ResidualMoEOutputs)
+    assert outputs.prediction.shape == (6, 1)
+    assert outputs.anchor_prediction.shape == (6, 1)
+    assert outputs.specialist_predictions.shape == (6, 1, 2)
+    assert outputs.specialist_weights.shape == (6, 2)
+    assert outputs.correction_amplitude.shape == (6, 1)
+    assert torch.isfinite(torch.cat(tuple(output.flatten() for output in outputs))).all()
+    assert (outputs.specialist_weights > 0).all()
+    assert torch.allclose(outputs.specialist_weights.sum(dim=1), torch.ones(6))
+    assert torch.all(outputs.correction_amplitude.abs() <= 0.25)
+
+
+def test_zero_initialized_router_starts_exactly_at_the_anchor():
+    network = ResidualMoE(_params()).return_network().eval()
+
+    outputs = network.training_outputs(torch.randn(5, 1, 25))
+
+    assert torch.equal(outputs.correction_amplitude, torch.zeros(5, 1))
+    assert torch.equal(outputs.prediction, outputs.anchor_prediction)
+
+
+def test_forced_router_applies_the_selected_signed_residual():
+    network = ResidualMoE(_params(residual_limit=0.4)).return_network().eval()
+    with torch.no_grad():
+        network.router.weight_layer.weight.zero_()
+        network.router.weight_layer.bias.copy_(torch.tensor([30.0, -30.0]))
+        network.router.amplitude_layer.weight.zero_()
+        network.router.amplitude_layer.bias.fill_(-2.0)
+
+    outputs = network.training_outputs(torch.randn(4, 1, 25))
+    selected = outputs.specialist_predictions[:, :, 0]
+    expected = outputs.anchor_prediction + outputs.correction_amplitude * (
+        selected - outputs.anchor_prediction
+    )
+
+    assert torch.all(outputs.specialist_weights.argmax(dim=1) == 0)
+    assert (outputs.correction_amplitude < 0).all()
+    assert torch.allclose(outputs.prediction, expected, atol=1e-6)
+
+
+def test_correction_cannot_exceed_the_configured_fraction_of_expert_disagreement():
+    network = ResidualMoE(_params(residual_limit=0.2)).return_network().eval()
+    with torch.no_grad():
+        network.router.amplitude_layer.bias.fill_(30.0)
+
+    outputs = network.training_outputs(torch.randn(5, 1, 25))
+    disagreements = (
+        outputs.specialist_predictions - outputs.anchor_prediction.unsqueeze(-1)
+    ).abs()
+    maximum_allowed = 0.2 * disagreements.amax(dim=-1)
+
+    assert torch.all(
+        (outputs.prediction - outputs.anchor_prediction).abs()
+        <= maximum_allowed + 1e-6
+    )
+
+
+def test_training_objective_adds_the_exact_specialist_auxiliary_loss():
+    model = ResidualMoE(_params(auxiliary_weight=2.0))
+    network = model.return_network().eval()
+    inputs = torch.randn(5, 25)
+    targets = torch.randn(5, 1)
+    outputs = network.training_outputs(inputs.unsqueeze(1))
+    expected = torch.nn.functional.mse_loss(outputs.prediction, targets)
+    expected = expected + 2.0 * torch.stack(
+        tuple(
+            torch.nn.functional.mse_loss(prediction, targets)
+            for prediction in outputs.specialist_predictions.unbind(dim=-1)
+        )
+    ).mean()
+
+    actual = model.training_loss(network, inputs, targets, "fridge")
+
+    assert torch.allclose(actual, expected)
+
+
+def test_training_objective_backpropagates_through_router_and_every_expert():
+    model = ResidualMoE(_params())
+    network = model.return_network()
+
+    loss = model.training_loss(
+        network, torch.randn(5, 25), torch.randn(5, 1), "fridge"
+    )
+    loss.backward()
+
+    assert all(
+        parameter.grad is not None and torch.isfinite(parameter.grad).all()
+        for parameter in network.parameters()
+    )
+    assert any(
+        parameter.grad.abs().sum() > 0
+        for parameter in network.specialists.parameters()
+    )
+    assert network.router.amplitude_layer.weight.grad.abs().sum() > 0
+
+
+@pytest.mark.parametrize(
+    ("params", "message"),
+    [
+        ({"sequence_length": 23}, "at least 25"),
+        ({"sequence_length": 24}, "odd"),
+        ({"gate_hidden_dim": True}, "positive integer"),
+        ({"gate_dropout": 1.0}, "less than 1"),
+        ({"residual_limit": 0.0}, "greater than"),
+        ({"residual_limit": 1.1}, "must not exceed"),
+        ({"expert_dropout": float("nan")}, "finite"),
+        ({"expert_dropout": 1.0}, "less than 1"),
+        ({"auxiliary_weight": -0.1}, "at least"),
+        ({"weight_decay": -1.0}, "at least"),
+    ],
+)
+def test_invalid_configuration_fails_at_construction(params, message):
+    with pytest.raises(ValueError, match=message):
+        ResidualMoE(_params(**params))
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"sequence_length": 0},
+        {"sequence_length": 23},
+        {"sequence_length": 24},
+        {"sequence_length": 25, "gate_hidden_dim": True},
+        {"sequence_length": 25, "gate_dropout": 1.0},
+        {"sequence_length": 25, "residual_limit": 0.0},
+        {"sequence_length": 25, "residual_limit": 1.1},
+        {"sequence_length": 25, "expert_dropout": 1.0},
+    ],
+)
+def test_network_constructor_enforces_its_public_contract(params):
+    with pytest.raises(ValueError):
+        ResidualMoENetwork(**params)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"sequence_length": 0},
+        {"sequence_length": 1},
+        {"sequence_length": 25, "hidden_dim": True},
+        {"sequence_length": 25, "dropout": 1.0},
+        {"sequence_length": 25, "residual_limit": float("nan")},
+        {"sequence_length": 25, "residual_limit": 0.0},
+        {"sequence_length": 25, "residual_limit": 1.1},
+    ],
+)
+def test_router_constructor_enforces_its_public_contract(params):
+    with pytest.raises(ValueError):
+        ResidualRouter(**params)
+
+
+@pytest.mark.parametrize(
+    "inputs",
+    [
+        object(),
+        torch.ones(2, 25),
+        torch.ones(2, 1, 24),
+        torch.ones(2, 1, 25, dtype=torch.int64),
+        torch.full((2, 1, 25), float("inf")),
+    ],
+)
+def test_router_rejects_invalid_inputs(inputs):
+    with pytest.raises((TypeError, ValueError)):
+        ResidualRouter(25)(inputs)
+
+
+def test_router_rejects_an_input_on_a_different_device():
+    router = ResidualRouter(25).to("meta")
+
+    with pytest.raises(ValueError, match="input is on cpu; model is on meta"):
+        router(torch.ones(1, 1, 25))
+
+
+@pytest.mark.parametrize(
+    "inputs",
+    [
+        object(),
+        torch.ones(2, 25),
+        torch.ones(2, 1, 24),
+        torch.ones(2, 1, 25, dtype=torch.int64),
+        torch.full((2, 1, 25), float("nan")),
+    ],
+)
+def test_network_rejects_invalid_inputs(inputs):
+    network = ResidualMoE(_params()).return_network()
+
+    with pytest.raises((TypeError, ValueError)):
+        network(inputs)
+
+
+def test_network_rejects_an_input_on_a_different_device():
+    network = ResidualMoE(_params()).return_network().to("meta")
+
+    with pytest.raises(ValueError, match="input is on cpu; model is on meta"):
+        network(torch.ones(1, 1, 25))
+
+
+def test_router_rejects_non_finite_internal_weights():
+    network = ResidualMoE(_params()).return_network()
+    with torch.no_grad():
+        network.router.weight_layer.weight.fill_(float("inf"))
+
+    with pytest.raises(RuntimeError, match="router produced non-finite"):
+        network(torch.ones(1, 1, 25))
+
+
+def test_network_rejects_a_non_finite_specialist_prediction():
+    class NonFiniteSpecialist(torch.nn.Module):
+        def forward(self, inputs):
+            return inputs.new_full((len(inputs), 1), float("inf"))
+
+    network = ResidualMoE(_params()).return_network()
+    network.specialists["PatchTST"] = NonFiniteSpecialist()
+
+    with pytest.raises(RuntimeError, match="produced non-finite outputs"):
+        network(torch.ones(1, 1, 25))
+
+
+def test_training_loss_rejects_the_wrong_network_type():
+    model = ResidualMoE(_params())
+
+    with pytest.raises(TypeError, match="ResidualMoENetwork"):
+        model.training_loss(torch.nn.Linear(25, 1), None, None, "fridge")
+
+
+def test_one_epoch_train_infer_smoke_preserves_every_row():
+    mains, targets = _chunks()
+    model = ResidualMoE(_params(appliance_params={}))
+
+    model.partial_fit(mains, targets)
+    result = model.disaggregate_chunk(mains)[0]
+
+    assert result.index.equals(mains[0].index)
+    assert result.columns.tolist() == ["fridge"]
+    assert result["fridge"].dtype == np.float32
+    assert np.isfinite(result["fridge"]).all()
+
+
+def test_checkpoint_roundtrip_restores_router_configuration_and_predictions(tmp_path):
+    mains, targets = _chunks()
+    model = ResidualMoE(
+        _params(
+            appliance_params={},
+            save_model_path=str(tmp_path),
+            gate_hidden_dim=6,
+            residual_limit=0.4,
+        )
+    )
+    model.partial_fit(mains, targets)
+    expected = model.disaggregate_chunk(mains)[0]
+
+    loaded = ResidualMoE(
+        _params(
+            appliance_params={},
+            pretrained_model_path=str(tmp_path),
+            gate_hidden_dim=4,
+            residual_limit=0.2,
+        )
+    )
+    actual = loaded.disaggregate_chunk(mains)[0]
+
+    assert loaded.gate_hidden_dim == 6
+    assert loaded.residual_limit == pytest.approx(0.4)
+    assert np.allclose(actual, expected)
+
+
+def test_public_export_catalog_defaults_and_parameter_count_are_stable():
+    import nilmtk_contrib.torch as torch_models
+
+    default = ResidualMoE({"device": "cpu"})
+    network = default.return_network()
+    entry = model_catalog_by_module()["nilmtk_contrib.torch.residual_moe"]
+
+    assert torch_models.ResidualMoE is ResidualMoE
+    assert default.sequence_length == 299
+    assert default.batch_size == 128
+    assert default.gate_hidden_dim == 32
+    assert default.residual_limit == pytest.approx(0.25)
+    assert default.auxiliary_weight == pytest.approx(0.1)
+    assert default.weight_decay == pytest.approx(1e-4)
+    assert sum(parameter.numel() for parameter in network.parameters()) == 440870
+    assert entry.class_name == "ResidualMoE"
+    assert entry.exported_from == "nilmtk_contrib.torch"
+
+
+def test_none_uses_documented_defaults():
+    model = ResidualMoE()
+
+    assert model.sequence_length == 299
+    assert model.gate_hidden_dim == 32

--- a/tests/test_torch_migration_contract.py
+++ b/tests/test_torch_migration_contract.py
@@ -34,6 +34,7 @@ DEFAULTS_BY_MODULE = {
     "nilmtk_contrib.torch.nilmmoe": ExpectedDefaults(299, 10, 128, 1800, 600),
     "nilmtk_contrib.torch.patchtst": ExpectedDefaults(99, 10, 128, 1800, 600),
     "nilmtk_contrib.torch.reformer": ExpectedDefaults(99, 10, 512, 1800, 600),
+    "nilmtk_contrib.torch.residual_moe": ExpectedDefaults(299, 10, 128, 1800, 600),
     "nilmtk_contrib.torch.resnet": ExpectedDefaults(299, 10, 512, 1800, 600),
     "nilmtk_contrib.torch.resnet_classification": ExpectedDefaults(
         99, 10, 512, 1800, 600


### PR DESCRIPTION
## What changed

- add `nilmtk_contrib.torch.ResidualMoE`
- use TimesNet as the anchor and PatchTST/ModernTCN as residual specialists
- route each input through inspectable seven-feature window summaries
- extract the summary calculation shared with `NILMMoE`, removing duplicated validation and feature code
- register and document the model without making benchmark claims

## Why

The first convex `NILMMoE` benchmark did not beat its strongest expert. `ResidualMoE` therefore starts exactly at TimesNet and can only apply an input-conditioned signed correction bounded to a configurable fraction of the strongest specialist disagreement. The default bound is 25%.

The correction amplitude is initialized to exactly zero. PatchTST and ModernTCN still receive auxiliary regression losses, so they learn while the main prediction begins at the anchor. The complete routing decision is available through a named output contract.

## Verification

- 53 focused ResidualMoE tests passed
- 103 combined ResidualMoE/NILMMoE tests passed
- 100% statement coverage for `residual_moe.py` and `_window_features.py`
- full suite: 743 passed, 100 dependency-gated skips
- all-model PyTorch train/infer smoke: 24 passed, 13 non-PyTorch/dependency skips
- Ruff passed across the repository
- wheel and source distribution built successfully
- isolated wheel import and forward pass verified the expert shapes, normalized routing weights, and exact anchor initialization
- `git diff --check` passed

The real REDD/A100 benchmark belongs in a separate NILMbench PR after this model PR is merged.
