### PR TITLE
Add leakage-safe LBM training contract

### DIFF
--- a/docs/latent-bayesian-melding.md
+++ b/docs/latent-bayesian-melding.md
@@ -53,12 +53,43 @@ cycle category is integral. Setting the melding weight to zero removes both
 the cycle constraint and all population terms, recovering the ordinary
 relaxed AFHMM state problem.
 
+## Training and provenance contract
+
+The private `nilmtk_contrib.torch._lbm_training` fitter consumes dense,
+equal-length population windows. Every window records the dataset and version,
+a stable data URI, SHA-256 fingerprint, building, timezone-aware half-open
+interval, and sample period. It rejects overlapping training windows so the
+same evidence cannot be counted twice.
+
+Evaluation buildings are disjoint by default: using any window from an
+evaluation building is treated as leakage even when the timestamps differ.
+A same-building temporal study must opt in explicitly, and overlapping times
+remain forbidden. This is stricter than merely retaining a path to the source
+file and makes the cross-building NILMbench boundary enforceable in code.
+
+Training is deterministic and PyTorch-only:
+
+- one-dimensional state means use deterministic Lloyd iterations;
+- initial and transition probabilities use explicit pseudocounts, and
+  transitions never cross source-window boundaries;
+- cycle probabilities and cycle-conditioned daily energy/duration summaries
+  use population windows only;
+- induced summary moments are computed exactly from the fitted Markov chain,
+  without Monte Carlo sampling;
+- sparse cycle categories, non-convex population/HMM ratios, and numerical
+  overflow are rejected rather than silently repaired.
+
+The resulting metadata is JSON-safe and includes every fitted probability,
+summary statistic, source window, and the appliance emission variance. Model
+artifact persistence remains part of the wrapper PR.
+
 ## What this first kernel does not claim
 
 The numerical kernel is intentionally private: it is neither exported as a
 disaggregator nor included in the model catalog. It does not yet:
 
-- learn appliance HMM and population parameters from NILMTK training chunks;
+- adapt real NILMTK chunks into provenance-complete population windows or
+  orchestrate multi-appliance fitting;
 - alternate the paper's closed-form variance updates;
 - infer the non-negative piecewise-smooth unknown-load signal;
 - return the paper's separate latent appliance signals rather than the

