### PR TITLE
Add private neural semi-Markov scorer

### DIFF
--- a/docs/explicit-duration-models.md
+++ b/docs/explicit-duration-models.md
@@ -48,6 +48,22 @@ multi-appliance inference or timing features of TE-FHSMM. Model persistence is
 fail-closed until the next artifact PR, and the class remains private until a
 real-data T0 run succeeds.
 
+## Neural scoring layer
+
+The private `nilmtk_contrib.torch._neural_semi_markov` layer supplies the
+matched modern variant. A compact length-preserving dilated TCN produces
+contextual per-sample state scores. Initial-state, off-diagonal transition, and
+explicit-duration scores are trainable and normalized in log space. Training
+uses the exact semi-Markov log-partition rather than token-wise cross entropy;
+decoding calls the same Viterbi core as the classical model.
+
+Classical fitted probabilities can initialize the neural structure. This makes
+the comparison controlled: the neural method can begin from the classical
+state/duration prior and differ primarily in its learned contextual emission
+model. The full NILMTK training wrapper remains a separate PR so optimizer,
+windowing, checkpointing, and real-data validation do not get hidden inside
+the numerical-kernel review.
+
 Persistence, public export, the neural model, and NILMbench entries remain
 separate PRs. Neither model enters the public catalog until its complete
 training/inference contract and real-data T0 have passed.

