### PR TITLE
Add private explicit-duration HSMM fitting

### DIFF
--- a/docs/explicit-duration-models.md
+++ b/docs/explicit-duration-models.md
@@ -32,6 +32,22 @@ core will support both planned models:
 2. a neural semi-Markov model whose compact temporal encoder learns emission
    scores while exact decoding still enforces duration and transition structure.
 
-The classical model, neural model, and NILMbench entries remain separate PRs.
-Neither model enters the public catalog until its complete training/inference
-wrapper and real-data T0 have passed.
+## Classical fitting layer
+
+The private `nilmtk_contrib.torch._hsmm` layer now fits the classical model
+from aligned mains and appliance chunks. It shares deterministic ordered state
+fitting with LBM, learns initial and between-segment transition probabilities,
+an explicit duration histogram for each state, and Gaussian aggregate
+emissions conditioned on the labeled appliance state. Inference splits long
+chunks only at the configured duration cap and sends every block through the
+exact shared Viterbi recurrence.
+
+The fitter is intentionally supervised and one-target-at-a-time. It is a
+small, benchmarkable baseline, not a claim to reproduce the factorial
+multi-appliance inference or timing features of TE-FHSMM. Model persistence is
+fail-closed until the next artifact PR, and the class remains private until a
+real-data T0 run succeeds.
+
+Persistence, public export, the neural model, and NILMbench entries remain
+separate PRs. Neither model enters the public catalog until its complete
+training/inference contract and real-data T0 have passed.

--- a/nilmtk_contrib/torch/_data.py
+++ b/nilmtk_contrib/torch/_data.py
@@ -1,0 +1,36 @@
+"""Shared strict conversion of NILM power channels to numeric vectors."""
+
+import numpy as np
+
+
+def _float32_array(frame, label):
+    """Convert real numeric input without silently accepting lossy values."""
+    raw = frame.to_numpy() if hasattr(frame, "to_numpy") else np.asarray(frame)
+    if not np.issubdtype(raw.dtype, np.number) or np.issubdtype(raw.dtype, np.bool_):
+        raise TypeError(f"{label} must contain real numeric data.")
+    if np.iscomplexobj(raw):
+        raise TypeError(f"{label} must contain real numeric data.")
+    if not np.isfinite(raw).all():
+        raise ValueError(f"{label} must contain only finite values.")
+    with np.errstate(over="ignore", invalid="ignore"):
+        values = np.asarray(raw, dtype=np.float32)
+    if not np.isfinite(values).all():
+        raise ValueError(f"{label} is not representable as float32.")
+    return values
+
+
+def power_vector(frame, label, *, allow_empty=False):
+    """Validate one raw power channel and return a float32 vector."""
+    values = _float32_array(frame, label)
+    if values.ndim == 1:
+        vector = values
+    elif values.ndim == 2 and values.shape[1] == 1:
+        vector = values[:, 0]
+    else:
+        raise ValueError(f"{label} must contain exactly one power column.")
+    if not allow_empty and not len(vector):
+        raise ValueError(f"{label} must contain at least one sample.")
+    return vector
+
+
+__all__ = ["power_vector"]

