### PR TITLE
Preserve MSDC prediction indexes

### DIFF
--- a/nilmtk_contrib/torch/msdc.py
+++ b/nilmtk_contrib/torch/msdc.py
@@ -575,16 +575,25 @@ class MSDC(TorchDisaggregator):
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """Disaggregates a chunk of mains data using the trained models."""
         self.require_models(model)
+        test_main_list = list(test_main_list)
+        output_indexes = [
+            getattr(frame, "index", pd.RangeIndex(len(frame))).copy()
+            for frame in test_main_list
+        ]
         
         # Preprocess test data
         if do_preprocessing:
-            test_main_list = self.call_preprocessing(test_main_list, submeters_lst=None, method='test')
+            test_main_list = self.call_preprocessing(
+                test_main_list, submeters_lst=None, method="test"
+            )
         
         test_predictions = []
-        for test_main in test_main_list:
+        for chunk_index, (test_main, output_index) in enumerate(
+            zip(test_main_list, output_indexes, strict=True)
+        ):
             test_main = test_main.values
             test_main = test_main.reshape((-1, self.sequence_length, 1))
-            disggregation_dict = {}
+            disaggregation = {}
             
             test_main_tensor = torch.FloatTensor(test_main).to(self.device)
             
@@ -616,9 +625,20 @@ class MSDC(TorchDisaggregator):
                     pred = pred * self.appliance_params[appliance]['std'] + self.appliance_params[appliance]['mean']
                     pred = np.where(pred > 0, pred, 0)  # Ensure non-negative power
                 
-                disggregation_dict[appliance] = pred
-            
-            test_predictions.append(pd.DataFrame(disggregation_dict, dtype='float32'))
+                disaggregation[appliance] = pred
+
+            if any(
+                len(prediction) != len(output_index)
+                for _, prediction in disaggregation.items()
+            ):
+                raise RuntimeError(
+                    f"MSDC prediction length does not match input chunk {chunk_index}."
+                )
+            test_predictions.append(
+                pd.DataFrame(
+                    disaggregation, index=output_index, dtype="float32"
+                )
+            )
         
         return test_predictions
     

--- a/nilmtk_contrib/torch/msdc_without_crf.py
+++ b/nilmtk_contrib/torch/msdc_without_crf.py
@@ -506,16 +506,25 @@ class MSDC(TorchDisaggregator):
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """Disaggregate power consumption using the trained MSDC model."""
         self.require_models(model)
+        test_main_list = list(test_main_list)
+        output_indexes = [
+            getattr(frame, "index", pd.RangeIndex(len(frame))).copy()
+            for frame in test_main_list
+        ]
         
         # Preprocess the test mains
         if do_preprocessing:
-            test_main_list = self.call_preprocessing(test_main_list, submeters_lst=None, method='test')
+            test_main_list = self.call_preprocessing(
+                test_main_list, submeters_lst=None, method="test"
+            )
         
         test_predictions = []
-        for test_main in test_main_list:
+        for chunk_index, (test_main, output_index) in enumerate(
+            zip(test_main_list, output_indexes, strict=True)
+        ):
             test_main = test_main.values
             test_main = test_main.reshape((-1, self.sequence_length))
-            disggregation_dict = {}
+            disaggregation = {}
             
             test_main_tensor = torch.FloatTensor(test_main).to(self.device)
             
@@ -553,9 +562,20 @@ class MSDC(TorchDisaggregator):
                     pred = pred * self.appliance_params[appliance]['std'] + self.appliance_params[appliance]['mean']
                     pred = np.where(pred > 0, pred, 0)  # Ensure non-negative power
                 
-                disggregation_dict[appliance] = pred
-            
-            test_predictions.append(pd.DataFrame(disggregation_dict, dtype='float32'))
+                disaggregation[appliance] = pred
+
+            if any(
+                len(prediction) != len(output_index)
+                for _, prediction in disaggregation.items()
+            ):
+                raise RuntimeError(
+                    f"MSDC prediction length does not match input chunk {chunk_index}."
+                )
+            test_predictions.append(
+                pd.DataFrame(
+                    disaggregation, index=output_index, dtype="float32"
+                )
+            )
         
         return test_predictions
     

