### PR TITLE
Add validated LBM training artifacts

### DIFF
--- a/docs/latent-bayesian-melding.md
+++ b/docs/latent-bayesian-melding.md
@@ -80,8 +80,29 @@ Training is deterministic and PyTorch-only:
   overflow are rejected rather than silently repaired.
 
 The resulting metadata is JSON-safe and includes every fitted probability,
-summary statistic, source window, and the appliance emission variance. Model
-artifact persistence remains part of the wrapper PR.
+raw HMM count, summary statistic, source window, and the appliance emission
+variance.
+
+## Artifact contract
+
+The private `nilmtk_contrib.torch._lbm_artifacts` layer stores a collection of
+fitted appliances in one schema-versioned JSON file. JSON is intentional here:
+an LBM artifact is a small, read-mostly scientific record rather than a
+concurrently updated results database. It remains inspectable, diffable, and
+portable without adding SQLite migrations or another runtime dependency.
+
+Saving uses a same-directory temporary file, `fsync`, and atomic replacement.
+Loading has a size limit, exact field schemas, and a SHA-256 payload checksum;
+it never invokes `pickle` or executable deserialization. Raw initial,
+transition, and cycle counts are retained so their smoothed probabilities can
+be recomputed. The loader also rechecks source boundaries, leakage policy,
+HMM validity, and induced Markov reward moments. Saving revalidates the bundle
+at the persistence boundary, and the reconstructed numeric sequences are
+immutable.
+
+The checksum detects accidental corruption, not malicious authorship. It is
+not a signature: provenance still depends on trusted dataset fingerprints and
+the future benchmark run manifest.
 
 ## What this first kernel does not claim
 
@@ -94,7 +115,6 @@ disaggregator nor included in the model catalog. It does not yet:
 - infer the non-negative piecewise-smooth unknown-load signal;
 - return the paper's separate latent appliance signals rather than the
   collapsed state-mean prediction;
-- save and validate a model artifact with dataset/protocol provenance;
 - reproduce the paper's HES-to-UK-DALE experiment;
 - establish accuracy, speed, or parity on a real NILMbench task.
 
@@ -110,10 +130,15 @@ a tested numerical primitive with a reproduced scientific method.
    probabilities, cycle categories, and daily energy/duration priors from
    training data only. Use explicit pseudocounts and reject underspecified
    population data rather than silently leaking test-house statistics.
-3. **LBM inference wrapper.** Add variance alternation and the non-negative
+3. **Validated artifacts.** Persist one schema-checked JSON bundle with raw
+   probability counts, source provenance, deterministic bytes, and semantic
+   validation on both load and save.
+4. **NILMTK adapter.** Convert timestamped NILMTK chunks into the private
+   training contract without relaxing the leakage or dense-window checks.
+5. **LBM inference wrapper.** Add variance alternation and the non-negative
    total-variation unknown-load block, then expose `partial_fit` and
    `disaggregate_chunk`.
-4. **Scientific validation.** Compare the relaxation against tiny enumerated
+6. **Scientific validation.** Compare the relaxation against tiny enumerated
    cases; run T0 on real REDD; then run the full cross-building protocol before
    adding a leaderboard claim.
 