--- a/nilmtk_contrib/torch/_hsmm.py
+++ b/nilmtk_contrib/torch/_hsmm.py
@@ -1,0 +1,414 @@
+"""Supervised explicit-duration hidden semi-Markov NILM baseline."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from numbers import Integral, Real
+import math
+
+import numpy as np
+import pandas as pd
+import torch
+from nilmtk.disaggregate import Disaggregator
+
+from nilmtk_contrib.torch._base import resolve_torch_device
+from nilmtk_contrib.torch._data import power_vector
+from nilmtk_contrib.torch._semi_markov import semi_markov_viterbi
+from nilmtk_contrib.torch._state_fitting import assign_states, fit_state_means
+from nilmtk_contrib.utils.checkpoints import unsupported_persistence
+from nilmtk_contrib.utils.model import initialize_runtime
+from nilmtk_contrib.utils.params import (
+    DEFAULT_ALIASES,
+    get_param,
+    validate_positive_int,
+)
+
+
+@dataclass(frozen=True)
+class _HSMMParameters:
+    state_means: tuple[float, ...]
+    aggregate_means: tuple[float, ...]
+    aggregate_variances: tuple[float, ...]
+    initial_probabilities: tuple[float, ...]
+    transition_probabilities: tuple[tuple[float, ...], ...]
+    duration_probabilities: tuple[tuple[float, ...], ...]
+    state_counts: tuple[int, ...]
+    initial_counts: tuple[int, ...]
+    transition_counts: tuple[tuple[int, ...], ...]
+    duration_counts: tuple[tuple[int, ...], ...]
+    num_samples: int
+    num_chunks: int
+    num_segments: int
+    right_censored_segments: int
+
+
+def _positive_finite(name, value) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, Real)
+        or not math.isfinite(value)
+        or value <= 0
+    ):
+        raise ValueError(f"{name} must be a positive finite number.")
+    return float(value)
+
+
+def _as_power_tensor(frame, label) -> torch.Tensor:
+    values = power_vector(frame, label)
+    if bool((values < 0).any()):
+        raise ValueError(f"{label} must be non-negative.")
+    return torch.as_tensor(values, dtype=torch.float64, device="cpu").clone()
+
+
+def _frame_index(frame, length):
+    index = getattr(frame, "index", None)
+    return index if index is not None else pd.RangeIndex(length)
+
+
+def _aligned_windows(main_frames, target_frames, appliance_name):
+    if len(main_frames) != len(target_frames):
+        raise ValueError(
+            f"{appliance_name!r} has {len(target_frames)} chunks but mains has "
+            f"{len(main_frames)}."
+        )
+    mains = []
+    targets = []
+    for index, (main_frame, target_frame) in enumerate(zip(main_frames, target_frames)):
+        main = _as_power_tensor(main_frame, f"mains chunk {index}")
+        target = _as_power_tensor(
+            target_frame, f"{appliance_name!r} target chunk {index}"
+        )
+        if main.numel() != target.numel():
+            raise ValueError(
+                f"{appliance_name!r} target chunk {index} length does not match mains."
+            )
+        main_index = getattr(main_frame, "index", None)
+        target_index = getattr(target_frame, "index", None)
+        if (
+            main_index is not None
+            and target_index is not None
+            and not main_index.equals(target_index)
+        ):
+            raise ValueError(
+                f"{appliance_name!r} target chunk {index} index does not match mains."
+            )
+        mains.append(main)
+        targets.append(target)
+    return tuple(mains), tuple(targets)
+
+
+def _runs(states: torch.Tensor) -> tuple[tuple[int, int], ...]:
+    labels = states.tolist()
+    runs = []
+    start = 0
+    for end in range(1, len(labels) + 1):
+        if end == len(labels) or labels[end] != labels[start]:
+            runs.append((labels[start], end - start))
+            start = end
+    return tuple(runs)
+
+
+def _fit_hsmm(
+    mains_windows,
+    target_windows,
+    *,
+    num_states,
+    max_duration,
+    pseudocount,
+    variance_floor,
+    kmeans_max_iterations,
+) -> _HSMMParameters:
+    state_means = fit_state_means(
+        target_windows,
+        num_states=num_states,
+        max_iterations=kmeans_max_iterations,
+    )
+    state_windows = tuple(
+        assign_states(values, state_means) for values in target_windows
+    )
+    state_counts = sum(
+        (torch.bincount(states, minlength=num_states) for states in state_windows),
+        start=torch.zeros(num_states, dtype=torch.long),
+    )
+    initial_counts = torch.zeros(num_states, dtype=torch.long)
+    transition_counts = torch.zeros((num_states, num_states), dtype=torch.long)
+    duration_counts = torch.zeros((num_states, max_duration), dtype=torch.long)
+    num_segments = 0
+    right_censored_segments = 0
+    for states in state_windows:
+        runs = _runs(states)
+        initial_counts[runs[0][0]] += 1
+        num_segments += len(runs)
+        for run_index, (state, duration) in enumerate(runs):
+            if duration >= max_duration:
+                right_censored_segments += int(duration > max_duration)
+                duration = max_duration
+            duration_counts[state, duration - 1] += 1
+            if run_index:
+                transition_counts[runs[run_index - 1][0], state] += 1
+
+    initial_prior = pseudocount / num_states
+    initial_probabilities = initial_counts.to(torch.float64) + initial_prior
+    initial_probabilities /= initial_probabilities.sum()
+
+    off_diagonal = ~torch.eye(num_states, dtype=torch.bool)
+    transition_prior = pseudocount / (num_states - 1)
+    transition_probabilities = transition_counts.to(torch.float64)
+    transition_probabilities[off_diagonal] += transition_prior
+    transition_probabilities /= transition_probabilities.sum(dim=1, keepdim=True)
+
+    duration_prior = pseudocount / max_duration
+    duration_probabilities = duration_counts.to(torch.float64) + duration_prior
+    duration_probabilities /= duration_probabilities.sum(dim=1, keepdim=True)
+
+    all_mains = torch.cat(mains_windows)
+    all_states = torch.cat(state_windows)
+    aggregate_means = torch.stack(
+        [all_mains[all_states == state].mean() for state in range(num_states)]
+    )
+    aggregate_variances = torch.stack(
+        [
+            torch.square(all_mains[all_states == state] - aggregate_means[state]).mean()
+            for state in range(num_states)
+        ]
+    ).clamp_min(variance_floor)
+    if not bool(torch.isfinite(aggregate_means).all()) or not bool(
+        torch.isfinite(aggregate_variances).all()
+    ):
+        raise RuntimeError("HSMM emission fitting produced non-finite parameters.")
+
+    return _HSMMParameters(
+        state_means=tuple(float(value) for value in state_means),
+        aggregate_means=tuple(float(value) for value in aggregate_means),
+        aggregate_variances=tuple(float(value) for value in aggregate_variances),
+        initial_probabilities=tuple(float(value) for value in initial_probabilities),
+        transition_probabilities=tuple(
+            tuple(float(value) for value in row) for row in transition_probabilities
+        ),
+        duration_probabilities=tuple(
+            tuple(float(value) for value in row) for row in duration_probabilities
+        ),
+        state_counts=tuple(int(value) for value in state_counts),
+        initial_counts=tuple(int(value) for value in initial_counts),
+        transition_counts=tuple(
+            tuple(int(value) for value in row) for row in transition_counts
+        ),
+        duration_counts=tuple(
+            tuple(int(value) for value in row) for row in duration_counts
+        ),
+        num_samples=int(all_mains.numel()),
+        num_chunks=len(mains_windows),
+        num_segments=num_segments,
+        right_censored_segments=right_censored_segments,
+    )
+
+
+def _decode_block(values, model: _HSMMParameters, device) -> np.ndarray:
+    observations = torch.as_tensor(values, dtype=torch.float64, device=device)
+    state_means = torch.tensor(model.state_means, dtype=torch.float64, device=device)
+    aggregate_means = torch.tensor(
+        model.aggregate_means, dtype=torch.float64, device=device
+    )
+    aggregate_variances = torch.tensor(
+        model.aggregate_variances, dtype=torch.float64, device=device
+    )
+    initial_scores = torch.log(
+        torch.tensor(model.initial_probabilities, dtype=torch.float64, device=device)
+    )
+    transition_scores = torch.log(
+        torch.tensor(model.transition_probabilities, dtype=torch.float64, device=device)
+    )
+    duration_scores = torch.log(
+        torch.tensor(model.duration_probabilities, dtype=torch.float64, device=device)
+    )
+    emission_scores = -0.5 * (
+        torch.square(observations[:, None] - aggregate_means[None, :])
+        / aggregate_variances[None, :]
+        + torch.log(2 * torch.pi * aggregate_variances)[None, :]
+    )
+    path = semi_markov_viterbi(
+        emission_scores,
+        initial_scores,
+        transition_scores,
+        duration_scores,
+    )
+    return state_means[path.states].to(dtype=torch.float32).cpu().numpy()
+
+
+class HSMM(Disaggregator):
+    """Explicit-duration Gaussian HSMM fitted from aligned appliance labels."""
+
+    MODEL_NAME = "HSMM"
+
+    def __init__(self, params=None):
+        params = {} if params is None else params
+        if not isinstance(params, Mapping):
+            raise TypeError("params must be a mapping or None.")
+        super().__init__()
+        self.num_states = validate_positive_int(
+            "num_states", get_param(params, "num_states", 2)
+        )
+        if self.num_states < 2:
+            raise ValueError("num_states must be at least two.")
+        self.max_duration = validate_positive_int(
+            "max_duration", get_param(params, "max_duration", 720)
+        )
+        self.pseudocount = _positive_finite(
+            "pseudocount", get_param(params, "pseudocount", 1.0)
+        )
+        self.variance_floor = _positive_finite(
+            "variance_floor", get_param(params, "variance_floor", 1.0)
+        )
+        self.kmeans_max_iterations = validate_positive_int(
+            "kmeans_max_iterations",
+            get_param(params, "kmeans_max_iterations", 100),
+        )
+        self.device = resolve_torch_device(get_param(params, "device"))
+        if self.device.type == "mps":
+            raise ValueError("HSMM supports CPU and CUDA; float64 MPS is unsupported.")
+        self.seed = get_param(params, "seed")
+        self.verbose = get_param(params, "verbose", False)
+        if self.seed is not None and (
+            isinstance(self.seed, bool) or not isinstance(self.seed, Integral)
+        ):
+            raise ValueError("seed must be an integer or None.")
+        if not isinstance(self.verbose, bool):
+            raise ValueError("verbose must be a boolean.")
+        self.chunk_wise_training = False
+        self.save_model_path = get_param(
+            params,
+            "save_model_path",
+            aliases=DEFAULT_ALIASES["save_model_path"],
+        )
+        self.load_model_path = get_param(
+            params,
+            "pretrained_model_path",
+            aliases=DEFAULT_ALIASES["pretrained_model_path"],
+        )
+        self.models = OrderedDict()
+        initialize_runtime(
+            self,
+            {"seed": self.seed, "verbose": self.verbose},
+            backends=("python", "numpy", "torch"),
+        )
+        if self.load_model_path:
+            self.load_model(self.load_model_path)
+
+    def save_model(self, *_, **__):
+        unsupported_persistence(self.MODEL_NAME)
+
+    def load_model(self, *_, **__):
+        unsupported_persistence(self.MODEL_NAME)
+
+    def partial_fit(
+        self,
+        train_main,
+        train_appliances,
+        do_preprocessing=True,
+        current_epoch=0,
+        **_,
+    ):
+        del current_epoch
+        if not isinstance(do_preprocessing, bool):
+            raise ValueError("do_preprocessing must be a boolean.")
+        main_frames = list(train_main)
+        if not main_frames:
+            raise ValueError("Training requires at least one mains chunk.")
+        try:
+            appliance_entries = list(train_appliances)
+        except TypeError as exc:
+            raise TypeError(
+                "train_appliances must contain (name, frames) pairs."
+            ) from exc
+        if not appliance_entries:
+            raise ValueError("Training requires at least one appliance.")
+        fitted = OrderedDict()
+        for entry in appliance_entries:
+            try:
+                appliance_name, frames = entry
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    "Each appliance must be a (name, frames) pair."
+                ) from exc
+            if not isinstance(appliance_name, str) or not appliance_name.strip():
+                raise ValueError("Appliance names must be non-empty strings.")
+            if appliance_name != appliance_name.strip():
+                raise ValueError(
+                    "Appliance names must not have surrounding whitespace."
+                )
+            if appliance_name in fitted:
+                raise ValueError(f"Duplicate appliance name {appliance_name!r}.")
+            if isinstance(frames, (str, bytes)) or not isinstance(frames, Sequence):
+                raise TypeError(
+                    f"Training frames for {appliance_name!r} must be a sequence."
+                )
+            mains, targets = _aligned_windows(main_frames, list(frames), appliance_name)
+            fitted[appliance_name] = _fit_hsmm(
+                mains,
+                targets,
+                num_states=self.num_states,
+                max_duration=self.max_duration,
+                pseudocount=self.pseudocount,
+                variance_floor=self.variance_floor,
+                kmeans_max_iterations=self.kmeans_max_iterations,
+            )
+        previous_models = self.models
+        self.models = fitted
+        try:
+            if self.save_model_path:
+                self.save_model(self.save_model_path)
+        except Exception:
+            self.models = previous_models
+            raise
+
+    def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
+        if not isinstance(do_preprocessing, bool):
+            raise ValueError("do_preprocessing must be a boolean.")
+        models = self.models if model is None else model
+        if not isinstance(models, Mapping) or not models:
+            raise RuntimeError("HSMM requires a trained model mapping.")
+        for appliance_name, fitted in models.items():
+            if not isinstance(appliance_name, str) or not appliance_name.strip():
+                raise ValueError(
+                    "HSMM model appliance names must be non-empty strings."
+                )
+            if not isinstance(fitted, _HSMMParameters):
+                raise TypeError("HSMM model values must be fitted HSMM parameters.")
+            if len(fitted.state_means) != self.num_states:
+                raise ValueError("HSMM model state count does not match configuration.")
+            if any(
+                len(probabilities) != self.max_duration
+                for probabilities in fitted.duration_probabilities
+            ):
+                raise ValueError(
+                    "HSMM model duration cap does not match configuration."
+                )
+        results = []
+        for chunk_index, frame in enumerate(test_main_list):
+            values = power_vector(frame, f"mains chunk {chunk_index}", allow_empty=True)
+            if bool((values < 0).any()):
+                raise ValueError(f"mains chunk {chunk_index} must be non-negative.")
+            output_index = _frame_index(frame, len(values))
+            columns = OrderedDict()
+            for appliance_name, fitted in models.items():
+                blocks = [
+                    _decode_block(
+                        values[start : start + self.max_duration],
+                        fitted,
+                        self.device,
+                    )
+                    for start in range(0, len(values), self.max_duration)
+                ]
+                prediction = (
+                    np.concatenate(blocks).astype(np.float32, copy=False)
+                    if blocks
+                    else np.empty(0, dtype=np.float32)
+                )
+                columns[appliance_name] = pd.Series(prediction, index=output_index)
+            results.append(pd.DataFrame(columns, index=output_index))
+        return results
+
+
+__all__ = ["HSMM"]

--- a/nilmtk_contrib/torch/_lbm_training.py
+++ b/nilmtk_contrib/torch/_lbm_training.py
@@ -21,6 +21,10 @@ from nilmtk_contrib.torch._lbm import (
     _finite_real,
     _positive_int,
 )
+from nilmtk_contrib.torch._state_fitting import (
+    assign_states as _assign_states,
+    fit_state_means as _fit_state_means,
+)
 
 
 _SHA256 = re.compile(r"sha256:[0-9a-f]{64}")
@@ -309,57 +313,6 @@ def _source_sort_key(source: SourceWindow):
         str(source.building),
         source.interval,
     )
-
-
-def _fit_state_means(
-    windows: Sequence[torch.Tensor],
-    *,
-    num_states: int,
-    max_iterations: int,
-) -> torch.Tensor:
-    values = torch.sort(torch.cat(tuple(windows))).values
-    unique = torch.unique(values, sorted=True)
-    if unique.numel() < num_states:
-        raise ValueError(
-            f"Training power contains {unique.numel()} unique values; "
-            f"at least num_states={num_states} are required."
-        )
-    initial_indices = (
-        torch.linspace(
-            0,
-            unique.numel() - 1,
-            steps=num_states,
-            dtype=torch.float64,
-        )
-        .round()
-        .to(torch.long)
-    )
-    centers = unique[initial_indices]
-    previous_assignments = None
-    for _ in range(max_iterations):
-        assignments = torch.argmin(torch.abs(values[:, None] - centers[None, :]), dim=1)
-        if previous_assignments is not None and torch.equal(
-            assignments, previous_assignments
-        ):
-            break
-        counts = torch.bincount(assignments, minlength=num_states)
-        if bool((counts == 0).any()):
-            raise RuntimeError("Deterministic state fitting produced an empty cluster.")
-        centers = torch.stack(
-            [values[assignments == state].mean() for state in range(num_states)]
-        )
-        if not bool(torch.isfinite(centers).all()):
-            raise RuntimeError(
-                "State fitting produced non-finite means; rescale the power data."
-            )
-        previous_assignments = assignments
-    else:
-        raise RuntimeError("Deterministic state fitting did not converge.")
-    return torch.sort(centers).values
-
-
-def _assign_states(values: torch.Tensor, means: torch.Tensor) -> torch.Tensor:
-    return torch.argmin(torch.abs(values[:, None] - means[None, :]), dim=1)
 
 
 def _smoothed_probabilities(counts: torch.Tensor, pseudocount: float) -> torch.Tensor:

--- a/nilmtk_contrib/torch/_seq2point.py
+++ b/nilmtk_contrib/torch/_seq2point.py
@@ -24,6 +24,7 @@ from nilmtk_contrib.torch._base import (
     TorchDisaggregator,
     _validate_appliance_name,
 )
+from nilmtk_contrib.torch._data import _float32_array, power_vector
 from nilmtk_contrib.utils.checkpoints import (
     build_metadata,
     collect_dependencies,
@@ -53,36 +54,6 @@ def finite_number(name, value, *, minimum=None, strict=False):
             qualifier = "greater than" if strict else "at least"
             raise ValueError(f"{name} must be {qualifier} {minimum}.")
     return float(value)
-
-
-def _float32_array(frame, label):
-    """Convert real numeric input without silently accepting lossy values."""
-    raw = frame.to_numpy() if hasattr(frame, "to_numpy") else np.asarray(frame)
-    if not np.issubdtype(raw.dtype, np.number) or np.issubdtype(raw.dtype, np.bool_):
-        raise TypeError(f"{label} must contain real numeric data.")
-    if np.iscomplexobj(raw):
-        raise TypeError(f"{label} must contain real numeric data.")
-    if not np.isfinite(raw).all():
-        raise ValueError(f"{label} must contain only finite values.")
-    with np.errstate(over="ignore", invalid="ignore"):
-        values = np.asarray(raw, dtype=np.float32)
-    if not np.isfinite(values).all():
-        raise ValueError(f"{label} is not representable as float32.")
-    return values
-
-
-def power_vector(frame, label, *, allow_empty=False):
-    """Validate one raw power channel and return a float32 vector."""
-    values = _float32_array(frame, label)
-    if values.ndim == 1:
-        vector = values
-    elif values.ndim == 2 and values.shape[1] == 1:
-        vector = values[:, 0]
-    else:
-        raise ValueError(f"{label} must contain exactly one power column.")
-    if not allow_empty and not len(vector):
-        raise ValueError(f"{label} must contain at least one sample.")
-    return vector
 
 
 def window_matrix(frame, sequence_length, label, *, allow_empty=False):

--- a/nilmtk_contrib/torch/_state_fitting.py
+++ b/nilmtk_contrib/torch/_state_fitting.py
@@ -1,0 +1,61 @@
+"""Shared deterministic finite-state fitting for structured NILM models."""
+
+from collections.abc import Sequence
+
+import torch
+
+
+def fit_state_means(
+    windows: Sequence[torch.Tensor],
+    *,
+    num_states: int,
+    max_iterations: int,
+) -> torch.Tensor:
+    """Fit ordered one-dimensional centers with deterministic Lloyd steps."""
+    values = torch.sort(torch.cat(tuple(windows))).values
+    unique = torch.unique(values, sorted=True)
+    if unique.numel() < num_states:
+        raise ValueError(
+            f"Training power contains {unique.numel()} unique values; "
+            f"at least num_states={num_states} are required."
+        )
+    initial_indices = (
+        torch.linspace(
+            0,
+            unique.numel() - 1,
+            steps=num_states,
+            dtype=torch.float64,
+        )
+        .round()
+        .to(torch.long)
+    )
+    centers = unique[initial_indices]
+    previous_assignments = None
+    for _ in range(max_iterations):
+        assignments = assign_states(values, centers)
+        if previous_assignments is not None and torch.equal(
+            assignments, previous_assignments
+        ):
+            break
+        counts = torch.bincount(assignments, minlength=num_states)
+        if bool((counts == 0).any()):
+            raise RuntimeError("Deterministic state fitting produced an empty cluster.")
+        centers = torch.stack(
+            [values[assignments == state].mean() for state in range(num_states)]
+        )
+        if not bool(torch.isfinite(centers).all()):
+            raise RuntimeError(
+                "State fitting produced non-finite means; rescale the power data."
+            )
+        previous_assignments = assignments
+    else:
+        raise RuntimeError("Deterministic state fitting did not converge.")
+    return torch.sort(centers).values
+
+
+def assign_states(values: torch.Tensor, means: torch.Tensor) -> torch.Tensor:
+    """Assign each scalar to its nearest mean, breaking ties by state order."""
+    return torch.argmin(torch.abs(values[:, None] - means[None, :]), dim=1)
+
+
+__all__ = ["assign_states", "fit_state_means"]

--- a/tests/test_hsmm.py
+++ b/tests/test_hsmm.py
@@ -1,0 +1,283 @@
+import inspect
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+torch = pytest.importorskip("torch")
+hsmm_module = pytest.importorskip("nilmtk_contrib.torch._hsmm")
+HSMM = hsmm_module.HSMM
+
+
+def _params(**overrides):
+    return {
+        "device": "cpu",
+        "num_states": 2,
+        "max_duration": 8,
+        "pseudocount": 1.0,
+        "variance_floor": 0.1,
+        "kmeans_max_iterations": 50,
+        "seed": 7,
+    } | overrides
+
+
+def _chunks(*, length=24, start="2026-01-01", background=20.0):
+    index = pd.date_range(start, periods=length, freq="1min", tz="UTC")
+    states = np.tile(
+        np.array([0, 0, 0, 100, 100, 100], dtype=np.float32),
+        (length + 5) // 6,
+    )[:length]
+    residual = background + 0.1 * np.sin(np.arange(length, dtype=np.float32))
+    mains = states + residual
+    return (
+        pd.DataFrame({"power": mains}, index=index),
+        pd.DataFrame({"power": states}, index=index),
+    )
+
+
+def _training_chunks():
+    first_main, first_target = _chunks(length=24)
+    second_main, second_target = _chunks(length=18, start="2026-02-01", background=22.0)
+    return [first_main, second_main], [("fridge", [first_target, second_target])]
+
+
+def test_fit_learns_normalized_state_transition_and_duration_contracts():
+    mains, appliances = _training_chunks()
+    model = HSMM(_params())
+
+    model.partial_fit(mains, appliances)
+    fitted = model.models["fridge"]
+
+    assert fitted.state_means == pytest.approx((0.0, 100.0))
+    assert np.subtract(fitted.aggregate_means, fitted.state_means) == pytest.approx(
+        (21.0, 21.0), abs=0.2
+    )
+    assert sum(fitted.state_counts) == fitted.num_samples == 42
+    assert sum(fitted.initial_counts) == fitted.num_chunks == 2
+    assert sum(sum(row) for row in fitted.duration_counts) == fitted.num_segments
+    assert (
+        sum(sum(row) for row in fitted.transition_counts)
+        == fitted.num_segments - fitted.num_chunks
+    )
+    assert fitted.right_censored_segments == 0
+    assert sum(fitted.initial_probabilities) == pytest.approx(1.0)
+    assert all(
+        sum(row) == pytest.approx(1.0) for row in fitted.transition_probabilities
+    )
+    assert all(sum(row) == pytest.approx(1.0) for row in fitted.duration_probabilities)
+    assert all(fitted.transition_probabilities[state][state] == 0 for state in range(2))
+
+
+def test_train_infer_recovers_clean_states_and_preserves_index_and_dtype():
+    mains, appliances = _training_chunks()
+    model = HSMM(_params())
+    model.partial_fit(mains, appliances)
+
+    prediction = model.disaggregate_chunk(mains)[0]
+
+    assert prediction.index.equals(mains[0].index)
+    assert prediction.columns.tolist() == ["fridge"]
+    assert prediction["fridge"].dtype == np.float32
+    assert prediction["fridge"].to_numpy() == pytest.approx(
+        appliances[0][1][0]["power"].to_numpy()
+    )
+
+
+def test_inference_splits_long_and_partial_chunks_at_the_duration_cap(monkeypatch):
+    mains, appliances = _training_chunks()
+    model = HSMM(_params(max_duration=5))
+    model.partial_fit(mains, appliances)
+    lengths = []
+    original = hsmm_module.semi_markov_viterbi
+
+    def recording_decoder(emission, *args):
+        lengths.append(len(emission))
+        return original(emission, *args)
+
+    monkeypatch.setattr(hsmm_module, "semi_markov_viterbi", recording_decoder)
+    prediction = model.disaggregate_chunk([mains[0].iloc[:13]])[0]
+
+    assert lengths == [5, 5, 3]
+    assert len(prediction) == 13
+    assert np.isfinite(prediction["fridge"]).all()
+
+
+def test_long_training_runs_are_right_censored_at_the_inference_cap():
+    index = pd.date_range("2026-01-01", periods=20, freq="1min", tz="UTC")
+    target = np.array([0.0] * 5 + [100.0] * 5, dtype=np.float32)
+    target = np.tile(target, 2)
+    mains = pd.DataFrame({"power": target + 20}, index=index)
+    appliance = pd.DataFrame({"power": target}, index=index)
+    model = HSMM(_params(max_duration=3))
+
+    model.partial_fit([mains], [("fridge", [appliance])])
+    fitted = model.models["fridge"]
+
+    assert fitted.right_censored_segments == 4
+    assert fitted.duration_counts[0][-1] == 2
+    assert fitted.duration_counts[1][-1] == 2
+
+
+def test_repeated_fits_produce_identical_parameter_records():
+    mains, appliances = _training_chunks()
+    first = HSMM(_params(seed=1))
+    second = HSMM(_params(seed=999))
+
+    first.partial_fit(mains, appliances)
+    second.partial_fit(mains, appliances)
+
+    assert first.models == second.models
+
+
+def test_empty_inference_chunk_preserves_empty_index_and_columns():
+    mains, appliances = _training_chunks()
+    model = HSMM(_params())
+    model.partial_fit(mains, appliances)
+    empty = mains[0].iloc[:0]
+
+    prediction = model.disaggregate_chunk([empty])[0]
+
+    assert prediction.index.equals(empty.index)
+    assert prediction.columns.tolist() == ["fridge"]
+    assert prediction.empty
+
+
+def test_multiple_appliances_are_fitted_without_partial_state_on_failure():
+    mains, appliances = _training_chunks()
+    kettle = [frame.copy() for frame in appliances[0][1]]
+    for frame in kettle:
+        frame["power"] *= 2
+    model = HSMM(_params())
+    model.partial_fit(mains, appliances)
+    original = model.models
+
+    with pytest.raises(ValueError, match="unique values"):
+        model.partial_fit(
+            mains,
+            [
+                ("fridge", appliances[0][1]),
+                (
+                    "constant",
+                    [
+                        pd.DataFrame({"power": np.ones(len(frame))}, index=frame.index)
+                        for frame in mains
+                    ],
+                ),
+            ],
+        )
+
+    assert model.models is original
+    model.partial_fit(mains, [("fridge", appliances[0][1]), ("kettle", kettle)])
+    assert list(model.models) == ["fridge", "kettle"]
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error", "message"),
+    [
+        ({"num_states": 1}, ValueError, "at least two"),
+        ({"num_states": True}, ValueError, "positive integer"),
+        ({"max_duration": 0}, ValueError, "positive integer"),
+        ({"pseudocount": 0}, ValueError, "positive finite"),
+        ({"variance_floor": float("nan")}, ValueError, "positive finite"),
+        ({"kmeans_max_iterations": 0}, ValueError, "positive integer"),
+        ({"seed": True}, ValueError, "integer or None"),
+        ({"verbose": "yes"}, ValueError, "boolean"),
+    ],
+)
+def test_invalid_configuration_fails_at_construction(overrides, error, message):
+    with pytest.raises(error, match=message):
+        HSMM(_params(**overrides))
+
+
+@pytest.mark.parametrize(
+    ("mutation", "error", "message"),
+    [
+        (
+            lambda mains, targets: (mains, []),
+            ValueError,
+            "chunks but mains",
+        ),
+        (
+            lambda mains, targets: (mains, [targets[0].iloc[:-1], targets[1]]),
+            ValueError,
+            "length does not match",
+        ),
+        (
+            lambda mains, targets: (
+                mains,
+                [
+                    targets[0].set_axis(targets[0].index + pd.Timedelta(days=1)),
+                    targets[1],
+                ],
+            ),
+            ValueError,
+            "index does not match",
+        ),
+        (
+            lambda mains, targets: (
+                mains,
+                [targets[0].assign(power=-1), targets[1]],
+            ),
+            ValueError,
+            "non-negative",
+        ),
+    ],
+)
+def test_training_rejects_misaligned_or_invalid_targets(mutation, error, message):
+    mains, appliances = _training_chunks()
+    mutated_mains, mutated_targets = mutation(mains, appliances[0][1])
+    model = HSMM(_params())
+
+    with pytest.raises(error, match=message):
+        model.partial_fit(mutated_mains, [("fridge", mutated_targets)])
+
+
+def test_training_and_inference_contracts_reject_invalid_containers():
+    mains, appliances = _training_chunks()
+    model = HSMM(_params())
+
+    with pytest.raises(ValueError, match="at least one mains"):
+        model.partial_fit([], appliances)
+    with pytest.raises(ValueError, match="at least one appliance"):
+        model.partial_fit(mains, [])
+    with pytest.raises(ValueError, match="Duplicate appliance"):
+        model.partial_fit(mains, [appliances[0], appliances[0]])
+    with pytest.raises(RuntimeError, match="trained model"):
+        model.disaggregate_chunk(mains)
+    with pytest.raises(ValueError, match="boolean"):
+        model.partial_fit(mains, appliances, do_preprocessing="yes")
+
+
+def test_persistence_is_explicitly_fail_closed_until_artifact_pr(tmp_path):
+    mains, appliances = _training_chunks()
+    model = HSMM(_params())
+    model.partial_fit(mains, appliances)
+
+    with pytest.raises(NotImplementedError, match="HSMM"):
+        model.save_model(tmp_path)
+    with pytest.raises(NotImplementedError, match="HSMM"):
+        model.load_model(tmp_path)
+
+
+def test_implementation_uses_shared_exact_core_without_classical_solver():
+    source = Path(inspect.getfile(HSMM)).read_text(encoding="utf-8")
+
+    assert "semi_markov_viterbi" in source
+    for dependency in ("cvxpy", "hmmlearn", "mosek", "scipy"):
+        assert dependency not in source
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_cuda_inference_matches_cpu():
+    mains, appliances = _training_chunks()
+    cpu = HSMM(_params(device="cpu"))
+    cuda = HSMM(_params(device="cuda"))
+    cpu.partial_fit(mains, appliances)
+    cuda.partial_fit(mains, appliances)
+
+    cpu_prediction = cpu.disaggregate_chunk(mains)[0]
+    cuda_prediction = cuda.disaggregate_chunk(mains)[0]
+
+    assert np.array_equal(cpu_prediction.to_numpy(), cuda_prediction.to_numpy())

--- a/tests/test_state_fitting.py
+++ b/tests/test_state_fitting.py
@@ -1,0 +1,46 @@
+import pytest
+
+
+torch = pytest.importorskip("torch")
+
+from nilmtk_contrib.torch._state_fitting import (  # noqa: E402
+    assign_states,
+    fit_state_means,
+)
+
+
+def test_state_fitting_is_ordered_deterministic_and_window_invariant():
+    windows = (
+        torch.tensor([0.0, 1.0, 100.0], dtype=torch.float64),
+        torch.tensor([99.0, 2.0, 101.0], dtype=torch.float64),
+    )
+
+    first = fit_state_means(windows, num_states=2, max_iterations=20)
+    second = fit_state_means(tuple(reversed(windows)), num_states=2, max_iterations=20)
+
+    assert first.tolist() == pytest.approx([1.0, 100.0])
+    assert torch.equal(first, second)
+
+
+def test_assignment_breaks_exact_ties_toward_the_lower_ordered_state():
+    states = assign_states(
+        torch.tensor([0.0, 5.0, 10.0], dtype=torch.float64),
+        torch.tensor([0.0, 10.0], dtype=torch.float64),
+    )
+
+    assert states.tolist() == [0, 0, 1]
+
+
+def test_state_fitting_rejects_insufficient_support_and_nonconvergence():
+    with pytest.raises(ValueError, match="unique values"):
+        fit_state_means(
+            (torch.ones(4, dtype=torch.float64),),
+            num_states=2,
+            max_iterations=10,
+        )
+    with pytest.raises(RuntimeError, match="did not converge"):
+        fit_state_means(
+            (torch.tensor([0.0, 1.0, 9.0, 10.0], dtype=torch.float64),),
+            num_states=2,
+            max_iterations=1,
+        )


### PR DESCRIPTION
## Summary

- add a private supervised explicit-duration HSMM fitting/inference layer on the exact core from #124
- fit ordered appliance states, initial probabilities, between-segment transitions, explicit state-duration histograms, and Gaussian aggregate emissions
- preserve aligned chunk/index boundaries, right-censor training runs at the configured inference cap, and decode every complete/partial block exactly
- extract strict power-vector conversion and deterministic state fitting so HSMM, LBM, and sequence-to-point engines share them instead of copying boilerplate

The class remains private and persistence is explicitly fail-closed. Public export, persistence, and NILMbench entry require separate PRs plus real-data T0.

## Verification

- clean synthetic state recovery with original index and float32 output
- count/probability conservation, duration censoring, deterministic repeated fitting, long/partial/empty chunk handling, rollback on multi-appliance failure, malformed alignment/data/config rejection
- optional CUDA parity test
- focused cross-engine gate — 101 passed, 1 skipped
- `ruff check nilmtk_contrib tests scripts`
- `pytest -q` — 871 passed, 103 skipped
- `uv build` — source distribution and wheel built successfully

No CVXPY, hmmlearn, SciPy, solver, new dependency, public catalog entry, or accuracy claim is introduced.