--- a/tests/test_msdc_inference_contract.py
+++ b/tests/test_msdc_inference_contract.py
@@ -1,0 +1,112 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+
+torch = pytest.importorskip("torch")
+
+
+class _ViterbiStub:
+    @staticmethod
+    def viterbi_decode(emissions):
+        return emissions.argmax(dim=-1)
+
+
+class _CRFNetworkStub(torch.nn.Module):
+    def __init__(self, num_states=3):
+        super().__init__()
+        self.num_states = num_states
+        self.crf = _ViterbiStub()
+
+    def forward(self, inputs):
+        batch_size, sequence_length, _ = inputs.shape
+        shape = (batch_size, sequence_length, self.num_states)
+        return torch.zeros(shape), torch.ones(shape)
+
+
+class _DirectNetworkStub(torch.nn.Module):
+    def __init__(self, out_len=64, num_states=3):
+        super().__init__()
+        self.out_len = out_len
+        self.num_states = num_states
+
+    def forward(self, inputs):
+        batch_size = len(inputs)
+        shape = (batch_size, self.out_len * self.num_states)
+        return torch.ones(shape), torch.zeros(shape)
+
+
+@pytest.mark.parametrize(
+    ("module_name", "network_factory"),
+    [
+        ("nilmtk_contrib.torch.msdc", _CRFNetworkStub),
+        ("nilmtk_contrib.torch.msdc_without_crf", _DirectNetworkStub),
+    ],
+)
+def test_msdc_prediction_preserves_each_raw_chunk_index(module_name, network_factory):
+    import importlib
+
+    model_class = importlib.import_module(module_name).MSDC
+    model = model_class(
+        {
+            "device": "cpu",
+            "sequence_length": 19,
+            "appliance_params": {"fridge": {"mean": 100.0, "std": 20.0}},
+        }
+    )
+    indexes = [
+        pd.date_range(
+            "2026-01-01",
+            periods=23,
+            freq="15min",
+            tz="US/Eastern",
+            name="timestamp",
+        ),
+        pd.Index(["a", "b", "c"], name="sample"),
+    ]
+    mains = [
+        pd.DataFrame({"power": np.linspace(100.0, 200.0, len(index))}, index=index)
+        for index in indexes
+    ]
+
+    predictions = model.disaggregate_chunk(mains, model={"fridge": network_factory()})
+
+    assert len(predictions) == len(mains)
+    for prediction, source in zip(predictions, mains, strict=True):
+        assert prediction.index.equals(source.index)
+        assert prediction.index is not source.index
+        assert prediction.columns.tolist() == ["fridge"]
+        assert prediction.dtypes.tolist() == [np.dtype("float32")]
+        assert np.isfinite(prediction.to_numpy()).all()
+
+
+@pytest.mark.parametrize(
+    ("module_name", "network_factory"),
+    [
+        ("nilmtk_contrib.torch.msdc", _CRFNetworkStub),
+        ("nilmtk_contrib.torch.msdc_without_crf", _DirectNetworkStub),
+    ],
+)
+def test_msdc_prediction_preserves_preprocessed_chunk_index(
+    module_name, network_factory
+):
+    import importlib
+
+    model_class = importlib.import_module(module_name).MSDC
+    model = model_class(
+        {
+            "device": "cpu",
+            "sequence_length": 19,
+            "appliance_params": {"fridge": {"mean": 100.0, "std": 20.0}},
+        }
+    )
+    index = pd.Index([11, 13, 17], name="window")
+    windows = pd.DataFrame(np.ones((3, 19)), index=index)
+
+    prediction = model.disaggregate_chunk(
+        [windows],
+        model={"fridge": network_factory()},
+        do_preprocessing=False,
+    )[0]
+
+    assert prediction.index.equals(index)


### PR DESCRIPTION
## What changed
- preserve each input chunk's exact pandas index in both MSDC inference variants
- fail clearly if a model produces a different number of predictions than input rows
- cover timezone-aware, named, custom, multi-chunk, and preprocessed index contracts

## Why
NILMbench's strict prediction contract caught MSDC returning a fresh RangeIndex during the real 900-second REDD campaign. Values and row counts were valid, but timestamps were discarded.

## Verification
- full suite: 929 passed, 107 skipped
- focused contract/migration/registry suites: 250 passed
- Ruff and diff checks pass
- wheel and source distribution build successfully
- diagnostic real REDD/A100 smoke completed at 900 seconds with 264 train rows, 165 test rows, sequence length 19, and finite MAE/F1

The diagnostic bundle is not for publication; NILMbench will rebuild an immutable image from the merged commit and rerun all three seeds.