--- a/nilmtk_contrib/torch/_lbm_training.py
+++ b/nilmtk_contrib/torch/_lbm_training.py
@@ -1,0 +1,620 @@
+"""Leakage-safe, deterministic training primitives for structured LBM.
+
+The public NILMTK wrapper will adapt timestamped chunks to these private data
+contracts. Keeping the fitter independent of pandas and NILMTK makes the
+scientific inputs easy to test and keeps the PyTorch runtime self-contained.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime
+import math
+import re
+from typing import Sequence
+
+import torch
+
+from nilmtk_contrib.torch._lbm import (
+    GaussianRatioSummary,
+    StructuredAppliance,
+    _finite_real,
+    _positive_int,
+)
+
+
+_SHA256 = re.compile(r"sha256:[0-9a-f]{64}")
+
+
+def _nonempty_string(name: str, value: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty string.")
+    return value.strip()
+
+
+def _timestamp(name: str, value: str) -> datetime:
+    value = _nonempty_string(name, value)
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an ISO 8601 timestamp.") from exc
+    if parsed.utcoffset() is None:
+        raise ValueError(f"{name} must include an explicit UTC offset.")
+    return parsed
+
+
+@dataclass(frozen=True)
+class SourceWindow:
+    """Provenance for one dense, half-open dataset window ``[start, end)``."""
+
+    dataset: str
+    dataset_version: str
+    data_uri: str
+    data_fingerprint: str
+    building: str | int
+    start: str
+    end: str
+    sample_period_seconds: int
+
+    def __post_init__(self):
+        for field in ("dataset", "dataset_version", "data_uri"):
+            object.__setattr__(
+                self,
+                field,
+                _nonempty_string(field, getattr(self, field)),
+            )
+        if isinstance(self.building, bool) or not isinstance(self.building, (str, int)):
+            raise ValueError("building must be a non-empty string or integer.")
+        if isinstance(self.building, str):
+            object.__setattr__(
+                self, "building", _nonempty_string("building", self.building)
+            )
+        if not isinstance(self.data_fingerprint, str) or not _SHA256.fullmatch(
+            self.data_fingerprint
+        ):
+            raise ValueError(
+                "data_fingerprint must be lowercase sha256:<64 hexadecimal digits>."
+            )
+        object.__setattr__(self, "start", _nonempty_string("start", self.start))
+        object.__setattr__(self, "end", _nonempty_string("end", self.end))
+        start = _timestamp("start", self.start)
+        end = _timestamp("end", self.end)
+        if end.timestamp() <= start.timestamp():
+            raise ValueError("end must be later than start.")
+        object.__setattr__(
+            self,
+            "sample_period_seconds",
+            _positive_int("sample_period_seconds", self.sample_period_seconds),
+        )
+
+    @property
+    def interval(self) -> tuple[float, float]:
+        return (
+            _timestamp("start", self.start).timestamp(),
+            _timestamp("end", self.end).timestamp(),
+        )
+
+
+@dataclass(frozen=True)
+class ApplianceTrainingWindow:
+    """One dense appliance-power window and its complete provenance."""
+
+    source: SourceWindow
+    power: torch.Tensor | Sequence[float]
+
+
+@dataclass(frozen=True)
+class LBMTrainingResult:
+    """Fitted structured appliance plus auditable training diagnostics."""
+
+    appliance: StructuredAppliance
+    sources: tuple[SourceWindow, ...]
+    evaluation_sources: tuple[SourceWindow, ...]
+    num_samples: int
+    window_length: int
+    sample_period_seconds: int
+    state_counts: tuple[int, ...]
+    cycle_counts: tuple[int, ...]
+    emission_variance: float
+    pseudocount: float
+    minimum_windows_per_cycle: int
+    variance_floor: float
+    kmeans_max_iterations: int
+    allow_temporal_evaluation: bool
+
+    def metadata(self) -> dict:
+        """Return a JSON-safe record sufficient to audit the fitted inputs."""
+        summaries = []
+        for name, summary in zip(
+            ("energy_wh", "duration_minutes"), self.appliance.summaries
+        ):
+            summaries.append(
+                {
+                    "name": name,
+                    "state_weights": torch.as_tensor(summary.state_weights).tolist(),
+                    "conditional_means": torch.as_tensor(
+                        summary.conditional_means
+                    ).tolist(),
+                    "conditional_variance": summary.conditional_variance,
+                    "induced_mean": summary.induced_mean,
+                    "induced_variance": summary.induced_variance,
+                }
+            )
+        return {
+            "schema_version": 1,
+            "algorithm": "deterministic-1d-kmeans+hmm-counts",
+            "sources": [asdict(source) for source in self.sources],
+            "evaluation_sources": [
+                asdict(source) for source in self.evaluation_sources
+            ],
+            "num_samples": self.num_samples,
+            "window_length": self.window_length,
+            "sample_period_seconds": self.sample_period_seconds,
+            "state_means": torch.as_tensor(self.appliance.state_means).tolist(),
+            "initial_probabilities": torch.as_tensor(
+                self.appliance.initial_probabilities
+            ).tolist(),
+            "transition_probabilities": torch.as_tensor(
+                self.appliance.transition_probabilities
+            ).tolist(),
+            "cycle_probabilities": torch.as_tensor(
+                self.appliance.cycle_probabilities
+            ).tolist(),
+            "state_counts": list(self.state_counts),
+            "cycle_counts": list(self.cycle_counts),
+            "emission_variance": self.emission_variance,
+            "pseudocount": self.pseudocount,
+            "minimum_windows_per_cycle": self.minimum_windows_per_cycle,
+            "variance_floor": self.variance_floor,
+            "kmeans_max_iterations": self.kmeans_max_iterations,
+            "allow_temporal_evaluation": self.allow_temporal_evaluation,
+            "summaries": summaries,
+        }
+
+
+def _same_source_entity(first: SourceWindow, second: SourceWindow) -> bool:
+    same_building = str(first.building) == str(second.building)
+    same_dataset = first.dataset.casefold() == second.dataset.casefold()
+    same_fingerprint = first.data_fingerprint == second.data_fingerprint
+    same_uri = first.data_uri == second.data_uri
+    return same_building and (same_dataset or same_fingerprint or same_uri)
+
+
+def _windows_overlap(first: SourceWindow, second: SourceWindow) -> bool:
+    if not _same_source_entity(first, second):
+        return False
+    first_start, first_end = first.interval
+    second_start, second_end = second.interval
+    return first_start < second_end and second_start < first_end
+
+
+def assert_disjoint_sources(
+    training_sources: Sequence[SourceWindow],
+    evaluation_sources: Sequence[SourceWindow],
+    *,
+    allow_temporal_split: bool = False,
+) -> None:
+    """Reject evaluation-building leakage, with explicit temporal-split opt-in."""
+    if not isinstance(allow_temporal_split, bool):
+        raise TypeError("allow_temporal_split must be a boolean.")
+    for training in training_sources:
+        if not isinstance(training, SourceWindow):
+            raise TypeError("training_sources must contain SourceWindow instances.")
+        for evaluation in evaluation_sources:
+            if not isinstance(evaluation, SourceWindow):
+                raise TypeError(
+                    "evaluation_sources must contain SourceWindow instances."
+                )
+            same_building = _same_source_entity(training, evaluation)
+            if same_building and (
+                not allow_temporal_split or _windows_overlap(training, evaluation)
+            ):
+                raise ValueError(
+                    "Training/evaluation leakage: training data uses evaluation "
+                    "building "
+                    f"{training.dataset} building {training.building}."
+                )
+
+
+def _as_power(index: int, power) -> torch.Tensor:
+    try:
+        values = torch.as_tensor(power, dtype=torch.float64, device="cpu")
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise TypeError(f"windows[{index}].power must contain numeric values.") from exc
+    if values.ndim != 1 or values.numel() < 1:
+        raise ValueError(
+            f"windows[{index}].power must be non-empty and one-dimensional."
+        )
+    if not bool(torch.isfinite(values).all()):
+        raise ValueError(f"windows[{index}].power must contain only finite values.")
+    if bool((values < 0).any()):
+        raise ValueError(f"windows[{index}].power must be non-negative.")
+    return values.clone()
+
+
+def _prepare_windows(
+    windows: Sequence[ApplianceTrainingWindow],
+    evaluation_sources: Sequence[SourceWindow],
+    *,
+    allow_temporal_evaluation: bool,
+) -> tuple[tuple[SourceWindow, torch.Tensor], ...]:
+    if not isinstance(windows, Sequence) or isinstance(windows, (str, bytes)):
+        raise TypeError("windows must be a non-empty sequence.")
+    if not windows:
+        raise ValueError("windows must be non-empty.")
+
+    prepared = []
+    for index, window in enumerate(windows):
+        if not isinstance(window, ApplianceTrainingWindow):
+            raise TypeError(
+                f"windows[{index}] must be an ApplianceTrainingWindow instance."
+            )
+        if not isinstance(window.source, SourceWindow):
+            raise TypeError(f"windows[{index}].source must be a SourceWindow.")
+        values = _as_power(index, window.power)
+        start, end = window.source.interval
+        expected_seconds = values.numel() * window.source.sample_period_seconds
+        if not math.isclose(end - start, expected_seconds, abs_tol=1e-6, rel_tol=0):
+            raise ValueError(
+                f"windows[{index}] timestamps span {end - start:g} seconds but "
+                f"{values.numel()} samples require {expected_seconds:g} seconds."
+            )
+        prepared.append((window.source, values))
+
+    periods = {source.sample_period_seconds for source, _ in prepared}
+    lengths = {int(values.numel()) for _, values in prepared}
+    if len(periods) != 1:
+        raise ValueError("All training windows must use the same sample period.")
+    if len(lengths) != 1:
+        raise ValueError(
+            "All population windows must contain the same number of samples."
+        )
+
+    sources = [source for source, _ in prepared]
+    for index, source in enumerate(sources):
+        for previous in sources[:index]:
+            if _windows_overlap(previous, source):
+                raise ValueError(
+                    "Duplicate training evidence: training windows overlap for "
+                    f"{source.dataset} building {source.building}."
+                )
+    assert_disjoint_sources(
+        sources,
+        evaluation_sources,
+        allow_temporal_split=allow_temporal_evaluation,
+    )
+    return tuple(
+        sorted(
+            prepared,
+            key=lambda pair: _source_sort_key(pair[0]),
+        )
+    )
+
+
+def _source_sort_key(source: SourceWindow):
+    return (
+        source.dataset.casefold(),
+        source.dataset_version,
+        source.data_fingerprint,
+        str(source.building),
+        source.interval,
+    )
+
+
+def _fit_state_means(
+    windows: Sequence[torch.Tensor],
+    *,
+    num_states: int,
+    max_iterations: int,
+) -> torch.Tensor:
+    values = torch.sort(torch.cat(tuple(windows))).values
+    unique = torch.unique(values, sorted=True)
+    if unique.numel() < num_states:
+        raise ValueError(
+            f"Training power contains {unique.numel()} unique values; "
+            f"at least num_states={num_states} are required."
+        )
+    initial_indices = (
+        torch.linspace(
+            0,
+            unique.numel() - 1,
+            steps=num_states,
+            dtype=torch.float64,
+        )
+        .round()
+        .to(torch.long)
+    )
+    centers = unique[initial_indices]
+    previous_assignments = None
+    for _ in range(max_iterations):
+        assignments = torch.argmin(torch.abs(values[:, None] - centers[None, :]), dim=1)
+        if previous_assignments is not None and torch.equal(
+            assignments, previous_assignments
+        ):
+            break
+        counts = torch.bincount(assignments, minlength=num_states)
+        if bool((counts == 0).any()):
+            raise RuntimeError("Deterministic state fitting produced an empty cluster.")
+        centers = torch.stack(
+            [values[assignments == state].mean() for state in range(num_states)]
+        )
+        if not bool(torch.isfinite(centers).all()):
+            raise RuntimeError(
+                "State fitting produced non-finite means; rescale the power data."
+            )
+        previous_assignments = assignments
+    else:
+        raise RuntimeError("Deterministic state fitting did not converge.")
+    return torch.sort(centers).values
+
+
+def _assign_states(values: torch.Tensor, means: torch.Tensor) -> torch.Tensor:
+    return torch.argmin(torch.abs(values[:, None] - means[None, :]), dim=1)
+
+
+def _smoothed_probabilities(counts: torch.Tensor, pseudocount: float) -> torch.Tensor:
+    smoothed = counts.to(torch.float64) + pseudocount
+    return smoothed / smoothed.sum(dim=-1, keepdim=True)
+
+
+def _markov_reward_moments(
+    initial: torch.Tensor,
+    transition: torch.Tensor,
+    rewards: torch.Tensor,
+    time_points: int,
+) -> tuple[float, float]:
+    """Return exact mean and variance of an additive finite-state reward."""
+    probabilities = initial
+    first_moment = initial * rewards
+    second_moment = initial * torch.square(rewards)
+    for _ in range(1, time_points):
+        propagated_first = first_moment @ transition
+        probabilities = probabilities @ transition
+        second_moment = (
+            second_moment @ transition
+            + 2.0 * rewards * propagated_first
+            + torch.square(rewards) * probabilities
+        )
+        first_moment = propagated_first + rewards * probabilities
+    mean = float(first_moment.sum())
+    raw_variance = float(second_moment.sum()) - mean**2
+    if not math.isfinite(mean) or not math.isfinite(raw_variance):
+        raise RuntimeError(
+            "HMM reward moments became non-finite; rescale the power data."
+        )
+    tolerance = 1e-10 * max(1.0, mean**2, abs(float(second_moment.sum())))
+    if raw_variance < -tolerance:
+        raise RuntimeError("HMM reward variance became unexpectedly negative.")
+    variance = max(0.0, raw_variance)
+    return mean, variance
+
+
+def _fit_summary(
+    name: str,
+    observed: torch.Tensor,
+    cycle_assignments: torch.Tensor,
+    cycle_categories: int,
+    state_weights: torch.Tensor,
+    initial: torch.Tensor,
+    transition: torch.Tensor,
+    window_length: int,
+    variance_floor: float,
+) -> GaussianRatioSummary:
+    conditional_means = torch.stack(
+        [
+            observed[cycle_assignments == cycle].mean()
+            for cycle in range(cycle_categories)
+        ]
+    )
+    residuals = observed - conditional_means[cycle_assignments]
+    degrees_of_freedom = observed.numel() - cycle_categories
+    if degrees_of_freedom <= 0:
+        raise ValueError(f"{name} needs more windows than fitted cycle categories.")
+    conditional_variance = max(
+        variance_floor,
+        float(torch.dot(residuals, residuals)) / degrees_of_freedom,
+    )
+    if not bool(torch.isfinite(conditional_means).all()) or not math.isfinite(
+        conditional_variance
+    ):
+        raise RuntimeError(
+            f"{name} population statistics became non-finite; rescale the data."
+        )
+    induced_mean, induced_variance = _markov_reward_moments(
+        initial,
+        transition,
+        state_weights,
+        window_length,
+    )
+    if induced_variance <= conditional_variance:
+        raise ValueError(
+            f"{name} conditional variance {conditional_variance:g} must be smaller "
+            f"than induced HMM variance {induced_variance:g}; the LBM ratio would "
+            "not be convex."
+        )
+    return GaussianRatioSummary(
+        state_weights=state_weights,
+        conditional_means=conditional_means,
+        conditional_variance=conditional_variance,
+        induced_mean=induced_mean,
+        induced_variance=induced_variance,
+    )
+
+
+def fit_lbm_appliance(
+    windows: Sequence[ApplianceTrainingWindow],
+    *,
+    num_states: int = 2,
+    pseudocount: float = 1.0,
+    minimum_windows_per_cycle: int = 2,
+    variance_floor: float = 1e-6,
+    kmeans_max_iterations: int = 100,
+    evaluation_sources: Sequence[SourceWindow] = (),
+    allow_temporal_evaluation: bool = False,
+) -> LBMTrainingResult:
+    """Fit one private LBM appliance contract from dense population windows."""
+    num_states = _positive_int("num_states", num_states)
+    if num_states < 2:
+        raise ValueError("num_states must be at least two.")
+    pseudocount = _finite_real("pseudocount", pseudocount, positive=True)
+    minimum_windows_per_cycle = _positive_int(
+        "minimum_windows_per_cycle", minimum_windows_per_cycle
+    )
+    variance_floor = _finite_real("variance_floor", variance_floor, positive=True)
+    kmeans_max_iterations = _positive_int(
+        "kmeans_max_iterations", kmeans_max_iterations
+    )
+    if not isinstance(allow_temporal_evaluation, bool):
+        raise TypeError("allow_temporal_evaluation must be a boolean.")
+    if not isinstance(evaluation_sources, Sequence) or isinstance(
+        evaluation_sources, (str, bytes)
+    ):
+        raise TypeError(
+            "evaluation_sources must be a sequence of SourceWindow instances."
+        )
+    evaluation_sources = tuple(evaluation_sources)
+    prepared = _prepare_windows(
+        windows,
+        evaluation_sources,
+        allow_temporal_evaluation=allow_temporal_evaluation,
+    )
+    sources = tuple(source for source, _ in prepared)
+    powers = tuple(values for _, values in prepared)
+    window_length = int(powers[0].numel())
+    sample_period = sources[0].sample_period_seconds
+
+    state_means = _fit_state_means(
+        powers,
+        num_states=num_states,
+        max_iterations=kmeans_max_iterations,
+    )
+    state_windows = tuple(_assign_states(values, state_means) for values in powers)
+    state_counts = sum(
+        (torch.bincount(states, minlength=num_states) for states in state_windows),
+        start=torch.zeros(num_states, dtype=torch.long),
+    )
+    initial_counts = torch.bincount(
+        torch.stack([states[0] for states in state_windows]),
+        minlength=num_states,
+    )
+    transition_counts = torch.zeros((num_states, num_states), dtype=torch.long)
+    for states in state_windows:
+        flat_transitions = states[:-1] * num_states + states[1:]
+        transition_counts += torch.bincount(
+            flat_transitions,
+            minlength=num_states * num_states,
+        ).reshape(num_states, num_states)
+    initial = _smoothed_probabilities(initial_counts, pseudocount)
+    transition = _smoothed_probabilities(transition_counts, pseudocount)
+
+    off_state = int(torch.argmin(state_means))
+    cycles = torch.tensor(
+        [
+            int(((states[:-1] == off_state) & (states[1:] != off_state)).sum())
+            for states in state_windows
+        ],
+        dtype=torch.long,
+    )
+    cycle_categories = int(cycles.max()) + 1
+    cycle_counts = torch.bincount(cycles, minlength=cycle_categories)
+    sparse_categories = torch.nonzero(
+        cycle_counts < minimum_windows_per_cycle,
+        as_tuple=False,
+    ).flatten()
+    if sparse_categories.numel():
+        categories = ", ".join(str(int(value)) for value in sparse_categories)
+        raise ValueError(
+            "Population windows are underspecified: cycle categories "
+            f"{categories} have fewer than minimum_windows_per_cycle="
+            f"{minimum_windows_per_cycle}."
+        )
+    cycle_probabilities = _smoothed_probabilities(cycle_counts, pseudocount)
+
+    energy = torch.tensor(
+        [float(values.sum()) * sample_period / 3600.0 for values in powers],
+        dtype=torch.float64,
+    )
+    duration = torch.tensor(
+        [
+            float((states != off_state).sum()) * sample_period / 60.0
+            for states in state_windows
+        ],
+        dtype=torch.float64,
+    )
+    if not bool(torch.isfinite(energy).all()) or not bool(
+        torch.isfinite(duration).all()
+    ):
+        raise RuntimeError(
+            "Population summaries became non-finite; rescale the power data."
+        )
+    energy_weights = state_means * sample_period / 3600.0
+    duration_weights = torch.full_like(state_means, sample_period / 60.0)
+    duration_weights[off_state] = 0.0
+    summaries = (
+        _fit_summary(
+            "energy_wh",
+            energy,
+            cycles,
+            cycle_categories,
+            energy_weights,
+            initial,
+            transition,
+            window_length,
+            variance_floor,
+        ),
+        _fit_summary(
+            "duration_minutes",
+            duration,
+            cycles,
+            cycle_categories,
+            duration_weights,
+            initial,
+            transition,
+            window_length,
+            variance_floor,
+        ),
+    )
+    all_power = torch.cat(powers)
+    all_states = torch.cat(state_windows)
+    emission_residuals = all_power - state_means[all_states]
+    emission_variance = max(
+        variance_floor,
+        float(torch.mean(torch.square(emission_residuals))),
+    )
+    if not math.isfinite(emission_variance):
+        raise RuntimeError(
+            "Emission variance became non-finite; rescale the power data."
+        )
+    appliance = StructuredAppliance(
+        state_means=state_means,
+        initial_probabilities=initial,
+        transition_probabilities=transition,
+        off_state=off_state,
+        cycle_probabilities=cycle_probabilities,
+        summaries=summaries,
+    )
+    return LBMTrainingResult(
+        appliance=appliance,
+        sources=sources,
+        evaluation_sources=tuple(sorted(evaluation_sources, key=_source_sort_key)),
+        num_samples=int(all_power.numel()),
+        window_length=window_length,
+        sample_period_seconds=sample_period,
+        state_counts=tuple(int(value) for value in state_counts),
+        cycle_counts=tuple(int(value) for value in cycle_counts),
+        emission_variance=emission_variance,
+        pseudocount=pseudocount,
+        minimum_windows_per_cycle=minimum_windows_per_cycle,
+        variance_floor=variance_floor,
+        kmeans_max_iterations=kmeans_max_iterations,
+        allow_temporal_evaluation=allow_temporal_evaluation,
+    )
+
+
+__all__ = [
+    "ApplianceTrainingWindow",
+    "LBMTrainingResult",
+    "SourceWindow",
+    "assert_disjoint_sources",
+    "fit_lbm_appliance",
+]

--- a/tests/test_lbm_training.py
+++ b/tests/test_lbm_training.py
@@ -1,0 +1,400 @@
+from datetime import datetime, timedelta, timezone
+from itertools import product
+import json
+import math
+
+import pytest
+
+
+torch = pytest.importorskip("torch")
+
+from nilmtk_contrib.torch._lbm import solve_structured_relaxation  # noqa: E402
+from nilmtk_contrib.torch._lbm_training import (  # noqa: E402
+    ApplianceTrainingWindow,
+    SourceWindow,
+    _fit_summary,
+    _markov_reward_moments,
+    assert_disjoint_sources,
+    fit_lbm_appliance,
+)
+
+
+FINGERPRINT = "sha256:" + "a" * 64
+POWER_WINDOWS = (
+    [0, 1, 0, 2, 0, 1],
+    [1, 0, 2, 1, 0, 2],
+    [2, 1, 0, 1, 2, 0],
+    [0, 90, 100, 100, 0, 0],
+    [0, 0, 95, 105, 0, 0],
+    [0, 110, 100, 0, 0, 0],
+    [0, 90, 0, 100, 0, 0],
+    [0, 80, 0, 110, 0, 0],
+    [0, 100, 0, 90, 0, 0],
+)
+
+
+def _source(index, *, building="1", start=None, end=None, **overrides):
+    start_value = start or datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(
+        hours=index
+    )
+    if isinstance(start_value, str):
+        start_time = datetime.fromisoformat(start_value.replace("Z", "+00:00"))
+    else:
+        start_time = start_value
+    period = overrides.get("sample_period_seconds", 60)
+    end_value = end or start_time + timedelta(seconds=6 * max(period, 1))
+    params = {
+        "dataset": "REDD",
+        "dataset_version": "nilmtk-converted-v1",
+        "data_uri": "https://example.org/redd.h5",
+        "data_fingerprint": FINGERPRINT,
+        "building": building,
+        "start": (
+            start_value if isinstance(start_value, str) else start_value.isoformat()
+        ),
+        "end": end_value if isinstance(end_value, str) else end_value.isoformat(),
+        "sample_period_seconds": 60,
+    }
+    params.update(overrides)
+    return SourceWindow(**params)
+
+
+def _windows():
+    return tuple(
+        ApplianceTrainingWindow(_source(index), power)
+        for index, power in enumerate(POWER_WINDOWS)
+    )
+
+
+def _tensor(value):
+    return torch.as_tensor(value, dtype=torch.float64)
+
+
+def test_fitter_builds_a_kernel_ready_appliance_with_complete_metadata():
+    result = fit_lbm_appliance(_windows())
+    appliance = result.appliance
+
+    assert _tensor(appliance.state_means).tolist() == pytest.approx(
+        [0.3902439024, 97.6923076923]
+    )
+    assert _tensor(appliance.initial_probabilities).tolist() == pytest.approx(
+        [10 / 11, 1 / 11]
+    )
+    assert torch.all(_tensor(appliance.initial_probabilities) > 0)
+    assert torch.allclose(
+        _tensor(appliance.transition_probabilities).sum(dim=1),
+        torch.ones(2, dtype=torch.float64),
+    )
+    assert torch.all(_tensor(appliance.transition_probabilities) > 0)
+    assert appliance.off_state == 0
+    assert _tensor(appliance.cycle_probabilities).tolist() == pytest.approx(
+        [1 / 3, 1 / 3, 1 / 3]
+    )
+    assert len(appliance.summaries) == 2
+    assert result.num_samples == 54
+    assert result.window_length == 6
+    assert result.sample_period_seconds == 60
+    assert result.cycle_counts == (3, 3, 3)
+    assert result.emission_variance > 0
+
+    metadata = result.metadata()
+    assert json.loads(json.dumps(metadata)) == metadata
+    assert metadata["schema_version"] == 1
+    assert metadata["evaluation_sources"] == []
+    assert metadata["allow_temporal_evaluation"] is False
+    assert metadata["sources"][0]["data_fingerprint"] == FINGERPRINT
+    assert [summary["name"] for summary in metadata["summaries"]] == [
+        "energy_wh",
+        "duration_minutes",
+    ]
+
+    inferred = solve_structured_relaxation(
+        POWER_WINDOWS[3],
+        [appliance],
+        observation_variance=result.emission_variance + 1.0,
+        max_iterations=5,
+    )
+    assert inferred.prediction.shape == (6,)
+    assert inferred.cycle_posteriors[0] is not None
+
+
+def test_transition_counts_do_not_cross_source_window_boundaries():
+    result = fit_lbm_appliance(_windows(), pseudocount=1.0)
+    means = _tensor(result.appliance.state_means)
+    expected_counts = torch.zeros((2, 2), dtype=torch.float64)
+    for power in POWER_WINDOWS:
+        states = torch.argmin(
+            torch.abs(_tensor(power)[:, None] - means[None, :]),
+            dim=1,
+        )
+        for previous, current in zip(states[:-1], states[1:]):
+            expected_counts[previous, current] += 1
+    expected = (expected_counts + 1.0) / (expected_counts + 1.0).sum(
+        dim=1,
+        keepdim=True,
+    )
+
+    assert torch.allclose(_tensor(result.appliance.transition_probabilities), expected)
+
+
+def test_fitting_is_invariant_to_caller_window_order():
+    forward = fit_lbm_appliance(_windows())
+    reverse = fit_lbm_appliance(tuple(reversed(_windows())))
+
+    assert forward.metadata() == reverse.metadata()
+
+
+def test_markov_reward_moments_match_complete_path_enumeration():
+    initial = _tensor([0.6, 0.4])
+    transition = _tensor([[0.7, 0.3], [0.2, 0.8]])
+    rewards = _tensor([0.0, 2.0])
+    mean, variance = _markov_reward_moments(initial, transition, rewards, 3)
+
+    outcomes = []
+    for path in product(range(2), repeat=3):
+        probability = float(initial[path[0]])
+        for previous, current in zip(path[:-1], path[1:]):
+            probability *= float(transition[previous, current])
+        outcomes.append((probability, sum(float(rewards[state]) for state in path)))
+    expected_mean = sum(probability * value for probability, value in outcomes)
+    expected_variance = sum(
+        probability * (value - expected_mean) ** 2 for probability, value in outcomes
+    )
+
+    assert mean == pytest.approx(expected_mean, abs=1e-12)
+    assert variance == pytest.approx(expected_variance, abs=1e-12)
+
+
+def test_overlap_guard_rejects_evaluation_building_by_default():
+    training = _source(0)
+    overlapping = _source(
+        50,
+        start=datetime(2026, 1, 1, 0, 3, tzinfo=timezone.utc),
+        end=datetime(2026, 1, 1, 0, 9, tzinfo=timezone.utc),
+        data_fingerprint="sha256:" + "b" * 64,
+    )
+    disjoint_same_building = _source(1)
+    different_building = _source(0, building="2")
+
+    with pytest.raises(ValueError, match="Training/evaluation leakage"):
+        assert_disjoint_sources([training], [overlapping])
+
+    with pytest.raises(ValueError, match="Training/evaluation leakage"):
+        assert_disjoint_sources([training], [disjoint_same_building])
+
+    assert_disjoint_sources([training], [different_building])
+
+
+def test_disjoint_same_building_time_requires_explicit_temporal_opt_in():
+    training = _source(0)
+    evaluation = _source(1)
+    overlapping = _source(
+        2,
+        start=datetime(2026, 1, 1, 0, 3, tzinfo=timezone.utc),
+        end=datetime(2026, 1, 1, 0, 9, tzinfo=timezone.utc),
+    )
+
+    assert_disjoint_sources(
+        [training],
+        [evaluation],
+        allow_temporal_split=True,
+    )
+    with pytest.raises(ValueError, match="Training/evaluation leakage"):
+        assert_disjoint_sources(
+            [training],
+            [overlapping],
+            allow_temporal_split=True,
+        )
+    fit_lbm_appliance(
+        _windows(),
+        evaluation_sources=[_source(20)],
+        allow_temporal_evaluation=True,
+    )
+
+
+def test_metadata_records_sorted_evaluation_sources_and_training_policy():
+    evaluation = [_source(0, building="3"), _source(0, building="2")]
+
+    result = fit_lbm_appliance(
+        _windows(),
+        evaluation_sources=evaluation,
+        minimum_windows_per_cycle=2,
+        kmeans_max_iterations=50,
+    )
+    metadata = result.metadata()
+
+    assert [source["building"] for source in metadata["evaluation_sources"]] == [
+        "2",
+        "3",
+    ]
+    assert metadata["minimum_windows_per_cycle"] == 2
+    assert metadata["kmeans_max_iterations"] == 50
+    assert metadata["allow_temporal_evaluation"] is False
+
+
+def test_matching_fingerprint_or_uri_blocks_dataset_alias_leakage():
+    aliases = [
+        _source(20, dataset="REDD alias"),
+        _source(
+            20,
+            dataset="REDD alias",
+            data_fingerprint="sha256:" + "b" * 64,
+        ),
+    ]
+
+    for aliased_evaluation in aliases:
+        with pytest.raises(ValueError, match="Training/evaluation leakage"):
+            fit_lbm_appliance(_windows(), evaluation_sources=[aliased_evaluation])
+
+
+def test_fit_rejects_overlapping_evaluation_source():
+    evaluation = _source(0, data_fingerprint="sha256:" + "b" * 64)
+
+    with pytest.raises(ValueError, match="Training/evaluation leakage"):
+        fit_lbm_appliance(_windows(), evaluation_sources=[evaluation])
+
+
+def test_fit_rejects_overlapping_or_duplicate_training_evidence():
+    duplicated = _windows() + (_windows()[0],)
+
+    with pytest.raises(ValueError, match="Duplicate training evidence"):
+        fit_lbm_appliance(duplicated)
+
+
+def test_fit_rejects_missing_population_cycle_categories():
+    sparse = tuple(
+        ApplianceTrainingWindow(_source(index), power)
+        for index, power in enumerate(POWER_WINDOWS[:3] + POWER_WINDOWS[6:])
+    )
+
+    with pytest.raises(ValueError, match="underspecified"):
+        fit_lbm_appliance(sparse)
+
+
+@pytest.mark.parametrize(
+    ("source_kwargs", "message"),
+    [
+        ({"dataset": " "}, "dataset must be a non-empty"),
+        ({"data_fingerprint": "sha256:bad"}, "data_fingerprint"),
+        ({"start": "2026-01-01T00:00:00"}, "explicit UTC offset"),
+        (
+            {
+                "start": "2026-01-01T01:00:00+00:00",
+                "end": "2026-01-01T00:00:00+00:00",
+            },
+            "later than start",
+        ),
+        ({"sample_period_seconds": 0}, "must be positive"),
+        ({"building": []}, "building must be"),
+    ],
+)
+def test_source_provenance_is_strictly_validated(source_kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        _source(0, **source_kwargs)
+
+
+@pytest.mark.parametrize(
+    ("mutator", "message"),
+    [
+        (lambda windows: (), "non-empty"),
+        (
+            lambda windows: (
+                ApplianceTrainingWindow(windows[0].source, [0.0, math.nan]),
+            ),
+            "finite",
+        ),
+        (
+            lambda windows: (ApplianceTrainingWindow(windows[0].source, [0.0, -1.0]),),
+            "non-negative",
+        ),
+        (
+            lambda windows: (ApplianceTrainingWindow(windows[0].source, [0.0, 1.0]),),
+            "timestamps span",
+        ),
+        (
+            lambda windows: windows[:-1]
+            + (
+                ApplianceTrainingWindow(
+                    _source(8, sample_period_seconds=30),
+                    windows[-1].power,
+                ),
+            ),
+            "same sample period",
+        ),
+    ],
+)
+def test_fit_rejects_malformed_training_windows(mutator, message):
+    with pytest.raises(ValueError, match=message):
+        fit_lbm_appliance(mutator(_windows()))
+
+
+def test_fit_rejects_insufficient_state_support():
+    constant = tuple(
+        ApplianceTrainingWindow(_source(index), [1.0] * 6) for index in range(3)
+    )
+
+    with pytest.raises(ValueError, match="unique values"):
+        fit_lbm_appliance(constant, minimum_windows_per_cycle=1)
+
+
+def test_fit_rejects_numerical_overflow_instead_of_persisting_nan():
+    extreme = tuple(
+        ApplianceTrainingWindow(
+            _source(index),
+            [1e308, 0.0, 1e308, 0.0, 1e308, 0.0],
+        )
+        for index in range(3)
+    )
+
+    with pytest.raises(RuntimeError, match="non-finite"):
+        fit_lbm_appliance(extreme, minimum_windows_per_cycle=1)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error", "message"),
+    [
+        ({"num_states": 1}, ValueError, "at least two"),
+        ({"pseudocount": 0.0}, ValueError, "positive"),
+        ({"kmeans_max_iterations": True}, TypeError, "integer"),
+        (
+            {"allow_temporal_evaluation": "yes"},
+            TypeError,
+            "must be a boolean",
+        ),
+        (
+            {"evaluation_sources": [object()]},
+            TypeError,
+            "SourceWindow instances",
+        ),
+    ],
+)
+def test_fit_rejects_invalid_runtime_contracts(kwargs, error, message):
+    with pytest.raises(error, match=message):
+        fit_lbm_appliance(_windows(), **kwargs)
+
+
+def test_summary_fit_rejects_a_nonconvex_population_to_hmm_ratio():
+    with pytest.raises(ValueError, match="would not be convex"):
+        _fit_summary(
+            "energy_wh",
+            _tensor([0.0, 100.0]),
+            torch.tensor([0, 0], dtype=torch.long),
+            1,
+            _tensor([0.0, 1.0]),
+            _tensor([0.5, 0.5]),
+            _tensor([[0.5, 0.5], [0.5, 0.5]]),
+            1,
+            1e-6,
+        )
+
+
+def test_training_path_has_no_classical_solver_or_dataframe_dependency():
+    source = (
+        __import__("pathlib").Path(__file__).parents[1]
+        / "nilmtk_contrib"
+        / "torch"
+        / "_lbm_training.py"
+    ).read_text(encoding="utf-8")
+    for dependency in ("cvxpy", "hmmlearn", "mosek", "numpy", "pandas", "scipy"):
+        assert f"import {dependency}" not in source
+        assert f"from {dependency}" not in source


### PR DESCRIPTION
## Summary

- fit structured LBM state means, HMM probabilities, cycle priors, and cycle-conditioned daily energy/duration summaries with PyTorch only
- require provenance-complete dense windows: dataset/version, stable URI, SHA-256 fingerprint, building, timezone-aware interval, and sample period
- reject evaluation-building leakage by default; same-building temporal studies require explicit opt-in and still forbid overlapping timestamps
- count initial states and transitions within each source window, never across chunk boundaries
- compute induced Markov reward moments exactly rather than through Monte Carlo sampling
- persist JSON-safe fitted parameters, source/evaluation windows, leakage policy, smoothing parameters, and emission variance
- reject sparse cycle categories, non-convex Gaussian ratios, malformed timestamps, duplicate evidence, and numerical overflow

This remains a private training primitive. It does not export an LBM disaggregator, alter the model catalog, or make a benchmark claim.

## Verification

- `uv run ruff check nilmtk_contrib tests scripts`
- focused training/provenance suite: 31 passed
- complete suite: 799 passed, 101 skipped
- `uv build`: wheel and sdist succeeded
- built wheel contains `nilmtk_contrib/torch/_lbm_training.py`
- training path has no NumPy, pandas, SciPy, hmmlearn, CVXPY, or MOSEK runtime import

## Next PR

Adapt real NILMTK chunks to these provenance-complete windows, orchestrate multiple appliances, persist artifacts, and add the remaining variance/unknown-load inference blocks. Real REDD validation and NILMbench registration remain separate after that.
