### PR TITLE
Publish validated explicit-duration HSMM baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ The table below lists the public model surface. "Verification" describes how the
 | DAE | TensorFlow | `nilmtk_contrib.disaggregate.DAE` | Neural NILM implementation requiring experiment validation for new claims | Kelly and Knottenbelt, Neural NILM | TensorFlow/Keras backend |
 | DAE | PyTorch | `nilmtk_contrib.torch.DAE` | PyTorch implementation requiring parity validation for new claims | Kelly and Knottenbelt, Neural NILM | PyTorch backend |
 | DLinear | PyTorch | `nilmtk_contrib.torch.DLinear` | DLinear-inspired sequence-to-point adaptation; benchmark claims require NILMbench result bundles | Zeng et al., DLinear | PyTorch backend |
+| HSMM | PyTorch | `nilmtk_contrib.torch.HSMM` | Supervised single-appliance explicit-duration baseline; benchmark claims require NILMbench result bundles | Chiappa, explicit-duration Markov switching models | Exact PyTorch dynamic program; no external solver |
 | RNN | TensorFlow | `nilmtk_contrib.disaggregate.RNN` | Neural NILM implementation requiring experiment validation for new claims | Kelly and Knottenbelt, Neural NILM | TensorFlow/Keras backend |
 | RNN | PyTorch | `nilmtk_contrib.torch.RNN` | PyTorch implementation requiring parity validation for new claims | Kelly and Knottenbelt, Neural NILM | PyTorch backend |
 | Seq2Point | TensorFlow | `nilmtk_contrib.disaggregate.Seq2Point` | NILM paper implementation requiring dataset-specific validation | Zhang et al., Sequence-to-Point Learning | TensorFlow/Keras backend |
@@ -284,6 +285,8 @@ NILM-specific references:
 - Sudoso and Piccialli, "Non-Intrusive Load Monitoring with an Attention-based Deep Neural Network", arXiv:1912.00759, https://arxiv.org/abs/1912.00759.
 - MSDC, "Exploiting Multi-State Power Consumption in Non-intrusive Load Monitoring based on A Dual-CNN Model", arXiv:2302.05565, https://arxiv.org/abs/2302.05565.
 - Petralia et al., "NILMFormer: Non-Intrusive Load Monitoring that Accounts for Non-Stationarity", arXiv:2506.05880, https://arxiv.org/abs/2506.05880.
+- Chiappa, "Explicit-Duration Markov Switching Models", arXiv:1909.05800, https://arxiv.org/abs/1909.05800.
+- Wu et al., "A time-efficient factorial hidden Semi-Markov model for non-intrusive load monitoring", Electric Power Systems Research 2021, https://doi.org/10.1016/j.epsr.2021.107372.
 - Nie et al., "A Time Series is Worth 64 Words: Long-term Forecasting with Transformers", arXiv:2211.14730, https://arxiv.org/abs/2211.14730.
 - Luo and Wang, "ModernTCN: A Modern Pure Convolution Structure for General Time Series Analysis", ICLR 2024, https://openreview.net/forum?id=vpJMJerXHU.
 - Zeng et al., "Are Transformers Effective for Time Series Forecasting?", AAAI 2023, https://arxiv.org/abs/2205.13504.

--- a/docs/explicit-duration-models.md
+++ b/docs/explicit-duration-models.md
@@ -38,15 +38,18 @@ The private `nilmtk_contrib.torch._hsmm` layer now fits the classical model
 from aligned mains and appliance chunks. It shares deterministic ordered state
 fitting with LBM, learns initial and between-segment transition probabilities,
 an explicit duration histogram for each state, and Gaussian aggregate
-emissions conditioned on the labeled appliance state. Inference splits long
-chunks only at the configured duration cap and sends every block through the
-exact shared Viterbi recurrence.
+emissions conditioned on the labeled appliance state. Inference sends each
+complete input chunk through the exact shared Viterbi recurrence; the duration
+cap limits one state's dwell time but does not introduce artificial reset
+boundaries.
 
 The fitter is intentionally supervised and one-target-at-a-time. It is a
 small, benchmarkable baseline, not a claim to reproduce the factorial
-multi-appliance inference or timing features of TE-FHSMM. Model persistence is
-fail-closed until the next artifact PR, and the class remains private until a
-real-data T0 run succeeds.
+multi-appliance inference or timing features of TE-FHSMM. The public `HSMM`
+export stores fitted parameters in a validated, schema-versioned JSON artifact;
+it does not load executable pickle data. A private real-data gate on the
+corrected REDD T0 split passed before public export. Official multi-seed results
+remain a separate NILMbench publication step.
 
 ## Neural scoring layer
 
@@ -64,6 +67,6 @@ model. The full NILMTK training wrapper remains a separate PR so optimizer,
 windowing, checkpointing, and real-data validation do not get hidden inside
 the numerical-kernel review.
 
-Persistence, public export, the neural model, and NILMbench entries remain
-separate PRs. Neither model enters the public catalog until its complete
-training/inference contract and real-data T0 have passed.
+The neural wrapper and NILMbench entries remain separate PRs. The neural scorer
+does not enter the public catalog until its complete training, persistence, and
+real-data contracts pass.