--- a/nilmtk_contrib/torch/_neural_semi_markov.py
+++ b/nilmtk_contrib/torch/_neural_semi_markov.py
@@ -1,0 +1,282 @@
+"""Compact neural emissions with exact semi-Markov likelihood and decoding."""
+
+from __future__ import annotations
+
+from numbers import Real
+import math
+
+import torch
+from torch import nn
+
+from nilmtk_contrib.torch._semi_markov import (
+    semi_markov_nll,
+    semi_markov_viterbi,
+)
+from nilmtk_contrib.utils.params import validate_positive_int
+
+
+def _finite_probability(name, value, *, allow_zero=False) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, Real)
+        or not math.isfinite(value)
+    ):
+        raise ValueError(f"{name} must be a finite number.")
+    minimum_invalid = value < 0 if allow_zero else value <= 0
+    if minimum_invalid:
+        qualifier = "non-negative" if allow_zero else "positive"
+        raise ValueError(f"{name} must be {qualifier}.")
+    return float(value)
+
+
+class TemporalResidualBlock(nn.Module):
+    """Length-preserving dilated temporal residual block."""
+
+    def __init__(self, channels, kernel_size, dilation, dropout):
+        super().__init__()
+        validate_positive_int("channels", channels)
+        validate_positive_int("kernel_size", kernel_size)
+        validate_positive_int("dilation", dilation)
+        if kernel_size % 2 == 0:
+            raise ValueError("kernel_size must be odd to preserve alignment.")
+        dropout = _finite_probability("dropout", dropout, allow_zero=True)
+        if dropout >= 1:
+            raise ValueError("dropout must be less than one.")
+        padding = dilation * (kernel_size - 1) // 2
+        self.temporal = nn.Conv1d(
+            channels,
+            channels,
+            kernel_size,
+            padding=padding,
+            dilation=dilation,
+        )
+        self.normalization = nn.GroupNorm(1, channels)
+        self.activation = nn.GELU()
+        self.dropout = nn.Dropout(dropout)
+        self.projection = nn.Conv1d(channels, channels, kernel_size=1)
+
+    def forward(self, inputs):
+        residual = inputs
+        values = self.temporal(inputs)
+        values = self.normalization(values)
+        values = self.activation(values)
+        values = self.dropout(values)
+        return residual + self.projection(values)
+
+
+class NeuralSemiMarkovNetwork(nn.Module):
+    """TCN emission scorer with trainable exact semi-Markov structure."""
+
+    def __init__(
+        self,
+        *,
+        num_states=2,
+        max_duration=99,
+        hidden_channels=32,
+        num_blocks=3,
+        kernel_size=5,
+        dropout=0.1,
+    ):
+        super().__init__()
+        self.num_states = validate_positive_int("num_states", num_states)
+        if self.num_states < 2:
+            raise ValueError("num_states must be at least two.")
+        self.max_duration = validate_positive_int("max_duration", max_duration)
+        self.hidden_channels = validate_positive_int("hidden_channels", hidden_channels)
+        self.num_blocks = validate_positive_int("num_blocks", num_blocks)
+        self.kernel_size = validate_positive_int("kernel_size", kernel_size)
+        if self.kernel_size % 2 == 0:
+            raise ValueError("kernel_size must be odd to preserve alignment.")
+        self.dropout_probability = _finite_probability(
+            "dropout", dropout, allow_zero=True
+        )
+        if self.dropout_probability >= 1:
+            raise ValueError("dropout must be less than one.")
+
+        padding = self.kernel_size // 2
+        self.stem = nn.Conv1d(
+            1,
+            self.hidden_channels,
+            self.kernel_size,
+            padding=padding,
+        )
+        self.blocks = nn.ModuleList(
+            TemporalResidualBlock(
+                self.hidden_channels,
+                self.kernel_size,
+                dilation=2**index,
+                dropout=self.dropout_probability,
+            )
+            for index in range(self.num_blocks)
+        )
+        self.emission_head = nn.Conv1d(
+            self.hidden_channels, self.num_states, kernel_size=1
+        )
+        self.initial_logits = nn.Parameter(torch.zeros(self.num_states))
+        self.transition_logits = nn.Parameter(
+            torch.zeros((self.num_states, self.num_states))
+        )
+        self.duration_logits = nn.Parameter(
+            torch.zeros((self.num_states, self.max_duration))
+        )
+
+    def _validate_inputs(self, inputs) -> None:
+        if not isinstance(inputs, torch.Tensor):
+            raise TypeError("inputs must be a torch.Tensor.")
+        if (
+            inputs.ndim != 3
+            or inputs.shape[0] < 1
+            or inputs.shape[1] != 1
+            or inputs.shape[2] < 1
+        ):
+            raise ValueError(
+                "inputs must have shape (batch, 1, time) with batch/time >= 1."
+            )
+        if not torch.is_floating_point(inputs) or inputs.is_complex():
+            raise TypeError("inputs must be real floating tensors.")
+        if inputs.device != self.initial_logits.device:
+            raise ValueError(
+                f"inputs must be on model device {self.initial_logits.device}."
+            )
+        if not bool(torch.isfinite(inputs).all()):
+            raise ValueError("inputs must contain only finite values.")
+
+    def emission_scores(self, inputs) -> torch.Tensor:
+        """Return contextual per-time state scores with shape ``(B, T, K)``."""
+        self._validate_inputs(inputs)
+        values = inputs.to(dtype=self.initial_logits.dtype)
+        values = self.stem(values)
+        for block in self.blocks:
+            values = block(values)
+        scores = self.emission_head(values).transpose(1, 2)
+        if not bool(torch.isfinite(scores).all()):
+            raise RuntimeError("Neural semi-Markov emissions became non-finite.")
+        return scores
+
+    def structure_scores(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Return normalized initial, off-diagonal transition, and duration logs."""
+        initial = torch.log_softmax(self.initial_logits, dim=0)
+        diagonal = torch.eye(
+            self.num_states,
+            dtype=torch.bool,
+            device=self.transition_logits.device,
+        )
+        transitions = torch.log_softmax(
+            self.transition_logits.masked_fill(diagonal, -torch.inf),
+            dim=1,
+        )
+        durations = torch.log_softmax(self.duration_logits, dim=1)
+        return initial, transitions, durations
+
+    @torch.no_grad()
+    def initialize_structure(
+        self,
+        initial_probabilities,
+        transition_probabilities,
+        duration_probabilities,
+    ) -> None:
+        """Initialize logits from a fitted classical semi-Markov model."""
+        device = self.initial_logits.device
+        dtype = self.initial_logits.dtype
+        values = []
+        for name, probabilities, shape in (
+            ("initial_probabilities", initial_probabilities, (self.num_states,)),
+            (
+                "transition_probabilities",
+                transition_probabilities,
+                (self.num_states, self.num_states),
+            ),
+            (
+                "duration_probabilities",
+                duration_probabilities,
+                (self.num_states, self.max_duration),
+            ),
+        ):
+            try:
+                tensor = torch.as_tensor(probabilities, dtype=dtype, device=device)
+            except (TypeError, ValueError, RuntimeError) as exc:
+                raise TypeError(f"{name} must contain real numeric values.") from exc
+            if tuple(tensor.shape) != shape:
+                raise ValueError(f"{name} must have shape {shape}.")
+            if not bool(torch.isfinite(tensor).all()) or bool((tensor < 0).any()):
+                raise ValueError(f"{name} must contain finite non-negative values.")
+            values.append(tensor)
+        initial, transitions, durations = values
+        if bool((initial <= 0).any()) or not torch.isclose(
+            initial.sum(), initial.new_tensor(1.0), atol=1e-6, rtol=1e-6
+        ):
+            raise ValueError("initial_probabilities must be positive and sum to one.")
+        diagonal = torch.eye(self.num_states, dtype=torch.bool, device=device)
+        if bool((transitions[diagonal] != 0).any()) or bool(
+            (transitions[~diagonal] <= 0).any()
+        ):
+            raise ValueError(
+                "transition_probabilities must have zero diagonal and positive "
+                "off-diagonal values."
+            )
+        if not torch.allclose(
+            transitions.sum(dim=1),
+            torch.ones(self.num_states, dtype=dtype, device=device),
+            atol=1e-6,
+            rtol=1e-6,
+        ):
+            raise ValueError("transition_probabilities rows must sum to one.")
+        if bool((durations <= 0).any()) or not torch.allclose(
+            durations.sum(dim=1),
+            torch.ones(self.num_states, dtype=dtype, device=device),
+            atol=1e-6,
+            rtol=1e-6,
+        ):
+            raise ValueError(
+                "duration_probabilities must be positive and rows must sum to one."
+            )
+        self.initial_logits.copy_(torch.log(initial))
+        self.transition_logits.copy_(
+            torch.where(diagonal, torch.zeros_like(transitions), torch.log(transitions))
+        )
+        self.duration_logits.copy_(torch.log(durations))
+
+    def negative_log_likelihood(self, inputs, states) -> torch.Tensor:
+        """Return mean exact semi-Markov NLL for a labeled mini-batch."""
+        emissions = self.emission_scores(inputs)
+        if not isinstance(states, torch.Tensor):
+            raise TypeError("states must be a torch.Tensor.")
+        if states.dtype != torch.int64 or states.ndim != 2:
+            raise TypeError("states must be a two-dimensional torch.int64 tensor.")
+        if states.device != emissions.device:
+            raise ValueError(f"states must be on {emissions.device}.")
+        if tuple(states.shape) != emissions.shape[:2]:
+            raise ValueError(f"states must have shape {tuple(emissions.shape[:2])}.")
+        initial, transitions, durations = self.structure_scores()
+        losses = [
+            semi_markov_nll(
+                labels,
+                scores,
+                initial,
+                transitions,
+                durations,
+            )
+            for scores, labels in zip(emissions, states)
+        ]
+        loss = torch.stack(losses).mean()
+        if not bool(torch.isfinite(loss)):
+            raise RuntimeError("Neural semi-Markov loss became non-finite.")
+        return loss
+
+    @torch.no_grad()
+    def decode(self, inputs):
+        """Decode each sequence with the shared exact semi-Markov Viterbi core."""
+        was_training = self.training
+        self.eval()
+        try:
+            emissions = self.emission_scores(inputs)
+            initial, transitions, durations = self.structure_scores()
+            return tuple(
+                semi_markov_viterbi(scores, initial, transitions, durations)
+                for scores in emissions
+            )
+        finally:
+            self.train(was_training)
+
+
+__all__ = ["NeuralSemiMarkovNetwork", "TemporalResidualBlock"]

--- a/tests/test_model_registry_comprehensive.py
+++ b/tests/test_model_registry_comprehensive.py
@@ -247,6 +247,7 @@ def test_model_self_method_calls_are_defined_or_known_runtime_methods(repo_root)
     known_runtime_methods = {
         "apply",
         "appliance_minmax_params",
+        "eval",
         "load_model",
         "modules",
         "named_parameters",
@@ -254,6 +255,7 @@ def test_model_self_method_calls_are_defined_or_known_runtime_methods(repo_root)
         "require_models",
         "save_model",
         "set_appliance_params",
+        "train",
         "_validated_appliance_stats",
         "_checked_model_output",
     }

--- a/tests/test_neural_semi_markov.py
+++ b/tests/test_neural_semi_markov.py
@@ -1,0 +1,250 @@
+import inspect
+from pathlib import Path
+
+import pytest
+
+
+torch = pytest.importorskip("torch")
+
+from nilmtk_contrib.torch._neural_semi_markov import (  # noqa: E402
+    NeuralSemiMarkovNetwork,
+    TemporalResidualBlock,
+)
+
+
+def _network(**overrides):
+    params = {
+        "num_states": 2,
+        "max_duration": 6,
+        "hidden_channels": 8,
+        "num_blocks": 2,
+        "kernel_size": 3,
+        "dropout": 0.0,
+    }
+    params.update(overrides)
+    return NeuralSemiMarkovNetwork(**params)
+
+
+def _batch(length=6):
+    inputs = torch.tensor(
+        [
+            [[0.0, 0.1, -0.1, 1.0, 1.1, 0.9]],
+            [[1.0, 0.9, 1.1, 0.0, 0.1, -0.1]],
+        ],
+        dtype=torch.float32,
+    )[:, :, :length]
+    states = torch.tensor(
+        [[0, 0, 0, 1, 1, 1], [1, 1, 1, 0, 0, 0]],
+        dtype=torch.int64,
+    )[:, :length]
+    return inputs, states
+
+
+def test_network_emissions_preserve_batch_time_and_state_axes():
+    network = _network(num_states=3)
+    inputs = torch.randn(4, 1, 11)
+
+    scores = network.emission_scores(inputs)
+
+    assert scores.shape == (4, 11, 3)
+    assert torch.isfinite(scores).all()
+    assert sum(parameter.numel() for parameter in network.parameters()) < 5_000
+
+
+def test_structure_scores_are_normalized_and_forbid_self_transitions():
+    network = _network(num_states=3, max_duration=5)
+    initial, transitions, durations = network.structure_scores()
+
+    assert float(torch.exp(initial).sum()) == pytest.approx(1.0)
+    assert torch.isneginf(torch.diagonal(transitions)).all()
+    assert torch.allclose(
+        torch.exp(transitions).sum(dim=1), torch.ones(3), atol=1e-7, rtol=0
+    )
+    assert torch.allclose(
+        torch.exp(durations).sum(dim=1), torch.ones(3), atol=1e-7, rtol=0
+    )
+
+
+def test_classical_probabilities_initialize_the_same_structure_scores():
+    network = _network(max_duration=3)
+    initial = [0.8, 0.2]
+    transitions = [[0.0, 1.0], [1.0, 0.0]]
+    durations = [[0.6, 0.3, 0.1], [0.2, 0.3, 0.5]]
+
+    network.initialize_structure(initial, transitions, durations)
+    actual_initial, actual_transitions, actual_durations = network.structure_scores()
+
+    assert torch.exp(actual_initial).tolist() == pytest.approx(initial)
+    assert torch.allclose(
+        torch.exp(actual_transitions), torch.tensor(transitions), atol=1e-7, rtol=0
+    )
+    assert torch.allclose(
+        torch.exp(actual_durations), torch.tensor(durations), atol=1e-7, rtol=0
+    )
+
+
+def test_exact_nll_is_finite_nonnegative_and_backpropagates_every_score_family():
+    torch.manual_seed(4)
+    network = _network()
+    inputs, states = _batch()
+
+    loss = network.negative_log_likelihood(inputs, states)
+    loss.backward()
+
+    assert float(loss) >= 0
+    for name, parameter in network.named_parameters():
+        assert parameter.grad is not None, name
+        assert torch.isfinite(parameter.grad).all(), name
+    assert torch.all(torch.diagonal(network.transition_logits.grad) == 0)
+
+
+def test_a_small_optimizer_run_reduces_the_structured_training_loss():
+    torch.manual_seed(9)
+    network = _network(dropout=0.0)
+    inputs, states = _batch()
+    optimizer = torch.optim.Adam(network.parameters(), lr=0.02)
+    initial_loss = float(network.negative_log_likelihood(inputs, states))
+
+    for _ in range(12):
+        optimizer.zero_grad(set_to_none=True)
+        loss = network.negative_log_likelihood(inputs, states)
+        loss.backward()
+        optimizer.step()
+
+    final_loss = float(network.negative_log_likelihood(inputs, states))
+    assert final_loss < initial_loss
+
+
+def test_decode_is_deterministic_and_restores_training_mode():
+    torch.manual_seed(12)
+    network = _network(dropout=0.3)
+    inputs, _ = _batch()
+    network.train()
+
+    first = network.decode(inputs)
+    second = network.decode(inputs)
+
+    assert network.training
+    assert len(first) == len(inputs)
+    assert all(result.states.shape == (inputs.shape[2],) for result in first)
+    assert all(result.segments for result in first)
+    assert [result.score for result in first] == [result.score for result in second]
+    assert all(
+        torch.equal(left.states, right.states) for left, right in zip(first, second)
+    )
+
+
+def test_residual_block_preserves_length_and_propagates_gradients():
+    block = TemporalResidualBlock(channels=4, kernel_size=3, dilation=4, dropout=0.0)
+    inputs = torch.randn(2, 4, 17, requires_grad=True)
+
+    output = block(inputs)
+    output.square().mean().backward()
+
+    assert output.shape == inputs.shape
+    assert inputs.grad is not None
+    assert torch.isfinite(inputs.grad).all()
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error", "message"),
+    [
+        ({"num_states": 1}, ValueError, "at least two"),
+        ({"max_duration": 0}, ValueError, "positive integer"),
+        ({"hidden_channels": True}, ValueError, "positive integer"),
+        ({"num_blocks": 0}, ValueError, "positive integer"),
+        ({"kernel_size": 4}, ValueError, "odd"),
+        ({"dropout": -0.1}, ValueError, "non-negative"),
+        ({"dropout": 1.0}, ValueError, "less than one"),
+    ],
+)
+def test_invalid_architecture_configuration_fails(overrides, error, message):
+    with pytest.raises(error, match=message):
+        _network(**overrides)
+
+
+@pytest.mark.parametrize(
+    ("inputs", "error", "message"),
+    [
+        ([[[1.0]]], TypeError, "torch.Tensor"),
+        (torch.ones(2, 6), ValueError, "shape"),
+        (torch.ones(2, 2, 6), ValueError, "shape"),
+        (torch.ones(0, 1, 6), ValueError, "batch/time >= 1"),
+        (torch.ones(2, 1, 0), ValueError, "batch/time >= 1"),
+        (torch.ones(2, 1, 6, dtype=torch.int64), TypeError, "floating"),
+        (
+            torch.full((2, 1, 6), float("nan")),
+            ValueError,
+            "finite",
+        ),
+    ],
+)
+def test_invalid_network_inputs_fail_closed(inputs, error, message):
+    with pytest.raises(error, match=message):
+        _network().emission_scores(inputs)
+
+
+@pytest.mark.parametrize(
+    ("states", "error", "message"),
+    [
+        ([[0, 0, 0, 1, 1, 1]], TypeError, "torch.Tensor"),
+        (torch.zeros((2, 6), dtype=torch.float32), TypeError, "torch.int64"),
+        (torch.zeros(12, dtype=torch.int64), TypeError, "two-dimensional"),
+        (torch.zeros((1, 6), dtype=torch.int64), ValueError, "shape"),
+        (
+            torch.tensor([[0, 0, 0, 1, 1, 2], [1, 1, 1, 0, 0, 0]]),
+            ValueError,
+            "between 0 and 1",
+        ),
+    ],
+)
+def test_invalid_training_labels_fail_closed(states, error, message):
+    inputs, _ = _batch()
+    with pytest.raises(error, match=message):
+        _network().negative_log_likelihood(inputs, states)
+
+
+def test_gold_segment_longer_than_duration_support_is_rejected():
+    inputs, _ = _batch()
+    states = torch.zeros((2, inputs.shape[2]), dtype=torch.int64)
+
+    with pytest.raises(ValueError, match="longer than max_duration"):
+        _network(max_duration=3).negative_log_likelihood(inputs, states)
+
+
+@pytest.mark.parametrize(
+    ("values", "message"),
+    [
+        (([0.5, 0.5], [[0.5, 0.5], [1.0, 0.0]], [[0.5] * 6] * 2), "zero diagonal"),
+        (([1.0, 0.0], [[0.0, 1.0], [1.0, 0.0]], [[0.5] * 6] * 2), "positive and sum"),
+        (
+            ([0.5, 0.5], [[0.0, 1.0], [1.0, 0.0]], [[1.0, 0, 0, 0, 0, 0]] * 2),
+            "positive",
+        ),
+    ],
+)
+def test_invalid_classical_initialization_fails(values, message):
+    with pytest.raises(ValueError, match=message):
+        _network().initialize_structure(*values)
+
+
+def test_network_reuses_shared_dynamic_program_instead_of_copying_it():
+    source = Path(inspect.getfile(NeuralSemiMarkovNetwork)).read_text(encoding="utf-8")
+
+    assert "semi_markov_nll" in source
+    assert "semi_markov_viterbi" in source
+    assert "logsumexp" not in source
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_cuda_loss_and_decode_are_finite():
+    network = _network().cuda()
+    inputs, states = _batch()
+    inputs = inputs.cuda()
+    states = states.cuda()
+
+    loss = network.negative_log_likelihood(inputs, states)
+    decoded = network.decode(inputs)
+
+    assert torch.isfinite(loss)
+    assert all(result.states.device.type == "cuda" for result in decoded)


### PR DESCRIPTION
## Summary

- add a private compact dilated-TCN scorer for the exact semi-Markov core from #124
- learn contextual emissions plus normalized initial, off-diagonal transition, and explicit-duration scores
- train with exact semi-Markov conditional NLL and decode with the same exact Viterbi implementation
- allow controlled initialization from the classical probabilities fitted by #125
- make decode deterministic even when called in training mode, restoring the caller's mode afterward

This is the numerical/network layer only. NILMTK optimization/windowing, persistence, public export, and NILMbench entry remain gated follow-ups.

## Verification

- normalized structural scores and forbidden self-transitions
- classical-to-neural initialization parity
- finite gradients for every parameter family, zero diagonal transition gradient, and a small optimizer run that reduces exact NLL
- shape/dtype/device/config/probability/overlong-segment failures
- deterministic decode with training-mode restoration, residual-block gradient flow, optional CUDA loss/decode
- focused structured suite — 61 passed, 2 skipped
- `ruff check nilmtk_contrib tests scripts`
- `pytest -q` — 902 passed, 104 skipped
- `uv build` — source distribution and wheel built successfully

The implementation imports the shared NLL/Viterbi core and contains no second `logsumexp` recurrence.
