### PR TITLE
Add exact semi-Markov dynamic programming core

### DIFF
--- a/docs/explicit-duration-models.md
+++ b/docs/explicit-duration-models.md
@@ -1,0 +1,37 @@
+# Explicit-duration models for NILM
+
+## Why add them
+
+An ordinary HMM implies a geometric dwell-time distribution. That is a poor
+default for appliances whose off, heating, cooling, or cycle states have
+characteristic durations. A hidden semi-Markov model (HSMM) separates the
+probability of the next state from the probability of the current state's
+duration.
+
+This is established model structure, not a new NILM claim. Useful primary
+references are:
+
+- [Explicit-Duration Markov Switching Models](https://arxiv.org/abs/1909.05800)
+- [A time-efficient factorial hidden Semi-Markov model for non-intrusive load monitoring](https://doi.org/10.1016/j.epsr.2021.107372)
+- [Neural Semi-Markov Conditional Random Fields](https://aclanthology.org/N19-1280/)
+
+## Shared exact core
+
+`nilmtk_contrib.torch._semi_markov` is a private PyTorch implementation of the
+semi-Markov forward and Viterbi recurrences. It accepts per-sample emission,
+initial-state, between-segment transition, and segment-duration scores. The
+transition diagonal must be negative infinity: state persistence is represented
+only by duration, so every state sequence has one maximal-segment encoding.
+
+The forward recurrence gives an exact differentiable log-partition. Viterbi
+gives the exact best segmentation and uses the same score contract. This one
+core will support both planned models:
+
+1. a classical explicit-duration HSMM with fitted Gaussian emissions and
+   duration histograms;
+2. a neural semi-Markov model whose compact temporal encoder learns emission
+   scores while exact decoding still enforces duration and transition structure.
+
+The classical model, neural model, and NILMbench entries remain separate PRs.
+Neither model enters the public catalog until its complete training/inference
+wrapper and real-data T0 have passed.

--- a/nilmtk_contrib/torch/_semi_markov.py
+++ b/nilmtk_contrib/torch/_semi_markov.py
@@ -1,0 +1,388 @@
+"""Exact, differentiable semi-Markov dynamic programming primitives.
+
+The score of a segmentation is the sum of per-sample emission scores, one
+duration score per segment, an initial-state score, and transition scores
+between adjacent segments. Transition diagonals are forbidden so each state
+sequence has one unambiguous maximal-segment representation.
+
+This module is private. The classical explicit-duration HSMM and its neural
+semi-Markov counterpart share it so their decoding semantics cannot drift.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+
+_FLOAT_DTYPES = frozenset({torch.float32, torch.float64})
+_INTEGER_DTYPES = frozenset(
+    {
+        torch.int8,
+        torch.int16,
+        torch.int32,
+        torch.int64,
+        torch.uint8,
+    }
+)
+
+
+@dataclass(frozen=True)
+class SemiMarkovSegment:
+    """One half-open constant-state segment ``[start, end)``."""
+
+    state: int
+    start: int
+    end: int
+
+    @property
+    def duration(self) -> int:
+        return self.end - self.start
+
+
+@dataclass(frozen=True)
+class SemiMarkovViterbiResult:
+    """Highest-scoring state path and its maximal constant-state segments."""
+
+    states: torch.Tensor
+    segments: tuple[SemiMarkovSegment, ...]
+    score: float
+
+
+def _score_tensor(name, value, *, shape=None, reference=None) -> torch.Tensor:
+    if not isinstance(value, torch.Tensor):
+        raise TypeError(f"{name} must be a torch.Tensor.")
+    if value.dtype not in _FLOAT_DTYPES or value.is_complex():
+        raise TypeError(f"{name} must use torch.float32 or torch.float64.")
+    if shape is not None and tuple(value.shape) != tuple(shape):
+        raise ValueError(f"{name} must have shape {tuple(shape)}.")
+    if reference is not None:
+        if value.dtype != reference.dtype:
+            raise ValueError(f"{name} must use dtype {reference.dtype}.")
+        if value.device != reference.device:
+            raise ValueError(f"{name} must be on {reference.device}.")
+    if bool(torch.isnan(value).any()) or bool(torch.isposinf(value).any()):
+        raise ValueError(f"{name} must not contain NaN or positive infinity.")
+    return value
+
+
+def _validate_scores(
+    emission_scores,
+    initial_scores,
+    transition_scores,
+    duration_scores,
+) -> tuple[int, int, int]:
+    emissions = _score_tensor("emission_scores", emission_scores)
+    if emissions.ndim != 2 or emissions.shape[0] < 1 or emissions.shape[1] < 2:
+        raise ValueError(
+            "emission_scores must have shape (time, states) with time >= 1 "
+            "and states >= 2."
+        )
+    if not bool(torch.isfinite(emissions).all()):
+        raise ValueError("emission_scores must contain only finite values.")
+    time_points, states = emissions.shape
+    initial = _score_tensor(
+        "initial_scores",
+        initial_scores,
+        shape=(states,),
+        reference=emissions,
+    )
+    transitions = _score_tensor(
+        "transition_scores",
+        transition_scores,
+        shape=(states, states),
+        reference=emissions,
+    )
+    durations = _score_tensor(
+        "duration_scores",
+        duration_scores,
+        reference=emissions,
+    )
+    if durations.ndim != 2 or durations.shape[0] != states or durations.shape[1] < 1:
+        raise ValueError(f"duration_scores must have shape ({states}, max_duration).")
+    if not bool(torch.isfinite(initial).any()):
+        raise ValueError("initial_scores must allow at least one state.")
+    if not bool(torch.isneginf(torch.diagonal(transitions)).all()):
+        raise ValueError(
+            "transition_scores diagonal must be negative infinity; "
+            "durations, not self-transitions, represent state persistence."
+        )
+    if not bool(torch.isfinite(durations).any(dim=1).all()):
+        raise ValueError("Every state must allow at least one duration.")
+    return int(time_points), int(states), int(durations.shape[1])
+
+
+def _emission_prefix(emission_scores: torch.Tensor) -> torch.Tensor:
+    return torch.cat(
+        (
+            emission_scores.new_zeros((1, emission_scores.shape[1])),
+            torch.cumsum(emission_scores, dim=0),
+        ),
+        dim=0,
+    )
+
+
+def _safe_logsumexp(values: torch.Tensor, *, dim: int) -> torch.Tensor:
+    """Keep gradients finite for slices whose every path is forbidden."""
+    impossible = torch.isneginf(values).all(dim=dim)
+    safe_values = torch.where(
+        impossible.unsqueeze(dim),
+        torch.zeros_like(values),
+        values,
+    )
+    reduced = torch.logsumexp(safe_values, dim=dim)
+    return torch.where(
+        impossible,
+        torch.full_like(reduced, -torch.inf),
+        reduced,
+    )
+
+
+def semi_markov_log_partition(
+    emission_scores,
+    initial_scores,
+    transition_scores,
+    duration_scores,
+) -> torch.Tensor:
+    """Return the exact log-partition over all valid segmentations.
+
+    The result remains differentiable with respect to every finite score.
+    Runtime is ``O(T * K * D * K)`` in arithmetic but only ``O(T * K)`` in
+    stored dynamic-programming state, where ``D`` is the duration cap.
+    """
+
+    time_points, states, max_duration = _validate_scores(
+        emission_scores,
+        initial_scores,
+        transition_scores,
+        duration_scores,
+    )
+    prefix = _emission_prefix(emission_scores)
+    rows: list[torch.Tensor | None] = [None]
+    for end in range(1, time_points + 1):
+        length = min(max_duration, end)
+        starts = end - torch.arange(
+            1,
+            length + 1,
+            device=emission_scores.device,
+        )
+        earliest_positive_start = max(1, end - length)
+        if earliest_positive_start < end:
+            predecessors = torch.stack(rows[earliest_positive_start:end]).flip(0)
+        else:
+            predecessors = None
+
+        end_scores = []
+        for state in range(states):
+            segment = (
+                prefix[end, state]
+                - prefix[starts, state]
+                + duration_scores[state, :length]
+            )
+            candidates = []
+            if predecessors is not None:
+                transitioned = _safe_logsumexp(
+                    predecessors + transition_scores[:, state],
+                    dim=1,
+                )
+                candidates.append(transitioned + segment[: transitioned.numel()])
+            if end <= max_duration:
+                candidates.append((initial_scores[state] + segment[-1]).reshape(1))
+            end_scores.append(_safe_logsumexp(torch.cat(candidates), dim=0))
+        rows.append(torch.stack(end_scores))
+
+    result = _safe_logsumexp(rows[-1], dim=0)
+    if not bool(torch.isfinite(result)):
+        raise ValueError("No valid semi-Markov segmentation reaches the sequence end.")
+    return result
+
+
+@torch.no_grad()
+def semi_markov_viterbi(
+    emission_scores,
+    initial_scores,
+    transition_scores,
+    duration_scores,
+) -> SemiMarkovViterbiResult:
+    """Decode the exact highest-scoring semi-Markov state sequence."""
+
+    time_points, states, max_duration = _validate_scores(
+        emission_scores,
+        initial_scores,
+        transition_scores,
+        duration_scores,
+    )
+    prefix = _emission_prefix(emission_scores)
+    best = emission_scores.new_full((time_points + 1, states), -torch.inf)
+    previous_state = torch.full(
+        (time_points + 1, states),
+        -1,
+        dtype=torch.int64,
+        device=emission_scores.device,
+    )
+    best_duration = torch.zeros_like(previous_state)
+
+    for end in range(1, time_points + 1):
+        length = min(max_duration, end)
+        starts = end - torch.arange(
+            1,
+            length + 1,
+            device=emission_scores.device,
+        )
+        earliest_positive_start = max(1, end - length)
+        predecessor_rows = best[earliest_positive_start:end].flip(0)
+        for state in range(states):
+            segment = (
+                prefix[end, state]
+                - prefix[starts, state]
+                + duration_scores[state, :length]
+            )
+            candidate_scores = []
+            candidate_states = []
+            if predecessor_rows.shape[0]:
+                transitioned, sources = torch.max(
+                    predecessor_rows + transition_scores[:, state],
+                    dim=1,
+                )
+                candidate_scores.append(transitioned + segment[: transitioned.numel()])
+                candidate_states.append(sources)
+            if end <= max_duration:
+                candidate_scores.append(
+                    (initial_scores[state] + segment[-1]).reshape(1)
+                )
+                candidate_states.append(
+                    torch.full(
+                        (1,),
+                        -1,
+                        dtype=torch.int64,
+                        device=emission_scores.device,
+                    )
+                )
+            scores = torch.cat(candidate_scores)
+            sources = torch.cat(candidate_states)
+            candidate = int(torch.argmax(scores))
+            best[end, state] = scores[candidate]
+            previous_state[end, state] = sources[candidate]
+            best_duration[end, state] = candidate + 1
+
+    final_state = int(torch.argmax(best[time_points]))
+    final_score = best[time_points, final_state]
+    if not bool(torch.isfinite(final_score)):
+        raise ValueError("No valid semi-Markov segmentation reaches the sequence end.")
+
+    decoded = torch.empty(
+        time_points,
+        dtype=torch.int64,
+        device=emission_scores.device,
+    )
+    segments = []
+    end = time_points
+    state = final_state
+    while end:
+        duration = int(best_duration[end, state])
+        if duration < 1 or duration > end:
+            raise RuntimeError(
+                "Semi-Markov backtracking encountered an invalid duration."
+            )
+        start = end - duration
+        decoded[start:end] = state
+        segments.append(SemiMarkovSegment(state=state, start=start, end=end))
+        state = int(previous_state[end, state])
+        end = start
+        if end and state < 0:
+            raise RuntimeError("Semi-Markov backtracking lost its predecessor state.")
+    segments.reverse()
+    return SemiMarkovViterbiResult(
+        states=decoded,
+        segments=tuple(segments),
+        score=float(final_score),
+    )
+
+
+def semi_markov_path_score(
+    states,
+    emission_scores,
+    initial_scores,
+    transition_scores,
+    duration_scores,
+) -> torch.Tensor:
+    """Score one labeled path under the same maximal-segment convention."""
+
+    time_points, state_count, max_duration = _validate_scores(
+        emission_scores,
+        initial_scores,
+        transition_scores,
+        duration_scores,
+    )
+    if not isinstance(states, torch.Tensor):
+        raise TypeError("states must be a torch.Tensor.")
+    if states.dtype not in _INTEGER_DTYPES or states.ndim != 1:
+        raise TypeError("states must be a one-dimensional integer tensor.")
+    if states.device != emission_scores.device:
+        raise ValueError(f"states must be on {emission_scores.device}.")
+    if states.numel() != time_points:
+        raise ValueError(f"states must contain exactly {time_points} labels.")
+    if bool(((states < 0) | (states >= state_count)).any()):
+        raise ValueError(f"states labels must be between 0 and {state_count - 1}.")
+
+    labels = states.detach().cpu().tolist()
+    segments = []
+    start = 0
+    for end in range(1, time_points + 1):
+        if end == time_points or labels[end] != labels[start]:
+            segments.append(SemiMarkovSegment(labels[start], start, end))
+            start = end
+    if any(segment.duration > max_duration for segment in segments):
+        raise ValueError("states contain a segment longer than max_duration.")
+
+    first = segments[0]
+    score = initial_scores[first.state]
+    previous = None
+    for segment in segments:
+        if previous is not None:
+            score = score + transition_scores[previous.state, segment.state]
+        score = (
+            score
+            + emission_scores[segment.start : segment.end, segment.state].sum()
+            + duration_scores[segment.state, segment.duration - 1]
+        )
+        previous = segment
+    if not bool(torch.isfinite(score)):
+        raise ValueError("states describe a path forbidden by the model scores.")
+    return score
+
+
+def semi_markov_nll(
+    states,
+    emission_scores,
+    initial_scores,
+    transition_scores,
+    duration_scores,
+) -> torch.Tensor:
+    """Return exact conditional negative log likelihood for one labeled path."""
+
+    log_partition = semi_markov_log_partition(
+        emission_scores,
+        initial_scores,
+        transition_scores,
+        duration_scores,
+    )
+    gold_score = semi_markov_path_score(
+        states,
+        emission_scores,
+        initial_scores,
+        transition_scores,
+        duration_scores,
+    )
+    return log_partition - gold_score
+
+
+__all__ = [
+    "SemiMarkovSegment",
+    "SemiMarkovViterbiResult",
+    "semi_markov_log_partition",
+    "semi_markov_nll",
+    "semi_markov_path_score",
+    "semi_markov_viterbi",
+]

--- a/tests/test_semi_markov.py
+++ b/tests/test_semi_markov.py
@@ -1,0 +1,393 @@
+from itertools import product
+import inspect
+import math
+from pathlib import Path
+
+import pytest
+
+
+torch = pytest.importorskip("torch")
+
+from nilmtk_contrib.torch._semi_markov import (  # noqa: E402
+    SemiMarkovSegment,
+    semi_markov_log_partition,
+    semi_markov_nll,
+    semi_markov_path_score,
+    semi_markov_viterbi,
+)
+
+
+def _scores(*, dtype=torch.float64, device="cpu"):
+    return (
+        torch.tensor(
+            [
+                [0.8, -0.2],
+                [0.5, 0.1],
+                [-0.4, 0.9],
+                [0.2, 0.6],
+            ],
+            dtype=dtype,
+            device=device,
+        ),
+        torch.tensor([0.2, -0.1], dtype=dtype, device=device),
+        torch.tensor(
+            [[-torch.inf, 0.3], [-0.2, -torch.inf]],
+            dtype=dtype,
+            device=device,
+        ),
+        torch.tensor(
+            [[0.1, 0.4, -0.3], [0.2, -0.1, 0.3]],
+            dtype=dtype,
+            device=device,
+        ),
+    )
+
+
+def _enumerated_paths(scores):
+    emission, initial, transition, duration = scores
+    valid = []
+    for labels in product(range(emission.shape[1]), repeat=emission.shape[0]):
+        states = torch.tensor(labels, dtype=torch.int64, device=emission.device)
+        try:
+            score = semi_markov_path_score(
+                states,
+                emission,
+                initial,
+                transition,
+                duration,
+            )
+        except ValueError:
+            continue
+        valid.append((labels, score))
+    return valid
+
+
+def test_forward_and_viterbi_match_exhaustive_enumeration():
+    scores = _scores()
+    paths = _enumerated_paths(scores)
+    expected_partition = torch.logsumexp(
+        torch.stack([score for _, score in paths]), dim=0
+    )
+    expected_labels, expected_score = max(paths, key=lambda item: float(item[1]))
+
+    actual_partition = semi_markov_log_partition(*scores)
+    result = semi_markov_viterbi(*scores)
+
+    assert actual_partition == pytest.approx(float(expected_partition), abs=1e-12)
+    assert result.score == pytest.approx(float(expected_score), abs=1e-12)
+    assert tuple(result.states.tolist()) == expected_labels
+    assert result.segments == (
+        SemiMarkovSegment(state=0, start=0, end=2),
+        SemiMarkovSegment(state=1, start=2, end=4),
+    )
+
+
+@pytest.mark.parametrize(
+    ("time_points", "states", "max_duration", "seed"),
+    [
+        (1, 2, 1, 1),
+        (2, 2, 1, 2),
+        (3, 2, 2, 3),
+        (4, 2, 4, 4),
+        (3, 3, 2, 5),
+        (4, 3, 3, 6),
+        (5, 3, 2, 7),
+    ],
+)
+def test_random_small_problems_match_exhaustive_oracle(
+    time_points, states, max_duration, seed
+):
+    generator = torch.Generator().manual_seed(seed)
+    emission = torch.randn(
+        (time_points, states), dtype=torch.float64, generator=generator
+    )
+    initial = torch.randn(states, dtype=torch.float64, generator=generator)
+    transition = torch.randn((states, states), dtype=torch.float64, generator=generator)
+    transition.fill_diagonal_(-torch.inf)
+    duration = torch.randn(
+        (states, max_duration), dtype=torch.float64, generator=generator
+    )
+    scores = (emission, initial, transition, duration)
+    paths = _enumerated_paths(scores)
+    expected_partition = torch.logsumexp(
+        torch.stack([score for _, score in paths]), dim=0
+    )
+    expected_score = max(float(score) for _, score in paths)
+
+    partition = semi_markov_log_partition(*scores)
+    result = semi_markov_viterbi(*scores)
+
+    assert partition == pytest.approx(float(expected_partition), abs=1e-12)
+    assert result.score == pytest.approx(expected_score, abs=1e-12)
+    assert float(partition) >= result.score
+
+
+def test_path_score_uses_maximal_segments_and_duration_scores():
+    emission, initial, transition, duration = _scores()
+    states = torch.tensor([0, 0, 1, 1], dtype=torch.int64)
+
+    actual = semi_markov_path_score(
+        states,
+        emission,
+        initial,
+        transition,
+        duration,
+    )
+    expected = (
+        initial[0]
+        + emission[:2, 0].sum()
+        + duration[0, 1]
+        + transition[0, 1]
+        + emission[2:, 1].sum()
+        + duration[1, 1]
+    )
+
+    assert actual == expected
+
+
+def test_duration_scores_change_the_best_path_without_postprocessing():
+    emission = torch.zeros((4, 2), dtype=torch.float64)
+    initial = torch.tensor([0.0, -10.0], dtype=torch.float64)
+    transition = torch.tensor(
+        [[-torch.inf, 0.0], [0.0, -torch.inf]], dtype=torch.float64
+    )
+    duration = torch.tensor(
+        [[-10.0, 4.0, -10.0, -10.0], [-10.0, 4.0, -10.0, -10.0]],
+        dtype=torch.float64,
+    )
+
+    result = semi_markov_viterbi(emission, initial, transition, duration)
+
+    assert result.states.tolist() == [0, 0, 1, 1]
+    assert [segment.duration for segment in result.segments] == [2, 2]
+
+
+def test_single_segment_sequence_and_duration_cap_are_handled_exactly():
+    emission, initial, transition, duration = _scores()
+    one_sample = semi_markov_viterbi(
+        emission[:1],
+        initial,
+        transition,
+        duration,
+    )
+
+    assert one_sample.states.tolist() == [0]
+    assert one_sample.segments == (SemiMarkovSegment(0, 0, 1),)
+    with pytest.raises(ValueError, match="longer than max_duration"):
+        semi_markov_path_score(
+            torch.zeros(4, dtype=torch.int64),
+            emission,
+            initial,
+            transition,
+            duration,
+        )
+
+
+def test_log_partition_and_nll_are_differentiable_and_nonnegative():
+    emission, initial, transition, duration = _scores()
+    emission.requires_grad_()
+    initial.requires_grad_()
+    duration.requires_grad_()
+    states = torch.tensor([0, 0, 1, 1], dtype=torch.int64)
+
+    loss = semi_markov_nll(
+        states,
+        emission,
+        initial,
+        transition,
+        duration,
+    )
+    loss.backward()
+
+    assert float(loss) >= 0
+    for value in (emission, initial, duration):
+        assert value.grad is not None
+        assert torch.isfinite(value.grad).all()
+
+
+def test_temporarily_unreachable_states_do_not_create_nan_gradients():
+    emission = torch.zeros((3, 2), dtype=torch.float64, requires_grad=True)
+    initial = torch.tensor([0.0, -torch.inf], dtype=torch.float64)
+    transition = torch.tensor(
+        [[-torch.inf, 0.0], [0.0, -torch.inf]], dtype=torch.float64
+    )
+    duration = torch.tensor(
+        [[0.0, -torch.inf], [-torch.inf, 0.0]],
+        dtype=torch.float64,
+        requires_grad=True,
+    )
+
+    partition = semi_markov_log_partition(
+        emission,
+        initial,
+        transition,
+        duration,
+    )
+    partition.backward()
+
+    assert torch.isfinite(partition)
+    assert emission.grad is not None
+    assert duration.grad is not None
+    assert torch.isfinite(emission.grad).all()
+    assert torch.isfinite(duration.grad).all()
+
+
+def test_log_partition_passes_float64_autograd_gradcheck():
+    emission, initial, _, duration = _scores()
+    off_diagonal = torch.tensor([0.3, -0.2], dtype=torch.float64)
+    values = tuple(
+        value.clone().requires_grad_()
+        for value in (emission, initial, off_diagonal, duration)
+    )
+
+    def partition(emission_value, initial_value, off_value, duration_value):
+        negative_infinity = emission_value.new_tensor(-torch.inf)
+        transition_value = torch.stack(
+            (
+                torch.stack((negative_infinity, off_value[0])),
+                torch.stack((off_value[1], negative_infinity)),
+            )
+        )
+        return semi_markov_log_partition(
+            emission_value,
+            initial_value,
+            transition_value,
+            duration_value,
+        )
+
+    assert torch.autograd.gradcheck(partition, values, atol=1e-6, rtol=1e-5)
+
+
+def test_impossible_models_fail_instead_of_returning_negative_infinity():
+    emission = torch.zeros((2, 2), dtype=torch.float64)
+    initial = torch.zeros(2, dtype=torch.float64)
+    transition = torch.full((2, 2), -torch.inf, dtype=torch.float64)
+    duration = torch.zeros((2, 1), dtype=torch.float64)
+
+    with pytest.raises(ValueError, match="No valid"):
+        semi_markov_log_partition(emission, initial, transition, duration)
+    with pytest.raises(ValueError, match="No valid"):
+        semi_markov_viterbi(emission, initial, transition, duration)
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement", "error", "message"),
+    [
+        ("emission", [[1.0, 2.0]], TypeError, "torch.Tensor"),
+        (
+            "emission",
+            torch.ones((3, 1), dtype=torch.float64),
+            ValueError,
+            "states >= 2",
+        ),
+        (
+            "emission",
+            torch.ones((3, 2), dtype=torch.int64),
+            TypeError,
+            "float32 or torch.float64",
+        ),
+        (
+            "emission",
+            torch.tensor([[0.0, math.nan]], dtype=torch.float64),
+            ValueError,
+            "NaN",
+        ),
+        (
+            "initial",
+            torch.zeros(3, dtype=torch.float64),
+            ValueError,
+            "shape",
+        ),
+        (
+            "transition",
+            torch.zeros((2, 2), dtype=torch.float64),
+            ValueError,
+            "diagonal",
+        ),
+        (
+            "duration",
+            torch.empty((2, 0), dtype=torch.float64),
+            ValueError,
+            "max_duration",
+        ),
+        (
+            "duration",
+            torch.tensor([[-torch.inf, -torch.inf], [0.0, 0.0]], dtype=torch.float64),
+            ValueError,
+            "Every state",
+        ),
+    ],
+)
+def test_score_contract_rejects_invalid_inputs(field, replacement, error, message):
+    emission, initial, transition, duration = _scores()
+    values = {
+        "emission": emission,
+        "initial": initial,
+        "transition": transition,
+        "duration": duration,
+    }
+    values[field] = replacement
+
+    with pytest.raises(error, match=message):
+        semi_markov_viterbi(
+            values["emission"],
+            values["initial"],
+            values["transition"],
+            values["duration"],
+        )
+
+
+@pytest.mark.parametrize(
+    ("states", "error", "message"),
+    [
+        ([0, 0, 1, 1], TypeError, "torch.Tensor"),
+        (torch.tensor([0.0, 0.0, 1.0, 1.0]), TypeError, "integer"),
+        (torch.tensor([[0, 0, 1, 1]]), TypeError, "one-dimensional"),
+        (torch.tensor([0, 1]), ValueError, "exactly 4"),
+        (torch.tensor([0, 0, 1, 2]), ValueError, "between 0 and 1"),
+    ],
+)
+def test_path_score_rejects_invalid_state_labels(states, error, message):
+    with pytest.raises(error, match=message):
+        semi_markov_path_score(states, *_scores())
+
+
+def test_float32_and_longer_sequences_remain_finite_and_deterministic():
+    generator = torch.Generator().manual_seed(42)
+    emission = torch.randn((128, 3), generator=generator)
+    initial = torch.randn(3, generator=generator)
+    transition = torch.randn((3, 3), generator=generator)
+    transition.fill_diagonal_(-torch.inf)
+    duration = torch.randn((3, 32), generator=generator)
+
+    first = semi_markov_viterbi(emission, initial, transition, duration)
+    second = semi_markov_viterbi(emission, initial, transition, duration)
+
+    assert first.score == second.score
+    assert torch.equal(first.states, second.states)
+    assert first.segments == second.segments
+    assert torch.isfinite(
+        semi_markov_log_partition(emission, initial, transition, duration)
+    )
+
+
+def test_core_has_no_solver_or_array_runtime_dependency():
+    source = Path(inspect.getfile(semi_markov_viterbi)).read_text(encoding="utf-8")
+
+    for dependency in ("cvxpy", "mosek", "numpy", "scipy"):
+        assert dependency not in source
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_cuda_matches_cpu_with_float64():
+    cpu_scores = _scores()
+    cuda_scores = tuple(value.cuda() for value in cpu_scores)
+
+    cpu_partition = semi_markov_log_partition(*cpu_scores)
+    cuda_partition = semi_markov_log_partition(*cuda_scores).cpu()
+    cpu_path = semi_markov_viterbi(*cpu_scores)
+    cuda_path = semi_markov_viterbi(*cuda_scores)
+
+    assert cuda_partition == pytest.approx(float(cpu_partition), abs=1e-10)
+    assert cuda_path.score == pytest.approx(cpu_path.score, abs=1e-10)
+    assert cuda_path.states.cpu().tolist() == cpu_path.states.tolist()


### PR DESCRIPTION
## Summary

- add one private PyTorch score contract shared by classical HSMM and neural semi-Markov models
- implement exact differentiable forward log-partition, exact Viterbi decoding, labeled-path scoring, and NLL
- enforce maximal segments by forbidding transition diagonals, so duration and self-transition semantics cannot conflict
- keep gradients finite when a state is temporarily unreachable under sparse support

This PR deliberately does not export a model or change the catalog. The classical HSMM wrapper and neural model remain separate follow-ups.

## Verification

- exhaustive enumeration agrees with forward and Viterbi across deterministic and randomized 2/3-state problems
- float64 autograd gradcheck and sparse-support gradient tests pass
- malformed shape/dtype/device/score contracts and impossible models are rejected
- deterministic long-sequence test and optional CUDA parity included
- `ruff check nilmtk_contrib tests scripts`
- `pytest -q` — 846 passed, 102 skipped
- `uv build` — source distribution and wheel built; wheel contains `_semi_markov.py`

## Scientific basis

The design note cites primary explicit-duration switching, NILM FHSMM, and neural semi-Markov CRF references. No solver, NumPy, SciPy, or new dependency is introduced.