--- a/nilmtk_contrib/torch/_lbm_artifacts.py
+++ b/nilmtk_contrib/torch/_lbm_artifacts.py
@@ -1,0 +1,504 @@
+"""Safe, checksummed persistence for private LBM training artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import hmac
+import json
+import math
+from pathlib import Path
+from types import MappingProxyType
+from typing import Mapping
+
+import torch
+
+from nilmtk_contrib.torch._lbm import (
+    GaussianRatioSummary,
+    StructuredAppliance,
+    _finite_real,
+    _positive_int,
+    _prepare_appliances,
+)
+from nilmtk_contrib.torch._lbm_training import (
+    LBMTrainingResult,
+    SourceWindow,
+    _markov_reward_moments,
+    _windows_overlap,
+    assert_disjoint_sources,
+)
+from nilmtk_contrib.utils.checkpoints import save_json_atomic
+
+
+ARTIFACT_FILENAME = "lbm-training.json"
+ARTIFACT_TYPE = "nilmtk-contrib-lbm-training"
+ARTIFACT_SCHEMA_VERSION = 1
+MAX_ARTIFACT_BYTES = 16 * 1024 * 1024
+_TRAINING_ALGORITHM = "deterministic-1d-kmeans+hmm-counts"
+_SUMMARY_NAMES = ("energy_wh", "duration_minutes")
+
+
+def _canonical_json(payload: dict) -> bytes:
+    try:
+        encoded = json.dumps(
+            payload,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise ValueError(
+            "LBM artifact payload must be finite and JSON-serializable."
+        ) from exc
+    return encoded.encode("utf-8")
+
+
+def _payload_digest(payload: dict) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json(payload)).hexdigest()
+
+
+def _exact_keys(name: str, value, expected: set[str]) -> dict:
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must be a JSON object.")
+    actual = set(value)
+    if actual != expected:
+        missing = ", ".join(sorted(expected - actual)) or "none"
+        unknown = ", ".join(sorted(actual - expected)) or "none"
+        raise ValueError(
+            f"{name} fields do not match schema; missing: {missing}; unknown: {unknown}."
+        )
+    return value
+
+
+def _nonnegative_int(name: str, value) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{name} must be an integer.")
+    if value < 0:
+        raise ValueError(f"{name} must be non-negative.")
+    return value
+
+
+def _count_vector(name: str, value, length: int) -> tuple[int, ...]:
+    if not isinstance(value, list) or len(value) != length:
+        raise ValueError(f"{name} must contain exactly {length} counts.")
+    return tuple(
+        _nonnegative_int(f"{name}[{index}]", item) for index, item in enumerate(value)
+    )
+
+
+def _count_matrix(name: str, value, size: int) -> tuple[tuple[int, ...], ...]:
+    if not isinstance(value, list) or len(value) != size:
+        raise ValueError(f"{name} must contain exactly {size} rows.")
+    return tuple(
+        _count_vector(f"{name}[{index}]", row, size) for index, row in enumerate(value)
+    )
+
+
+def _sources(name: str, value) -> tuple[SourceWindow, ...]:
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be a JSON array.")
+    sources = []
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise ValueError(f"{name}[{index}] must be a JSON object.")
+        try:
+            sources.append(SourceWindow(**item))
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid {name}[{index}]: {exc}") from exc
+    return tuple(sources)
+
+
+def _probabilities_from_counts(
+    counts: torch.Tensor, pseudocount: float
+) -> torch.Tensor:
+    smoothed = counts.to(torch.float64) + pseudocount
+    return smoothed / smoothed.sum(dim=-1, keepdim=True)
+
+
+def _require_close(name: str, actual, expected) -> None:
+    actual_tensor = torch.as_tensor(actual, dtype=torch.float64)
+    expected_tensor = torch.as_tensor(expected, dtype=torch.float64)
+    if actual_tensor.shape != expected_tensor.shape or not torch.allclose(
+        actual_tensor,
+        expected_tensor,
+        atol=1e-12,
+        rtol=1e-12,
+    ):
+        raise ValueError(f"{name} do not match the persisted raw counts.")
+
+
+_TRAINING_FIELDS = {
+    "schema_version",
+    "algorithm",
+    "sources",
+    "evaluation_sources",
+    "num_samples",
+    "window_length",
+    "sample_period_seconds",
+    "state_means",
+    "initial_probabilities",
+    "transition_probabilities",
+    "off_state",
+    "cycle_probabilities",
+    "state_counts",
+    "initial_counts",
+    "transition_counts",
+    "cycle_counts",
+    "emission_variance",
+    "pseudocount",
+    "minimum_windows_per_cycle",
+    "variance_floor",
+    "kmeans_max_iterations",
+    "allow_temporal_evaluation",
+    "summaries",
+}
+
+_SUMMARY_FIELDS = {
+    "name",
+    "state_weights",
+    "conditional_means",
+    "conditional_variance",
+    "induced_mean",
+    "induced_variance",
+    "weight",
+}
+
+
+def _training_result_from_metadata(metadata, *, label: str) -> LBMTrainingResult:
+    metadata = _exact_keys(label, metadata, _TRAINING_FIELDS)
+    if metadata["schema_version"] != 1:
+        raise ValueError(f"{label}.schema_version must be 1.")
+    if metadata["algorithm"] != _TRAINING_ALGORITHM:
+        raise ValueError(f"{label}.algorithm is unsupported.")
+    sources = _sources(f"{label}.sources", metadata["sources"])
+    if not sources:
+        raise ValueError(f"{label}.sources must be non-empty.")
+    evaluation_sources = _sources(
+        f"{label}.evaluation_sources", metadata["evaluation_sources"]
+    )
+    num_samples = _positive_int(f"{label}.num_samples", metadata["num_samples"])
+    window_length = _positive_int(f"{label}.window_length", metadata["window_length"])
+    sample_period = _positive_int(
+        f"{label}.sample_period_seconds", metadata["sample_period_seconds"]
+    )
+    pseudocount = _finite_real(
+        f"{label}.pseudocount", metadata["pseudocount"], positive=True
+    )
+    minimum_windows_per_cycle = _positive_int(
+        f"{label}.minimum_windows_per_cycle",
+        metadata["minimum_windows_per_cycle"],
+    )
+    variance_floor = _finite_real(
+        f"{label}.variance_floor", metadata["variance_floor"], positive=True
+    )
+    kmeans_max_iterations = _positive_int(
+        f"{label}.kmeans_max_iterations", metadata["kmeans_max_iterations"]
+    )
+    allow_temporal = metadata["allow_temporal_evaluation"]
+    if not isinstance(allow_temporal, bool):
+        raise ValueError(f"{label}.allow_temporal_evaluation must be a boolean.")
+    emission_variance = _finite_real(
+        f"{label}.emission_variance", metadata["emission_variance"], positive=True
+    )
+
+    try:
+        state_means = torch.as_tensor(metadata["state_means"], dtype=torch.float64)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(f"{label}.state_means must be numeric.") from exc
+    if state_means.ndim != 1 or state_means.numel() < 2:
+        raise ValueError(f"{label}.state_means must contain at least two states.")
+    if not bool(torch.isfinite(state_means).all()):
+        raise ValueError(f"{label}.state_means must be finite.")
+    state_count = int(state_means.numel())
+    off_state = _nonnegative_int(f"{label}.off_state", metadata["off_state"])
+    if off_state >= state_count or off_state != int(torch.argmin(state_means)):
+        raise ValueError(f"{label}.off_state must identify the lowest-mean state.")
+
+    cycle_values = metadata["cycle_probabilities"]
+    if not isinstance(cycle_values, list) or not cycle_values:
+        raise ValueError(f"{label}.cycle_probabilities must be a non-empty array.")
+    cycle_categories = len(cycle_values)
+    state_counts = _count_vector(
+        f"{label}.state_counts", metadata["state_counts"], state_count
+    )
+    initial_counts = _count_vector(
+        f"{label}.initial_counts", metadata["initial_counts"], state_count
+    )
+    transition_counts = _count_matrix(
+        f"{label}.transition_counts", metadata["transition_counts"], state_count
+    )
+    cycle_counts = _count_vector(
+        f"{label}.cycle_counts", metadata["cycle_counts"], cycle_categories
+    )
+    window_count = len(sources)
+    if num_samples != window_count * window_length:
+        raise ValueError(f"{label}.num_samples does not match source/window counts.")
+    if sum(state_counts) != num_samples:
+        raise ValueError(f"{label}.state_counts do not sum to num_samples.")
+    if sum(initial_counts) != window_count:
+        raise ValueError(f"{label}.initial_counts do not sum to the window count.")
+    expected_transitions = window_count * max(0, window_length - 1)
+    if sum(sum(row) for row in transition_counts) != expected_transitions:
+        raise ValueError(f"{label}.transition_counts do not match window boundaries.")
+    if sum(cycle_counts) != window_count:
+        raise ValueError(f"{label}.cycle_counts do not sum to the window count.")
+    if any(count < minimum_windows_per_cycle for count in cycle_counts):
+        raise ValueError(f"{label}.cycle_counts violate minimum_windows_per_cycle.")
+
+    expected_seconds = window_length * sample_period
+    for index, source in enumerate(sources):
+        if source.sample_period_seconds != sample_period:
+            raise ValueError(f"{label}.sources[{index}] has a different sample period.")
+        start, end = source.interval
+        if not math.isclose(end - start, expected_seconds, abs_tol=1e-6, rel_tol=0):
+            raise ValueError(f"{label}.sources[{index}] duration is inconsistent.")
+        for previous in sources[:index]:
+            if _windows_overlap(previous, source):
+                raise ValueError(f"{label}.sources contain overlapping evidence.")
+    assert_disjoint_sources(
+        sources,
+        evaluation_sources,
+        allow_temporal_split=allow_temporal,
+    )
+
+    summaries_value = metadata["summaries"]
+    if not isinstance(summaries_value, list) or len(summaries_value) != 2:
+        raise ValueError(f"{label}.summaries must contain energy and duration.")
+    summaries = []
+    for index, expected_name in enumerate(_SUMMARY_NAMES):
+        item = _exact_keys(
+            f"{label}.summaries[{index}]",
+            summaries_value[index],
+            _SUMMARY_FIELDS,
+        )
+        if item["name"] != expected_name:
+            raise ValueError(
+                f"{label}.summaries[{index}].name must be {expected_name!r}."
+            )
+        summaries.append(
+            GaussianRatioSummary(
+                state_weights=tuple(float(value) for value in item["state_weights"]),
+                conditional_means=tuple(
+                    float(value) for value in item["conditional_means"]
+                ),
+                conditional_variance=item["conditional_variance"],
+                induced_mean=item["induced_mean"],
+                induced_variance=item["induced_variance"],
+                weight=item["weight"],
+            )
+        )
+    appliance = StructuredAppliance(
+        state_means=tuple(float(value) for value in state_means),
+        initial_probabilities=tuple(
+            float(value) for value in metadata["initial_probabilities"]
+        ),
+        transition_probabilities=tuple(
+            tuple(float(value) for value in row)
+            for row in metadata["transition_probabilities"]
+        ),
+        off_state=off_state,
+        cycle_probabilities=tuple(float(value) for value in cycle_values),
+        summaries=tuple(summaries),
+    )
+    _prepare_appliances(
+        [appliance],
+        time_points=window_length,
+        device=torch.device("cpu"),
+        dtype=torch.float64,
+    )
+
+    expected_initial = _probabilities_from_counts(
+        torch.tensor(initial_counts), pseudocount
+    )
+    expected_transition = _probabilities_from_counts(
+        torch.tensor(transition_counts), pseudocount
+    )
+    expected_cycles = _probabilities_from_counts(
+        torch.tensor(cycle_counts), pseudocount
+    )
+    _require_close(
+        f"{label}.initial_probabilities",
+        metadata["initial_probabilities"],
+        expected_initial,
+    )
+    _require_close(
+        f"{label}.transition_probabilities",
+        metadata["transition_probabilities"],
+        expected_transition,
+    )
+    _require_close(
+        f"{label}.cycle_probabilities",
+        cycle_values,
+        expected_cycles,
+    )
+
+    initial_tensor = torch.as_tensor(
+        metadata["initial_probabilities"], dtype=torch.float64
+    )
+    transition_tensor = torch.as_tensor(
+        metadata["transition_probabilities"], dtype=torch.float64
+    )
+    for index, summary in enumerate(summaries):
+        induced_mean, induced_variance = _markov_reward_moments(
+            initial_tensor,
+            transition_tensor,
+            torch.as_tensor(summary.state_weights, dtype=torch.float64),
+            window_length,
+        )
+        if not math.isclose(
+            induced_mean, summary.induced_mean, rel_tol=1e-10, abs_tol=1e-10
+        ) or not math.isclose(
+            induced_variance,
+            summary.induced_variance,
+            rel_tol=1e-10,
+            abs_tol=1e-10,
+        ):
+            raise ValueError(
+                f"{label}.summaries[{index}] induced moments do not match the HMM."
+            )
+
+    result = LBMTrainingResult(
+        appliance=appliance,
+        sources=sources,
+        evaluation_sources=evaluation_sources,
+        num_samples=num_samples,
+        window_length=window_length,
+        sample_period_seconds=sample_period,
+        state_counts=state_counts,
+        initial_counts=initial_counts,
+        transition_counts=transition_counts,
+        cycle_counts=cycle_counts,
+        emission_variance=emission_variance,
+        pseudocount=pseudocount,
+        minimum_windows_per_cycle=minimum_windows_per_cycle,
+        variance_floor=variance_floor,
+        kmeans_max_iterations=kmeans_max_iterations,
+        allow_temporal_evaluation=allow_temporal,
+    )
+    if result.metadata() != metadata:
+        raise ValueError(f"{label} is not in canonical artifact form.")
+    return result
+
+
+@dataclass(frozen=True)
+class LBMTrainingBundle:
+    """Immutable, schema-validated collection of fitted LBM appliances."""
+
+    appliances: Mapping[str, LBMTrainingResult]
+
+    def __post_init__(self):
+        if not isinstance(self.appliances, Mapping) or not self.appliances:
+            raise ValueError("appliances must be a non-empty mapping.")
+        validated = {}
+        for raw_name, raw_result in self.appliances.items():
+            if not isinstance(raw_name, str) or not raw_name.strip():
+                raise ValueError("appliance names must be non-empty strings.")
+            name = raw_name.strip()
+            if name in validated:
+                raise ValueError(f"Duplicate normalized appliance name {name!r}.")
+            if not isinstance(raw_result, LBMTrainingResult):
+                raise TypeError(f"appliances[{name!r}] must be an LBMTrainingResult.")
+            validated[name] = _training_result_from_metadata(
+                raw_result.metadata(),
+                label=f"appliances[{name!r}]",
+            )
+        results = tuple(validated.values())
+        if len({result.window_length for result in results}) != 1:
+            raise ValueError("All LBM appliances must use the same window length.")
+        if len({result.sample_period_seconds for result in results}) != 1:
+            raise ValueError("All LBM appliances must use the same sample period.")
+        if len({result.evaluation_sources for result in results}) != 1:
+            raise ValueError(
+                "All LBM appliances must declare the same evaluation sources."
+            )
+        if len({result.allow_temporal_evaluation for result in results}) != 1:
+            raise ValueError("All LBM appliances must use the same leakage policy.")
+        object.__setattr__(
+            self,
+            "appliances",
+            MappingProxyType(dict(sorted(validated.items()))),
+        )
+
+    def metadata(self) -> dict:
+        return {
+            "artifact_type": ARTIFACT_TYPE,
+            "schema_version": ARTIFACT_SCHEMA_VERSION,
+            "appliances": {
+                name: result.metadata() for name, result in self.appliances.items()
+            },
+        }
+
+
+def _artifact_envelope(bundle: LBMTrainingBundle) -> dict:
+    payload = bundle.metadata()
+    return {**payload, "payload_sha256": _payload_digest(payload)}
+
+
+def save_lbm_training_bundle(path, bundle: LBMTrainingBundle) -> Path:
+    """Atomically save a deterministic, non-executable LBM JSON artifact."""
+    if not isinstance(bundle, LBMTrainingBundle):
+        raise TypeError("bundle must be an LBMTrainingBundle.")
+    # Revalidate at the persistence boundary rather than trusting a long-lived
+    # in-memory object graph.
+    bundle = LBMTrainingBundle(bundle.appliances)
+    target = Path(path) / ARTIFACT_FILENAME
+    save_json_atomic(target, _artifact_envelope(bundle))
+    return target
+
+
+def load_lbm_training_bundle(path) -> LBMTrainingBundle:
+    """Load and semantically validate a checksummed LBM JSON artifact."""
+    target = Path(path) / ARTIFACT_FILENAME
+    if target.stat().st_size > MAX_ARTIFACT_BYTES:
+        raise ValueError(
+            f"LBM artifact exceeds the {MAX_ARTIFACT_BYTES}-byte safety limit."
+        )
+    try:
+        with target.open(encoding="utf-8") as handle:
+            envelope = json.load(handle)
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise ValueError("LBM artifact is not valid UTF-8 JSON.") from exc
+    envelope = _exact_keys(
+        "artifact",
+        envelope,
+        {"artifact_type", "schema_version", "appliances", "payload_sha256"},
+    )
+    if envelope["artifact_type"] != ARTIFACT_TYPE:
+        raise ValueError("Unsupported LBM artifact_type.")
+    if envelope["schema_version"] != ARTIFACT_SCHEMA_VERSION:
+        raise ValueError("Unsupported LBM artifact schema_version.")
+    supplied_digest = envelope["payload_sha256"]
+    if not isinstance(supplied_digest, str):
+        raise ValueError("LBM artifact payload_sha256 must be a string.")
+    payload = {key: value for key, value in envelope.items() if key != "payload_sha256"}
+    expected_digest = _payload_digest(payload)
+    if not hmac.compare_digest(supplied_digest, expected_digest):
+        raise ValueError("LBM artifact checksum mismatch; the file is corrupt.")
+    appliances_value = payload["appliances"]
+    if not isinstance(appliances_value, dict) or not appliances_value:
+        raise ValueError("LBM artifact appliances must be a non-empty object.")
+    try:
+        results = {
+            name: _training_result_from_metadata(
+                metadata,
+                label=f"appliances[{name!r}]",
+            )
+            for name, metadata in appliances_value.items()
+        }
+    except (TypeError, RuntimeError, OverflowError) as exc:
+        raise ValueError(f"LBM artifact contains invalid model data: {exc}") from exc
+    bundle = LBMTrainingBundle(results)
+    if bundle.metadata() != payload:
+        raise ValueError("LBM artifact is not in canonical form.")
+    return bundle
+
+
+__all__ = [
+    "ARTIFACT_FILENAME",
+    "ARTIFACT_SCHEMA_VERSION",
+    "ARTIFACT_TYPE",
+    "LBMTrainingBundle",
+    "load_lbm_training_bundle",
+    "save_lbm_training_bundle",
+]

--- a/nilmtk_contrib/torch/_lbm_training.py
+++ b/nilmtk_contrib/torch/_lbm_training.py
@@ -114,6 +114,8 @@ class LBMTrainingResult:
     window_length: int
     sample_period_seconds: int
     state_counts: tuple[int, ...]
+    initial_counts: tuple[int, ...]
+    transition_counts: tuple[tuple[int, ...], ...]
     cycle_counts: tuple[int, ...]
     emission_variance: float
     pseudocount: float
@@ -131,13 +133,16 @@ class LBMTrainingResult:
             summaries.append(
                 {
                     "name": name,
-                    "state_weights": torch.as_tensor(summary.state_weights).tolist(),
+                    "state_weights": torch.as_tensor(
+                        summary.state_weights, dtype=torch.float64
+                    ).tolist(),
                     "conditional_means": torch.as_tensor(
-                        summary.conditional_means
+                        summary.conditional_means, dtype=torch.float64
                     ).tolist(),
                     "conditional_variance": summary.conditional_variance,
                     "induced_mean": summary.induced_mean,
                     "induced_variance": summary.induced_variance,
+                    "weight": summary.weight,
                 }
             )
         return {
@@ -150,17 +155,22 @@ class LBMTrainingResult:
             "num_samples": self.num_samples,
             "window_length": self.window_length,
             "sample_period_seconds": self.sample_period_seconds,
-            "state_means": torch.as_tensor(self.appliance.state_means).tolist(),
+            "state_means": torch.as_tensor(
+                self.appliance.state_means, dtype=torch.float64
+            ).tolist(),
             "initial_probabilities": torch.as_tensor(
-                self.appliance.initial_probabilities
+                self.appliance.initial_probabilities, dtype=torch.float64
             ).tolist(),
             "transition_probabilities": torch.as_tensor(
-                self.appliance.transition_probabilities
+                self.appliance.transition_probabilities, dtype=torch.float64
             ).tolist(),
+            "off_state": self.appliance.off_state,
             "cycle_probabilities": torch.as_tensor(
-                self.appliance.cycle_probabilities
+                self.appliance.cycle_probabilities, dtype=torch.float64
             ).tolist(),
             "state_counts": list(self.state_counts),
+            "initial_counts": list(self.initial_counts),
+            "transition_counts": [list(row) for row in self.transition_counts],
             "cycle_counts": list(self.cycle_counts),
             "emission_variance": self.emission_variance,
             "pseudocount": self.pseudocount,
@@ -601,6 +611,10 @@ def fit_lbm_appliance(
         window_length=window_length,
         sample_period_seconds=sample_period,
         state_counts=tuple(int(value) for value in state_counts),
+        initial_counts=tuple(int(value) for value in initial_counts),
+        transition_counts=tuple(
+            tuple(int(value) for value in row) for row in transition_counts
+        ),
         cycle_counts=tuple(int(value) for value in cycle_counts),
         emission_variance=emission_variance,
         pseudocount=pseudocount,

--- a/nilmtk_contrib/utils/checkpoints.py
+++ b/nilmtk_contrib/utils/checkpoints.py
@@ -113,23 +113,30 @@ def save_metadata(path, metadata):
 def save_metadata_atomic(path, metadata):
     """Atomically publish metadata as the commit marker for a checkpoint set."""
     folder = Path(path)
-    folder.mkdir(parents=True, exist_ok=True)
+    save_json_atomic(folder / METADATA_FILENAME, metadata)
+
+
+def save_json_atomic(path, payload):
+    """Atomically replace a JSON file with deterministic, host-readable output."""
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
     temporary = None
     try:
         with tempfile.NamedTemporaryFile(
             "w",
             encoding="utf-8",
-            dir=folder,
-            prefix=f".{METADATA_FILENAME}.",
+            dir=target.parent,
+            prefix=f".{target.name}.",
             delete=False,
         ) as handle:
-            json.dump(metadata, handle, indent=2, sort_keys=True)
+            json.dump(payload, handle, allow_nan=False, indent=2, sort_keys=True)
             handle.write("\n")
             handle.flush()
             os.fsync(handle.fileno())
             temporary = Path(handle.name)
-        os.replace(temporary, folder / METADATA_FILENAME)
+        os.replace(temporary, target)
         temporary = None
+        target.chmod(0o644)
     finally:
         if temporary is not None:
             temporary.unlink(missing_ok=True)

--- a/tests/lbm_training_data.py
+++ b/tests/lbm_training_data.py
@@ -1,0 +1,58 @@
+"""Shared synthetic LBM population windows for focused tests."""
+
+from datetime import datetime, timedelta, timezone
+
+import torch
+
+from nilmtk_contrib.torch._lbm_training import ApplianceTrainingWindow, SourceWindow
+
+
+FINGERPRINT = "sha256:" + "a" * 64
+POWER_WINDOWS = (
+    [0, 1, 0, 2, 0, 1],
+    [1, 0, 2, 1, 0, 2],
+    [2, 1, 0, 1, 2, 0],
+    [0, 90, 100, 100, 0, 0],
+    [0, 0, 95, 105, 0, 0],
+    [0, 110, 100, 0, 0, 0],
+    [0, 90, 0, 100, 0, 0],
+    [0, 80, 0, 110, 0, 0],
+    [0, 100, 0, 90, 0, 0],
+)
+
+
+def source_window(index, *, building="1", start=None, end=None, **overrides):
+    start_value = start or datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(
+        hours=index
+    )
+    if isinstance(start_value, str):
+        start_time = datetime.fromisoformat(start_value.replace("Z", "+00:00"))
+    else:
+        start_time = start_value
+    period = overrides.get("sample_period_seconds", 60)
+    end_value = end or start_time + timedelta(seconds=6 * max(period, 1))
+    params = {
+        "dataset": "REDD",
+        "dataset_version": "nilmtk-converted-v1",
+        "data_uri": "https://example.org/redd.h5",
+        "data_fingerprint": FINGERPRINT,
+        "building": building,
+        "start": (
+            start_value if isinstance(start_value, str) else start_value.isoformat()
+        ),
+        "end": end_value if isinstance(end_value, str) else end_value.isoformat(),
+        "sample_period_seconds": 60,
+    }
+    params.update(overrides)
+    return SourceWindow(**params)
+
+
+def training_windows():
+    return tuple(
+        ApplianceTrainingWindow(source_window(index), power)
+        for index, power in enumerate(POWER_WINDOWS)
+    )
+
+
+def tensor(value):
+    return torch.as_tensor(value, dtype=torch.float64)

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -14,6 +14,7 @@ from nilmtk_contrib.utils.checkpoints import (
     save_keras_weights,
     save_metadata,
     save_metadata_atomic,
+    save_json_atomic,
     save_torch_state,
     temporary_checkpoint,
     unsupported_persistence,
@@ -71,6 +72,21 @@ def test_atomic_metadata_publish_leaves_no_temporary_files(tmp_path):
 
     assert json.loads((tmp_path / "metadata.json").read_text()) == {"generation": 2}
     assert list(tmp_path.glob(".metadata.json.*")) == []
+
+
+def test_atomic_json_is_deterministic_host_readable_and_rejects_nan(tmp_path):
+    path = tmp_path / "nested" / "artifact.json"
+
+    save_json_atomic(path, {"z": 2, "a": 1})
+    first = path.read_bytes()
+    save_json_atomic(path, {"a": 1, "z": 2})
+
+    assert path.read_bytes() == first
+    assert path.stat().st_mode & 0o777 == 0o644
+    assert list(path.parent.glob(".artifact.json.*")) == []
+    with pytest.raises(ValueError, match="Out of range float values"):
+        save_json_atomic(path, {"invalid": float("nan")})
+    assert path.read_bytes() == first
 
 
 def test_load_metadata_rejects_missing_fields(tmp_path):

--- a/tests/test_lbm_artifacts.py
+++ b/tests/test_lbm_artifacts.py
@@ -1,0 +1,259 @@
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+import json
+
+import pytest
+
+
+torch = pytest.importorskip("torch")
+
+from nilmtk_contrib.torch._lbm_artifacts import (  # noqa: E402
+    ARTIFACT_FILENAME,
+    ARTIFACT_SCHEMA_VERSION,
+    ARTIFACT_TYPE,
+    LBMTrainingBundle,
+    _payload_digest,
+    load_lbm_training_bundle,
+    save_lbm_training_bundle,
+)
+from nilmtk_contrib.torch._lbm_training import (  # noqa: E402
+    ApplianceTrainingWindow,
+    fit_lbm_appliance,
+)
+from lbm_training_data import (  # noqa: E402
+    POWER_WINDOWS,
+    source_window,
+    training_windows,
+)
+
+
+def _evaluation_source(building="2"):
+    return source_window(100, building=building)
+
+
+def _training_result(*, evaluation_sources=(), allow_temporal_evaluation=False):
+    return fit_lbm_appliance(
+        training_windows(),
+        evaluation_sources=evaluation_sources,
+        allow_temporal_evaluation=allow_temporal_evaluation,
+    )
+
+
+def _read_envelope(path):
+    return json.loads((path / ARTIFACT_FILENAME).read_text(encoding="utf-8"))
+
+
+def _write_envelope(path, envelope, *, resign=True):
+    if resign:
+        payload = {
+            key: value for key, value in envelope.items() if key != "payload_sha256"
+        }
+        envelope["payload_sha256"] = _payload_digest(payload)
+    (path / ARTIFACT_FILENAME).write_text(
+        json.dumps(envelope, allow_nan=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_bundle_round_trip_is_deterministic_read_only_and_auditable(tmp_path):
+    result = _training_result(evaluation_sources=(_evaluation_source(),))
+    bundle = LBMTrainingBundle({"fridge": result})
+
+    target = save_lbm_training_bundle(tmp_path, bundle)
+    first = target.read_bytes()
+    loaded = load_lbm_training_bundle(tmp_path)
+    save_lbm_training_bundle(tmp_path, loaded)
+
+    assert target.read_bytes() == first
+    assert target.stat().st_mode & 0o777 == 0o644
+    assert list(tmp_path.glob(f".{ARTIFACT_FILENAME}.*")) == []
+    assert loaded.metadata() == bundle.metadata()
+    assert loaded.appliances["fridge"].metadata() == result.metadata()
+    with pytest.raises(TypeError):
+        loaded.appliances["kettle"] = result
+
+
+def test_bundle_writes_sorted_appliances_and_checksums_the_payload(tmp_path):
+    result = _training_result()
+    bundle = LBMTrainingBundle({"washing machine": result, "fridge": result})
+
+    save_lbm_training_bundle(tmp_path, bundle)
+    envelope = _read_envelope(tmp_path)
+    payload = {key: value for key, value in envelope.items() if key != "payload_sha256"}
+
+    assert list(envelope["appliances"]) == ["fridge", "washing machine"]
+    assert envelope["artifact_type"] == ARTIFACT_TYPE
+    assert envelope["schema_version"] == ARTIFACT_SCHEMA_VERSION
+    assert envelope["payload_sha256"] == _payload_digest(payload)
+
+
+def test_loader_rejects_corruption_before_reconstructing_models(tmp_path):
+    save_lbm_training_bundle(
+        tmp_path,
+        LBMTrainingBundle({"fridge": _training_result()}),
+    )
+    envelope = _read_envelope(tmp_path)
+    envelope["appliances"]["fridge"]["state_means"][1] += 1
+    _write_envelope(tmp_path, envelope, resign=False)
+
+    with pytest.raises(ValueError, match="checksum mismatch"):
+        load_lbm_training_bundle(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (
+            lambda metadata: metadata["initial_probabilities"].__setitem__(
+                slice(None), [0.5, 0.5]
+            ),
+            "initial_probabilities.*raw counts",
+        ),
+        (
+            lambda metadata: metadata["state_counts"].__setitem__(
+                0, metadata["state_counts"][0] + 1
+            ),
+            "state_counts do not sum",
+        ),
+        (
+            lambda metadata: metadata["summaries"][0].__setitem__(
+                "induced_mean", metadata["summaries"][0]["induced_mean"] + 1
+            ),
+            "induced moments do not match",
+        ),
+        (
+            lambda metadata: metadata["evaluation_sources"].append(
+                metadata["sources"][0]
+            ),
+            "Training/evaluation leakage",
+        ),
+    ],
+)
+def test_loader_rejects_resigned_but_semantically_false_artifacts(
+    tmp_path, mutation, message
+):
+    save_lbm_training_bundle(
+        tmp_path,
+        LBMTrainingBundle({"fridge": _training_result()}),
+    )
+    envelope = _read_envelope(tmp_path)
+    mutation(envelope["appliances"]["fridge"])
+    _write_envelope(tmp_path, envelope)
+
+    with pytest.raises(ValueError, match=message):
+        load_lbm_training_bundle(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({}, "fields do not match schema"),
+        (
+            {
+                "artifact_type": "wrong",
+                "schema_version": ARTIFACT_SCHEMA_VERSION,
+                "appliances": {},
+                "payload_sha256": "sha256:invalid",
+            },
+            "Unsupported LBM artifact_type",
+        ),
+    ],
+)
+def test_loader_rejects_invalid_envelopes(tmp_path, payload, message):
+    _write_envelope(tmp_path, payload, resign=False)
+
+    with pytest.raises(ValueError, match=message):
+        load_lbm_training_bundle(tmp_path)
+
+
+def test_loader_rejects_malformed_json_and_oversized_files(tmp_path, monkeypatch):
+    target = tmp_path / ARTIFACT_FILENAME
+    target.write_bytes(b"\xffnot-json")
+    with pytest.raises(ValueError, match="valid UTF-8 JSON"):
+        load_lbm_training_bundle(tmp_path)
+
+    target.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr("nilmtk_contrib.torch._lbm_artifacts.MAX_ARTIFACT_BYTES", 1)
+    with pytest.raises(ValueError, match="safety limit"):
+        load_lbm_training_bundle(tmp_path)
+
+
+def test_loader_rejects_excessive_json_nesting_with_a_validation_error(tmp_path):
+    depth = 2_000
+    (tmp_path / ARTIFACT_FILENAME).write_text(
+        "[" * depth + "0" + "]" * depth,
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError):
+        load_lbm_training_bundle(tmp_path)
+
+
+def test_bundle_rejects_cross_appliance_contract_mismatches():
+    result = _training_result(evaluation_sources=(_evaluation_source(),))
+    different_evaluation = replace(
+        result,
+        evaluation_sources=(_evaluation_source(building="3"),),
+    )
+    temporal_policy = replace(result, allow_temporal_evaluation=True)
+
+    with pytest.raises(ValueError, match="same evaluation sources"):
+        LBMTrainingBundle({"fridge": result, "kettle": different_evaluation})
+    with pytest.raises(ValueError, match="same leakage policy"):
+        LBMTrainingBundle({"fridge": result, "kettle": temporal_policy})
+
+
+def test_bundle_rejects_different_sample_periods_and_window_lengths():
+    result = _training_result()
+    thirty_second_windows = tuple(
+        ApplianceTrainingWindow(
+            source_window(index, sample_period_seconds=30),
+            power,
+        )
+        for index, power in enumerate(POWER_WINDOWS)
+    )
+    thirty_second_result = fit_lbm_appliance(thirty_second_windows)
+
+    start = datetime(2026, 2, 1, tzinfo=timezone.utc)
+    longer_windows = tuple(
+        ApplianceTrainingWindow(
+            source_window(
+                index,
+                start=start + timedelta(hours=index),
+                end=start + timedelta(hours=index, minutes=7),
+            ),
+            [*power, 0],
+        )
+        for index, power in enumerate(POWER_WINDOWS)
+    )
+    longer_result = fit_lbm_appliance(longer_windows)
+
+    with pytest.raises(ValueError, match="same sample period"):
+        LBMTrainingBundle({"fridge": result, "kettle": thirty_second_result})
+    with pytest.raises(ValueError, match="same window length"):
+        LBMTrainingBundle({"fridge": result, "kettle": longer_result})
+
+
+def test_bundle_rejects_ambiguous_names_and_non_results():
+    result = _training_result()
+
+    with pytest.raises(ValueError, match="Duplicate normalized"):
+        LBMTrainingBundle({"fridge": result, " fridge ": result})
+    with pytest.raises(ValueError, match="non-empty strings"):
+        LBMTrainingBundle({" ": result})
+    with pytest.raises(TypeError, match="LBMTrainingResult"):
+        LBMTrainingBundle({"fridge": object()})
+
+
+def test_save_requires_a_validated_bundle(tmp_path):
+    with pytest.raises(TypeError, match="LBMTrainingBundle"):
+        save_lbm_training_bundle(tmp_path, {"fridge": _training_result()})
+
+
+def test_bundle_freezes_fitted_numeric_sequences():
+    bundle = LBMTrainingBundle({"fridge": _training_result()})
+    probabilities = bundle.appliances["fridge"].appliance.initial_probabilities
+
+    assert isinstance(probabilities, tuple)
+    with pytest.raises(TypeError):
+        probabilities[0] = 0.5

--- a/tests/test_lbm_training.py
+++ b/tests/test_lbm_training.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from itertools import product
 import json
 import math
@@ -11,63 +11,18 @@ torch = pytest.importorskip("torch")
 from nilmtk_contrib.torch._lbm import solve_structured_relaxation  # noqa: E402
 from nilmtk_contrib.torch._lbm_training import (  # noqa: E402
     ApplianceTrainingWindow,
-    SourceWindow,
     _fit_summary,
     _markov_reward_moments,
     assert_disjoint_sources,
     fit_lbm_appliance,
 )
-
-
-FINGERPRINT = "sha256:" + "a" * 64
-POWER_WINDOWS = (
-    [0, 1, 0, 2, 0, 1],
-    [1, 0, 2, 1, 0, 2],
-    [2, 1, 0, 1, 2, 0],
-    [0, 90, 100, 100, 0, 0],
-    [0, 0, 95, 105, 0, 0],
-    [0, 110, 100, 0, 0, 0],
-    [0, 90, 0, 100, 0, 0],
-    [0, 80, 0, 110, 0, 0],
-    [0, 100, 0, 90, 0, 0],
+from lbm_training_data import (  # noqa: E402
+    FINGERPRINT,
+    POWER_WINDOWS,
+    source_window as _source,
+    tensor as _tensor,
+    training_windows as _windows,
 )
-
-
-def _source(index, *, building="1", start=None, end=None, **overrides):
-    start_value = start or datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(
-        hours=index
-    )
-    if isinstance(start_value, str):
-        start_time = datetime.fromisoformat(start_value.replace("Z", "+00:00"))
-    else:
-        start_time = start_value
-    period = overrides.get("sample_period_seconds", 60)
-    end_value = end or start_time + timedelta(seconds=6 * max(period, 1))
-    params = {
-        "dataset": "REDD",
-        "dataset_version": "nilmtk-converted-v1",
-        "data_uri": "https://example.org/redd.h5",
-        "data_fingerprint": FINGERPRINT,
-        "building": building,
-        "start": (
-            start_value if isinstance(start_value, str) else start_value.isoformat()
-        ),
-        "end": end_value if isinstance(end_value, str) else end_value.isoformat(),
-        "sample_period_seconds": 60,
-    }
-    params.update(overrides)
-    return SourceWindow(**params)
-
-
-def _windows():
-    return tuple(
-        ApplianceTrainingWindow(_source(index), power)
-        for index, power in enumerate(POWER_WINDOWS)
-    )
-
-
-def _tensor(value):
-    return torch.as_tensor(value, dtype=torch.float64)
 
 
 def test_fitter_builds_a_kernel_ready_appliance_with_complete_metadata():
@@ -94,12 +49,18 @@ def test_fitter_builds_a_kernel_ready_appliance_with_complete_metadata():
     assert result.num_samples == 54
     assert result.window_length == 6
     assert result.sample_period_seconds == 60
+    assert sum(result.state_counts) == 54
+    assert result.initial_counts == (9, 0)
+    assert sum(sum(row) for row in result.transition_counts) == 45
     assert result.cycle_counts == (3, 3, 3)
     assert result.emission_variance > 0
 
     metadata = result.metadata()
     assert json.loads(json.dumps(metadata)) == metadata
     assert metadata["schema_version"] == 1
+    assert metadata["initial_counts"] == [9, 0]
+    assert sum(sum(row) for row in metadata["transition_counts"]) == 45
+    assert metadata["off_state"] == 0
     assert metadata["evaluation_sources"] == []
     assert metadata["allow_temporal_evaluation"] is False
     assert metadata["sources"][0]["data_fingerprint"] == FINGERPRINT
@@ -107,6 +68,7 @@ def test_fitter_builds_a_kernel_ready_appliance_with_complete_metadata():
         "energy_wh",
         "duration_minutes",
     ]
+    assert [summary["weight"] for summary in metadata["summaries"]] == [1.0, 1.0]
 
     inferred = solve_structured_relaxation(
         POWER_WINDOWS[3],


### PR DESCRIPTION
## Summary

- persist fitted private LBM appliances in one deterministic, schema-versioned JSON bundle
- retain raw HMM counts and rederive smoothed probabilities, source boundaries, leakage policy, and induced moments while loading
- use size limits, a corruption checksum, immutable float64 reconstruction, atomic replacement, and no executable deserialization
- share the generic atomic JSON writer and reduce duplicated LBM test data

This remains a private implementation layer. It does not export LBM, add it to the model catalog, or claim a benchmark result.

## Verification

- `ruff check nilmtk_contrib tests scripts`
- `pytest -q` — 816 passed, 101 skipped
- focused persistence/training suite — 60 passed
- `uv build` — source distribution and wheel built successfully; wheel contains `_lbm.py`, `_lbm_training.py`, and `_lbm_artifacts.py`

The artifact checksum detects accidental corruption; it is intentionally documented as a checksum, not an authenticity signature.