--- a/nilmtk_contrib/metadata.py
+++ b/nilmtk_contrib/metadata.py
@@ -30,6 +30,7 @@ MODEL_CATALOG = (
     ModelCatalogEntry("ConvLSTM", "torch", "nilmtk_contrib.torch.conv_lstm", "ConvLSTM", "nilmtk_contrib.torch"),
     ModelCatalogEntry("DAE", "torch", "nilmtk_contrib.torch.dae", "DAE", "nilmtk_contrib.torch"),
     ModelCatalogEntry("DLinear", "torch", "nilmtk_contrib.torch.dlinear", "DLinear", "nilmtk_contrib.torch"),
+    ModelCatalogEntry("HSMM", "torch", "nilmtk_contrib.torch.hsmm", "HSMM", "nilmtk_contrib.torch"),
     ModelCatalogEntry("MSDC", "torch", "nilmtk_contrib.torch.msdc", "MSDC", "nilmtk_contrib.torch"),
     ModelCatalogEntry("MSDC without CRF", "torch", "nilmtk_contrib.torch.msdc_without_crf", "MSDC", None),
     ModelCatalogEntry("ModernTCN", "torch", "nilmtk_contrib.torch.moderntcn", "ModernTCN", "nilmtk_contrib.torch"),

--- a/nilmtk_contrib/torch/__init__.py
+++ b/nilmtk_contrib/torch/__init__.py
@@ -9,6 +9,7 @@ _EXPORTS = {
     "ConvLSTM": ("nilmtk_contrib.torch.conv_lstm", "ConvLSTM"),
     "DAE": ("nilmtk_contrib.torch.dae", "DAE"),
     "DLinear": ("nilmtk_contrib.torch.dlinear", "DLinear"),
+    "HSMM": ("nilmtk_contrib.torch.hsmm", "HSMM"),
     "MSDC": ("nilmtk_contrib.torch.msdc", "MSDC"),
     "ModernTCN": ("nilmtk_contrib.torch.moderntcn", "ModernTCN"),
     "NILMFormer": ("nilmtk_contrib.torch.nilmformer", "NILMFormer"),

--- a/nilmtk_contrib/torch/_base.py
+++ b/nilmtk_contrib/torch/_base.py
@@ -16,7 +16,11 @@ import torch
 from nilmtk.disaggregate import Disaggregator
 
 from nilmtk_contrib.utils.model import initialize_runtime
-from nilmtk_contrib.utils.params import normalize_common_params
+from nilmtk_contrib.utils.params import (
+    DEFAULT_ALIASES,
+    get_param,
+    normalize_common_params,
+)
 
 
 SUPPORTED_DEVICE_TYPES = frozenset({"cpu", "cuda", "mps"})
@@ -294,6 +298,74 @@ def compute_appliance_stats(
     if not statistics:
         raise ValueError("At least one appliance target is required.")
     return statistics
+
+
+class TorchStateSpaceDisaggregator(Disaggregator):
+    """Shared runtime for PyTorch state-space models without fake neural options."""
+
+    def __init__(self, params=None):
+        if params is None:
+            params = {}
+        if not isinstance(params, Mapping):
+            raise TypeError("params must be a mapping or None.")
+        seed = get_param(params, "seed")
+        verbose = get_param(params, "verbose", False)
+        chunk_wise_training = get_param(params, "chunk_wise_training", False)
+        if seed is not None and (
+            isinstance(seed, bool) or not isinstance(seed, Integral)
+        ):
+            raise ValueError("seed must be an integer or None.")
+        if not isinstance(verbose, bool):
+            raise ValueError("verbose must be a boolean.")
+        if not isinstance(chunk_wise_training, bool):
+            raise ValueError("chunk_wise_training must be a boolean.")
+
+        super().__init__()
+        initialize_runtime(
+            self,
+            {"seed": seed, "verbose": verbose},
+            backends=("python", "numpy", "torch"),
+        )
+        self.device = resolve_torch_device(get_param(params, "device"))
+        self.seed = seed
+        self.verbose = verbose
+        self.chunk_wise_training = chunk_wise_training
+        self.save_model_path = get_param(
+            params,
+            "save_model_path",
+            aliases=DEFAULT_ALIASES["save_model_path"],
+        )
+        self.load_model_path = get_param(
+            params,
+            "pretrained_model_path",
+            aliases=DEFAULT_ALIASES["pretrained_model_path"],
+        )
+        self.models = OrderedDict()
+
+    def _validate_model_record(self, appliance_name, model):
+        del appliance_name, model
+        raise NotImplementedError("State-space subclasses must validate model records.")
+
+    def require_models(self, models=None):
+        """Validate and optionally install a detached state-space model mapping."""
+        install_models = models is not None
+        candidate = models if install_models else self.models
+        if not isinstance(candidate, Mapping):
+            raise TypeError("models must be a mapping of appliance names to records.")
+        if not candidate:
+            if install_models:
+                raise ValueError("models must contain at least one appliance model.")
+            model_name = getattr(self, "MODEL_NAME", self.__class__.__name__)
+            raise RuntimeError(f"{model_name} requires a trained or loaded model.")
+
+        validated = OrderedDict()
+        for appliance_name, model in candidate.items():
+            _validate_appliance_name(appliance_name, label="Model appliance")
+            self._validate_model_record(appliance_name, model)
+            validated[appliance_name] = model
+        if install_models:
+            self.models = validated
+        return validated
 
 
 class TorchDisaggregator(Disaggregator):

--- a/nilmtk_contrib/torch/_hsmm.py
+++ b/nilmtk_contrib/torch/_hsmm.py
@@ -4,26 +4,22 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, fields
+import json
 from numbers import Integral, Real
 import math
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import torch
-from nilmtk.disaggregate import Disaggregator
 
-from nilmtk_contrib.torch._base import resolve_torch_device
+from nilmtk_contrib.torch._base import TorchStateSpaceDisaggregator
 from nilmtk_contrib.torch._data import power_vector
 from nilmtk_contrib.torch._semi_markov import semi_markov_viterbi
 from nilmtk_contrib.torch._state_fitting import assign_states, fit_state_means
-from nilmtk_contrib.utils.checkpoints import unsupported_persistence
-from nilmtk_contrib.utils.model import initialize_runtime
-from nilmtk_contrib.utils.params import (
-    DEFAULT_ALIASES,
-    get_param,
-    validate_positive_int,
-)
+from nilmtk_contrib.utils.checkpoints import save_json_atomic
+from nilmtk_contrib.utils.params import get_param, validate_positive_int
 
 
 @dataclass(frozen=True)
@@ -44,6 +40,18 @@ class _HSMMParameters:
     right_censored_segments: int
 
 
+_ARTIFACT_FILENAME = "hsmm.json"
+_ARTIFACT_SCHEMA_VERSION = 1
+_CONFIG_FIELDS = (
+    "num_states",
+    "max_duration",
+    "pseudocount",
+    "variance_floor",
+    "kmeans_max_iterations",
+)
+_PARAMETER_FIELDS = {field.name for field in fields(_HSMMParameters)}
+
+
 def _positive_finite(name, value) -> float:
     if (
         isinstance(value, bool)
@@ -53,6 +61,201 @@ def _positive_finite(name, value) -> float:
     ):
         raise ValueError(f"{name} must be a positive finite number.")
     return float(value)
+
+
+def _positive_integer(name, value) -> int:
+    return validate_positive_int(name, value)
+
+
+def _count_vector(name, values, length) -> tuple[int, ...]:
+    if not isinstance(values, (list, tuple)) or len(values) != length:
+        raise ValueError(f"{name} must contain exactly {length} counts.")
+    result = []
+    for value in values:
+        if isinstance(value, bool) or not isinstance(value, Integral) or value < 0:
+            raise ValueError(f"{name} must contain non-negative integers.")
+        result.append(int(value))
+    return tuple(result)
+
+
+def _finite_vector(name, values, length, *, positive=False, non_negative=False):
+    if not isinstance(values, (list, tuple)) or len(values) != length:
+        raise ValueError(f"{name} must contain exactly {length} values.")
+    result = []
+    for value in values:
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, Real)
+            or not math.isfinite(value)
+            or (positive and value <= 0)
+            or (non_negative and value < 0)
+        ):
+            qualifier = (
+                "positive finite"
+                if positive
+                else "non-negative finite"
+                if non_negative
+                else "finite"
+            )
+            raise ValueError(f"{name} must contain {qualifier} values.")
+        result.append(float(value))
+    return tuple(result)
+
+
+def _matrix(name, values, rows, columns, converter):
+    if not isinstance(values, (list, tuple)) or len(values) != rows:
+        raise ValueError(f"{name} must contain exactly {rows} rows.")
+    return tuple(
+        converter(f"{name}[{index}]", row, columns)
+        for index, row in enumerate(values)
+    )
+
+
+def _validate_fitted_model(model, *, num_states, max_duration) -> None:
+    if not isinstance(model, _HSMMParameters):
+        raise TypeError("HSMM model values must be fitted HSMM parameters.")
+    state_means = _finite_vector(
+        "state_means", model.state_means, num_states, non_negative=True
+    )
+    if any(left >= right for left, right in zip(state_means, state_means[1:])):
+        raise ValueError("state_means must be strictly increasing.")
+    _finite_vector(
+        "aggregate_means", model.aggregate_means, num_states, non_negative=True
+    )
+    _finite_vector(
+        "aggregate_variances", model.aggregate_variances, num_states, positive=True
+    )
+    initial = _finite_vector(
+        "initial_probabilities", model.initial_probabilities, num_states, positive=True
+    )
+    transitions = _matrix(
+        "transition_probabilities",
+        model.transition_probabilities,
+        num_states,
+        num_states,
+        lambda name, row, length: _finite_vector(
+            name, row, length, non_negative=True
+        ),
+    )
+    durations = _matrix(
+        "duration_probabilities",
+        model.duration_probabilities,
+        num_states,
+        max_duration,
+        lambda name, row, length: _finite_vector(name, row, length, positive=True),
+    )
+    if not math.isclose(sum(initial), 1.0, rel_tol=1e-6, abs_tol=1e-6):
+        raise ValueError("initial_probabilities must sum to one.")
+    for state, row in enumerate(transitions):
+        if row[state] != 0 or any(
+            probability <= 0
+            for other, probability in enumerate(row)
+            if other != state
+        ):
+            raise ValueError(
+                "transition_probabilities must have a zero diagonal and positive "
+                "off-diagonal values."
+            )
+        if not math.isclose(sum(row), 1.0, rel_tol=1e-6, abs_tol=1e-6):
+            raise ValueError("transition_probabilities rows must sum to one.")
+    if any(
+        not math.isclose(sum(row), 1.0, rel_tol=1e-6, abs_tol=1e-6)
+        for row in durations
+    ):
+        raise ValueError("duration_probabilities rows must sum to one.")
+
+    state_counts = _count_vector("state_counts", model.state_counts, num_states)
+    if any(count == 0 for count in state_counts):
+        raise ValueError("state_counts must show at least one sample in every state.")
+    initial_counts = _count_vector("initial_counts", model.initial_counts, num_states)
+    transition_counts = _matrix(
+        "transition_counts",
+        model.transition_counts,
+        num_states,
+        num_states,
+        _count_vector,
+    )
+    duration_counts = _matrix(
+        "duration_counts",
+        model.duration_counts,
+        num_states,
+        max_duration,
+        _count_vector,
+    )
+    num_samples = _positive_integer("num_samples", model.num_samples)
+    num_chunks = _positive_integer("num_chunks", model.num_chunks)
+    num_segments = _positive_integer("num_segments", model.num_segments)
+    right_censored = model.right_censored_segments
+    if (
+        isinstance(right_censored, bool)
+        or not isinstance(right_censored, Integral)
+        or not 0 <= right_censored <= num_segments
+    ):
+        raise ValueError(
+            "right_censored_segments must be an integer between zero and num_segments."
+        )
+    if any(row[state] != 0 for state, row in enumerate(transition_counts)):
+        raise ValueError("transition_counts must have a zero diagonal.")
+    if num_segments < num_chunks:
+        raise ValueError("num_segments must be at least num_chunks.")
+    expected_totals = (
+        (sum(state_counts), num_samples, "state_counts"),
+        (sum(initial_counts), num_chunks, "initial_counts"),
+        (
+            sum(map(sum, transition_counts)),
+            num_segments - num_chunks,
+            "transition_counts",
+        ),
+        (sum(map(sum, duration_counts)), num_segments, "duration_counts"),
+    )
+    for observed, expected, name in expected_totals:
+        if observed != expected:
+            raise ValueError(f"{name} total is inconsistent with fitted metadata.")
+
+
+def _parameters_from_payload(payload, *, num_states, max_duration):
+    if not isinstance(payload, Mapping) or set(payload) != _PARAMETER_FIELDS:
+        raise ValueError("HSMM artifact has invalid fitted-parameter fields.")
+    try:
+        parameters = _HSMMParameters(
+            state_means=tuple(payload["state_means"]),
+            aggregate_means=tuple(payload["aggregate_means"]),
+            aggregate_variances=tuple(payload["aggregate_variances"]),
+            initial_probabilities=tuple(payload["initial_probabilities"]),
+            transition_probabilities=tuple(
+                tuple(row) for row in payload["transition_probabilities"]
+            ),
+            duration_probabilities=tuple(
+                tuple(row) for row in payload["duration_probabilities"]
+            ),
+            state_counts=tuple(payload["state_counts"]),
+            initial_counts=tuple(payload["initial_counts"]),
+            transition_counts=tuple(tuple(row) for row in payload["transition_counts"]),
+            duration_counts=tuple(tuple(row) for row in payload["duration_counts"]),
+            num_samples=payload["num_samples"],
+            num_chunks=payload["num_chunks"],
+            num_segments=payload["num_segments"],
+            right_censored_segments=payload["right_censored_segments"],
+        )
+    except (TypeError, KeyError) as exc:
+        raise ValueError("HSMM artifact fitted parameters are malformed.") from exc
+    _validate_fitted_model(
+        parameters, num_states=num_states, max_duration=max_duration
+    )
+    return parameters
+
+
+def _reject_json_constant(value):
+    raise ValueError(f"Invalid JSON constant {value!r}.")
+
+
+def _unique_json_object(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"Duplicate JSON key {key!r}.")
+        result[key] = value
+    return result
 
 
 def _as_power_tensor(frame, label) -> torch.Tensor:
@@ -179,7 +382,7 @@ def _fit_hsmm(
     ):
         raise RuntimeError("HSMM emission fitting produced non-finite parameters.")
 
-    return _HSMMParameters(
+    fitted = _HSMMParameters(
         state_means=tuple(float(value) for value in state_means),
         aggregate_means=tuple(float(value) for value in aggregate_means),
         aggregate_variances=tuple(float(value) for value in aggregate_variances),
@@ -203,9 +406,13 @@ def _fit_hsmm(
         num_segments=num_segments,
         right_censored_segments=right_censored_segments,
     )
+    _validate_fitted_model(
+        fitted, num_states=num_states, max_duration=max_duration
+    )
+    return fitted
 
 
-def _decode_block(values, model: _HSMMParameters, device) -> np.ndarray:
+def _decode_sequence(values, model: _HSMMParameters, device) -> np.ndarray:
     observations = torch.as_tensor(values, dtype=torch.float64, device=device)
     state_means = torch.tensor(model.state_means, dtype=torch.float64, device=device)
     aggregate_means = torch.tensor(
@@ -237,16 +444,14 @@ def _decode_block(values, model: _HSMMParameters, device) -> np.ndarray:
     return state_means[path.states].to(dtype=torch.float32).cpu().numpy()
 
 
-class HSMM(Disaggregator):
+class HSMM(TorchStateSpaceDisaggregator):
     """Explicit-duration Gaussian HSMM fitted from aligned appliance labels."""
 
     MODEL_NAME = "HSMM"
 
     def __init__(self, params=None):
+        super().__init__(params)
         params = {} if params is None else params
-        if not isinstance(params, Mapping):
-            raise TypeError("params must be a mapping or None.")
-        super().__init__()
         self.num_states = validate_positive_int(
             "num_states", get_param(params, "num_states", 2)
         )
@@ -265,42 +470,103 @@ class HSMM(Disaggregator):
             "kmeans_max_iterations",
             get_param(params, "kmeans_max_iterations", 100),
         )
-        self.device = resolve_torch_device(get_param(params, "device"))
         if self.device.type == "mps":
             raise ValueError("HSMM supports CPU and CUDA; float64 MPS is unsupported.")
-        self.seed = get_param(params, "seed")
-        self.verbose = get_param(params, "verbose", False)
-        if self.seed is not None and (
-            isinstance(self.seed, bool) or not isinstance(self.seed, Integral)
-        ):
-            raise ValueError("seed must be an integer or None.")
-        if not isinstance(self.verbose, bool):
-            raise ValueError("verbose must be a boolean.")
-        self.chunk_wise_training = False
-        self.save_model_path = get_param(
-            params,
-            "save_model_path",
-            aliases=DEFAULT_ALIASES["save_model_path"],
-        )
-        self.load_model_path = get_param(
-            params,
-            "pretrained_model_path",
-            aliases=DEFAULT_ALIASES["pretrained_model_path"],
-        )
-        self.models = OrderedDict()
-        initialize_runtime(
-            self,
-            {"seed": self.seed, "verbose": self.verbose},
-            backends=("python", "numpy", "torch"),
-        )
+        if self.chunk_wise_training:
+            raise ValueError("HSMM does not support chunk_wise_training.")
         if self.load_model_path:
             self.load_model(self.load_model_path)
 
-    def save_model(self, *_, **__):
-        unsupported_persistence(self.MODEL_NAME)
+    def _validate_model_record(self, appliance_name, model):
+        del appliance_name
+        _validate_fitted_model(
+            model,
+            num_states=self.num_states,
+            max_duration=self.max_duration,
+        )
 
-    def load_model(self, *_, **__):
-        unsupported_persistence(self.MODEL_NAME)
+    def save_model(self, path=None):
+        target = path if path is not None else self.save_model_path
+        if target is None:
+            raise ValueError("HSMM save_model requires a checkpoint directory.")
+        models = self.require_models()
+        serialized_models = {}
+        for appliance_name, fitted in models.items():
+            serialized_models[appliance_name] = asdict(fitted)
+        payload = {
+            "schema_version": _ARTIFACT_SCHEMA_VERSION,
+            "model_class": self.MODEL_NAME,
+            "config": {name: getattr(self, name) for name in _CONFIG_FIELDS},
+            "models": serialized_models,
+        }
+        save_json_atomic(Path(target) / _ARTIFACT_FILENAME, payload)
+
+    def load_model(self, path=None):
+        source = path if path is not None else self.load_model_path
+        if source is None:
+            raise ValueError("HSMM load_model requires a checkpoint directory.")
+        artifact_path = Path(source) / _ARTIFACT_FILENAME
+        try:
+            with artifact_path.open(encoding="utf-8") as handle:
+                payload = json.load(
+                    handle,
+                    parse_constant=_reject_json_constant,
+                    object_pairs_hook=_unique_json_object,
+                )
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            raise ValueError(f"Could not load a valid HSMM artifact: {exc}") from exc
+        if not isinstance(payload, Mapping) or set(payload) != {
+            "schema_version",
+            "model_class",
+            "config",
+            "models",
+        }:
+            raise ValueError("HSMM artifact has invalid top-level fields.")
+        if (
+            isinstance(payload["schema_version"], bool)
+            or not isinstance(payload["schema_version"], Integral)
+            or payload["schema_version"] != _ARTIFACT_SCHEMA_VERSION
+        ):
+            raise ValueError("HSMM artifact has an unsupported schema_version.")
+        if payload["model_class"] != self.MODEL_NAME:
+            raise ValueError("HSMM artifact model_class does not match HSMM.")
+        config = payload["config"]
+        if not isinstance(config, Mapping) or set(config) != set(_CONFIG_FIELDS):
+            raise ValueError("HSMM artifact has invalid configuration fields.")
+        num_states = _positive_integer("num_states", config["num_states"])
+        if num_states < 2:
+            raise ValueError("num_states must be at least two.")
+        max_duration = _positive_integer("max_duration", config["max_duration"])
+        pseudocount = _positive_finite("pseudocount", config["pseudocount"])
+        variance_floor = _positive_finite(
+            "variance_floor", config["variance_floor"]
+        )
+        kmeans_max_iterations = _positive_integer(
+            "kmeans_max_iterations", config["kmeans_max_iterations"]
+        )
+        model_payloads = payload["models"]
+        if not isinstance(model_payloads, Mapping) or not model_payloads:
+            raise ValueError("HSMM artifact must contain at least one appliance model.")
+        loaded = OrderedDict()
+        for appliance_name, fitted_payload in model_payloads.items():
+            if (
+                not isinstance(appliance_name, str)
+                or not appliance_name.strip()
+                or appliance_name != appliance_name.strip()
+                or appliance_name in loaded
+            ):
+                raise ValueError("HSMM artifact has an invalid appliance name.")
+            loaded[appliance_name] = _parameters_from_payload(
+                fitted_payload,
+                num_states=num_states,
+                max_duration=max_duration,
+            )
+        self.num_states = num_states
+        self.max_duration = max_duration
+        self.pseudocount = pseudocount
+        self.variance_floor = variance_floor
+        self.kmeans_max_iterations = kmeans_max_iterations
+        self.models = loaded
 
     def partial_fit(
         self,
@@ -366,25 +632,7 @@ class HSMM(Disaggregator):
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         if not isinstance(do_preprocessing, bool):
             raise ValueError("do_preprocessing must be a boolean.")
-        models = self.models if model is None else model
-        if not isinstance(models, Mapping) or not models:
-            raise RuntimeError("HSMM requires a trained model mapping.")
-        for appliance_name, fitted in models.items():
-            if not isinstance(appliance_name, str) or not appliance_name.strip():
-                raise ValueError(
-                    "HSMM model appliance names must be non-empty strings."
-                )
-            if not isinstance(fitted, _HSMMParameters):
-                raise TypeError("HSMM model values must be fitted HSMM parameters.")
-            if len(fitted.state_means) != self.num_states:
-                raise ValueError("HSMM model state count does not match configuration.")
-            if any(
-                len(probabilities) != self.max_duration
-                for probabilities in fitted.duration_probabilities
-            ):
-                raise ValueError(
-                    "HSMM model duration cap does not match configuration."
-                )
+        models = self.require_models(model)
         results = []
         for chunk_index, frame in enumerate(test_main_list):
             values = power_vector(frame, f"mains chunk {chunk_index}", allow_empty=True)
@@ -393,17 +641,9 @@ class HSMM(Disaggregator):
             output_index = _frame_index(frame, len(values))
             columns = OrderedDict()
             for appliance_name, fitted in models.items():
-                blocks = [
-                    _decode_block(
-                        values[start : start + self.max_duration],
-                        fitted,
-                        self.device,
-                    )
-                    for start in range(0, len(values), self.max_duration)
-                ]
                 prediction = (
-                    np.concatenate(blocks).astype(np.float32, copy=False)
-                    if blocks
+                    _decode_sequence(values, fitted, self.device)
+                    if len(values)
                     else np.empty(0, dtype=np.float32)
                 )
                 columns[appliance_name] = pd.Series(prediction, index=output_index)

--- a/nilmtk_contrib/torch/hsmm.py
+++ b/nilmtk_contrib/torch/hsmm.py
@@ -1,0 +1,5 @@
+"""Public explicit-duration hidden semi-Markov NILM baseline."""
+
+from nilmtk_contrib.torch._hsmm import HSMM
+
+__all__ = ["HSMM"]

--- a/tests/model_smoke_helpers.py
+++ b/tests/model_smoke_helpers.py
@@ -42,6 +42,7 @@ TORCH_MODEL_SPECS = (
     ModelSpec("torch", "nilmtk_contrib.torch", "ConvLSTM", "nilmtk_contrib.torch.conv_lstm"),
     ModelSpec("torch", "nilmtk_contrib.torch", "DAE", "nilmtk_contrib.torch.dae"),
     ModelSpec("torch", "nilmtk_contrib.torch", "DLinear", "nilmtk_contrib.torch.dlinear"),
+    ModelSpec("torch", "nilmtk_contrib.torch", "HSMM", "nilmtk_contrib.torch.hsmm", trainable=False),
     ModelSpec("torch", "nilmtk_contrib.torch", "MSDC", "nilmtk_contrib.torch.msdc", min_sequence_length=121),
     ModelSpec("torch", "nilmtk_contrib.torch", "MSDC", "nilmtk_contrib.torch.msdc_without_crf", min_sequence_length=121),
     ModelSpec("torch", "nilmtk_contrib.torch", "ModernTCN", "nilmtk_contrib.torch.moderntcn"),

--- a/tests/test_hsmm.py
+++ b/tests/test_hsmm.py
@@ -1,4 +1,5 @@
 import inspect
+import json
 from pathlib import Path
 
 import numpy as np
@@ -85,7 +86,7 @@ def test_train_infer_recovers_clean_states_and_preserves_index_and_dtype():
     )
 
 
-def test_inference_splits_long_and_partial_chunks_at_the_duration_cap(monkeypatch):
+def test_inference_decodes_long_chunks_without_artificial_state_resets(monkeypatch):
     mains, appliances = _training_chunks()
     model = HSMM(_params(max_duration=5))
     model.partial_fit(mains, appliances)
@@ -99,7 +100,7 @@ def test_inference_splits_long_and_partial_chunks_at_the_duration_cap(monkeypatc
     monkeypatch.setattr(hsmm_module, "semi_markov_viterbi", recording_decoder)
     prediction = model.disaggregate_chunk([mains[0].iloc[:13]])[0]
 
-    assert lengths == [5, 5, 3]
+    assert lengths == [13]
     assert len(prediction) == 13
     assert np.isfinite(prediction["fridge"]).all()
 
@@ -184,6 +185,7 @@ def test_multiple_appliances_are_fitted_without_partial_state_on_failure():
         ({"kmeans_max_iterations": 0}, ValueError, "positive integer"),
         ({"seed": True}, ValueError, "integer or None"),
         ({"verbose": "yes"}, ValueError, "boolean"),
+        ({"chunk_wise_training": True}, ValueError, "does not support"),
     ],
 )
 def test_invalid_configuration_fails_at_construction(overrides, error, message):
@@ -244,21 +246,135 @@ def test_training_and_inference_contracts_reject_invalid_containers():
         model.partial_fit(mains, [])
     with pytest.raises(ValueError, match="Duplicate appliance"):
         model.partial_fit(mains, [appliances[0], appliances[0]])
-    with pytest.raises(RuntimeError, match="trained model"):
+    with pytest.raises(RuntimeError, match="trained or loaded"):
         model.disaggregate_chunk(mains)
     with pytest.raises(ValueError, match="boolean"):
         model.partial_fit(mains, appliances, do_preprocessing="yes")
 
 
-def test_persistence_is_explicitly_fail_closed_until_artifact_pr(tmp_path):
+def test_checkpoint_roundtrip_restores_config_models_and_predictions(tmp_path):
     mains, appliances = _training_chunks()
-    model = HSMM(_params())
+    model = HSMM(_params(save_model_path=str(tmp_path)))
     model.partial_fit(mains, appliances)
+    expected = model.disaggregate_chunk(mains)
 
-    with pytest.raises(NotImplementedError, match="HSMM"):
-        model.save_model(tmp_path)
-    with pytest.raises(NotImplementedError, match="HSMM"):
-        model.load_model(tmp_path)
+    loaded = HSMM(
+        _params(
+            num_states=3,
+            max_duration=3,
+            pseudocount=2.0,
+            variance_floor=2.0,
+            kmeans_max_iterations=2,
+            pretrained_model_path=str(tmp_path),
+        )
+    )
+    actual = loaded.disaggregate_chunk(mains)
+
+    assert loaded.num_states == 2
+    assert loaded.max_duration == 8
+    assert loaded.pseudocount == 1.0
+    assert loaded.variance_floor == 0.1
+    assert loaded.kmeans_max_iterations == 50
+    assert loaded.models == model.models
+    assert len(actual) == len(expected)
+    for actual_frame, expected_frame in zip(actual, expected):
+        assert np.array_equal(actual_frame.to_numpy(), expected_frame.to_numpy())
+
+
+def test_untrained_model_cannot_publish_an_artifact(tmp_path):
+    with pytest.raises(RuntimeError, match="trained or loaded"):
+        HSMM(_params()).save_model(tmp_path)
+
+
+def test_persistence_requires_an_explicit_directory():
+    model = HSMM(_params())
+
+    with pytest.raises(ValueError, match="checkpoint directory"):
+        model.save_model()
+    with pytest.raises(ValueError, match="checkpoint directory"):
+        model.load_model()
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda payload: payload.update(schema_version=999), "schema_version"),
+        (lambda payload: payload.update(schema_version=True), "schema_version"),
+        (lambda payload: payload.update(model_class="Other"), "model_class"),
+        (lambda payload: payload.update(extra=True), "top-level"),
+        (
+            lambda payload: payload["models"]["fridge"][
+                "initial_probabilities"
+            ].__setitem__(0, float("nan")),
+            "valid HSMM artifact",
+        ),
+        (
+            lambda payload: payload["models"]["fridge"]["state_counts"].__setitem__(
+                0, 0
+            ),
+            "state_counts",
+        ),
+        (
+            lambda payload: payload["models"]["fridge"][
+                "transition_probabilities"
+            ][0].__setitem__(0, 0.1),
+            "zero diagonal",
+        ),
+    ],
+)
+def test_malformed_artifacts_fail_closed_without_mutating_model(
+    tmp_path, mutation, message
+):
+    mains, appliances = _training_chunks()
+    source = tmp_path / "source"
+    model = HSMM(_params(save_model_path=str(source)))
+    model.partial_fit(mains, appliances)
+    artifact = source / "hsmm.json"
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    mutation(payload)
+    corrupt = tmp_path / "corrupt"
+    corrupt.mkdir()
+    (corrupt / "hsmm.json").write_text(json.dumps(payload), encoding="utf-8")
+    original_models = model.models
+    original_config = (model.num_states, model.max_duration)
+
+    with pytest.raises(ValueError, match=message):
+        model.load_model(corrupt)
+
+    assert model.models is original_models
+    assert (model.num_states, model.max_duration) == original_config
+
+
+def test_duplicate_artifact_keys_are_rejected(tmp_path):
+    mains, appliances = _training_chunks()
+    source = tmp_path / "source"
+    model = HSMM(_params(save_model_path=str(source)))
+    model.partial_fit(mains, appliances)
+    artifact = source / "hsmm.json"
+    content = artifact.read_text(encoding="utf-8")
+    content = content.replace(
+        '"schema_version": 1',
+        '"schema_version": 1, "schema_version": 1',
+        1,
+    )
+    artifact.write_text(content, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Duplicate JSON key"):
+        model.load_model(source)
+
+
+def test_public_export_catalog_and_defaults_are_complete():
+    import nilmtk_contrib.torch as torch_models
+    from nilmtk_contrib.metadata import model_catalog_by_module
+
+    default = torch_models.HSMM({"device": "cpu"})
+    entry = model_catalog_by_module()["nilmtk_contrib.torch.hsmm"]
+
+    assert torch_models.HSMM is HSMM
+    assert default.num_states == 2
+    assert default.max_duration == 720
+    assert entry.class_name == "HSMM"
+    assert entry.exported_from == "nilmtk_contrib.torch"
 
 
 def test_implementation_uses_shared_exact_core_without_classical_solver():

--- a/tests/test_torch_base.py
+++ b/tests/test_torch_base.py
@@ -67,6 +67,75 @@ def test_torch_disaggregator_centralizes_common_runtime_state():
     assert model.models == OrderedDict()
 
 
+def test_state_space_base_centralizes_only_relevant_runtime_state():
+    torch = pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchStateSpaceDisaggregator
+
+    model = TorchStateSpaceDisaggregator(
+        {
+            "device": "cpu",
+            "seed": 7,
+            "verbose": True,
+            "save_model_path": "/tmp/save",
+            "pretrained_model_path": "/tmp/load",
+        }
+    )
+
+    assert model.device == torch.device("cpu")
+    assert model.seed == 7
+    assert model.verbose is True
+    assert model.chunk_wise_training is False
+    assert model.save_model_path == "/tmp/save"
+    assert model.load_model_path == "/tmp/load"
+    assert model.models == OrderedDict()
+    assert not hasattr(model, "sequence_length")
+
+
+@pytest.mark.parametrize(
+    ("params", "message"),
+    [
+        ([], "params"),
+        ({"seed": True}, "seed"),
+        ({"verbose": 1}, "verbose"),
+        ({"chunk_wise_training": 1}, "chunk_wise_training"),
+    ],
+)
+def test_state_space_base_rejects_invalid_common_state(params, message):
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchStateSpaceDisaggregator
+
+    with pytest.raises((TypeError, ValueError), match=message):
+        TorchStateSpaceDisaggregator(params)
+
+
+def test_state_space_model_installation_is_validated_detached_and_transactional():
+    pytest.importorskip("torch")
+    from nilmtk_contrib.torch._base import TorchStateSpaceDisaggregator
+
+    class PositiveRecordModel(TorchStateSpaceDisaggregator):
+        MODEL_NAME = "PositiveRecord"
+
+        def _validate_model_record(self, appliance_name, model):
+            del appliance_name
+            if not isinstance(model, int) or model <= 0:
+                raise ValueError("record must be a positive integer")
+
+    model = PositiveRecordModel({"device": "cpu"})
+    with pytest.raises(RuntimeError, match="trained or loaded"):
+        model.require_models()
+
+    external = {"fridge": 1}
+    installed = model.require_models(external)
+    external["kettle"] = 2
+
+    assert installed == {"fridge": 1}
+    assert model.models == {"fridge": 1}
+    original = model.models
+    with pytest.raises(ValueError, match="positive integer"):
+        model.require_models({"fridge": 0})
+    assert model.models is original
+
+
 @pytest.mark.parametrize(
     ("params", "error", "message"),
     [

--- a/tests/test_torch_migration_contract.py
+++ b/tests/test_torch_migration_contract.py
@@ -11,6 +11,12 @@ import pytest
 from model_smoke_helpers import TORCH_MODEL_SPECS
 
 
+NEURAL_TORCH_MODEL_SPECS = tuple(spec for spec in TORCH_MODEL_SPECS if spec.trainable)
+STATE_SPACE_TORCH_MODEL_SPECS = tuple(
+    spec for spec in TORCH_MODEL_SPECS if not spec.trainable
+)
+
+
 @dataclass(frozen=True)
 class ExpectedDefaults:
     sequence_length: int
@@ -72,7 +78,7 @@ def _load_class(spec):
 
 @pytest.mark.parametrize(
     "spec",
-    TORCH_MODEL_SPECS,
+    NEURAL_TORCH_MODEL_SPECS,
     ids=lambda spec: f"{spec.module_name}.{spec.class_name}",
 )
 def test_every_torch_model_uses_shared_runtime_with_legacy_defaults(spec):
@@ -99,6 +105,34 @@ def test_every_torch_model_uses_shared_runtime_with_legacy_defaults(spec):
 
 @pytest.mark.parametrize(
     "spec",
+    STATE_SPACE_TORCH_MODEL_SPECS,
+    ids=lambda spec: f"{spec.module_name}.{spec.class_name}",
+)
+def test_state_space_models_use_shared_runtime_without_fake_neural_options(spec):
+    from nilmtk_contrib.torch._base import TorchStateSpaceDisaggregator
+
+    cls = _load_class(spec)
+    model = cls({"device": "cpu", "seed": 17, "verbose": True})
+
+    assert issubclass(cls, TorchStateSpaceDisaggregator)
+    assert model.seed == 17
+    assert model.verbose is True
+    assert model.chunk_wise_training is False
+    assert model.models == {}
+    assert str(model.device) == "cpu"
+    for irrelevant in (
+        "sequence_length",
+        "n_epochs",
+        "batch_size",
+        "mains_mean",
+        "mains_std",
+        "appliance_params",
+    ):
+        assert not hasattr(model, irrelevant)
+
+
+@pytest.mark.parametrize(
+    "spec",
     TORCH_MODEL_SPECS,
     ids=lambda spec: f"{spec.module_name}.{spec.class_name}",
 )
@@ -112,7 +146,7 @@ def test_every_torch_model_accepts_none_and_rejects_non_mapping_params(spec):
 
 @pytest.mark.parametrize(
     "spec",
-    TORCH_MODEL_SPECS,
+    NEURAL_TORCH_MODEL_SPECS,
     ids=lambda spec: f"{spec.module_name}.{spec.class_name}",
 )
 def test_every_torch_model_honors_validated_common_overrides(spec):
@@ -153,7 +187,7 @@ def test_every_torch_model_honors_validated_common_overrides(spec):
 
 @pytest.mark.parametrize(
     "spec",
-    TORCH_MODEL_SPECS,
+    NEURAL_TORCH_MODEL_SPECS,
     ids=lambda spec: f"{spec.module_name}.{spec.class_name}",
 )
 def test_every_torch_model_inherits_shared_statistics_policy(spec):
@@ -209,7 +243,7 @@ def test_torch_model_source_does_not_reintroduce_shared_boilerplate(spec):
 
 @pytest.mark.parametrize(
     "spec",
-    TORCH_MODEL_SPECS,
+    NEURAL_TORCH_MODEL_SPECS,
     ids=lambda spec: f"{spec.module_name}.{spec.class_name}",
 )
 def test_every_torch_disaggregation_path_validates_and_detaches_models(spec):
@@ -376,4 +410,6 @@ def test_model_specific_params_remain_owned_by_subclasses(
 
 
 def test_migration_contract_covers_every_registered_torch_model():
-    assert set(DEFAULTS_BY_MODULE) == {spec.module_name for spec in TORCH_MODEL_SPECS}
+    assert set(DEFAULTS_BY_MODULE) == {
+        spec.module_name for spec in NEURAL_TORCH_MODEL_SPECS
+    }


### PR DESCRIPTION
Adds one public, supervised single-appliance HSMM baseline backed by the already-reviewed exact semi-Markov core. Introduces a small shared state-space runtime base so classical PyTorch models reuse device, seed, checkpoint-path, and model-map contracts without pretending to have neural epochs, batches, or sequence lengths. Persistence is schema-versioned atomic JSON with no pickle; loading rejects NaN, duplicate keys, malformed shapes, invalid probabilities, and inconsistent sufficient statistics transactionally. Inference decodes each full chunk exactly; max_duration limits dwell time and does not reset state at artificial block boundaries. Public export, catalog metadata, model table, citations, synthetic smoke, CPU/CUDA parity, persistence, adversarial artifact, partial-chunk, and all-model migration coverage are included. Real REDD gate: configuration selected only on blocked task.train validation; the corrected held-out diagnostic completed at MAE 79.82 and F1 0.358. This is an honest structural baseline, not a performance claim; official multi-seed publication remains a separate NILMbench PR. Verification: 925 passed, 107 skipped; all exported PyTorch one-epoch smokes passed; ruff and compileall passed; wheel and sdist built.