### PR TITLE
Harden legacy Torch inference alignment

### DIFF
--- a/nilmtk_contrib/torch/TCN.py
+++ b/nilmtk_contrib/torch/TCN.py
@@ -442,7 +442,7 @@ class TCN(TorchDisaggregator):
             output_index = (
                 output_indexes[position]
                 if do_preprocessing
-                else getattr(frame, "index", pd.RangeIndex(len(windows)))
+                else pd.RangeIndex(len(windows))
             )
             if len(output_index) != len(windows):
                 raise ValueError(
@@ -491,7 +491,10 @@ class TCN(TorchDisaggregator):
                                 f"Model for {appliance_name!r} returned non-finite "
                                 "values."
                             )
-                        batches.append(prediction.detach().cpu())
+                        public_batch = prediction.detach().cpu()
+                        if public_batch.dtype == torch.bfloat16:
+                            public_batch = public_batch.to(dtype=torch.float32)
+                        batches.append(public_batch)
                 normalized = (
                     torch.cat(batches).numpy().reshape(-1)
                     if batches

--- a/nilmtk_contrib/torch/TCN.py
+++ b/nilmtk_contrib/torch/TCN.py
@@ -359,35 +359,163 @@ class TCN(TorchDisaggregator):
                     model.load_state_dict(torch.load(filepath, map_location=self.device))
 
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
-        """Disaggregates a chunk of mains data."""
-        self.require_models(model)
+        """Disaggregate one point per window without losing raw row indexes."""
+        models = self.require_models(model)
+        test_frames = list(test_main_list)
+        if not test_frames:
+            return []
 
-        # Preprocess test data
+        output_indexes = []
         if do_preprocessing:
-            test_main_list = self.call_preprocessing(test_main_list, submeters_lst=None, method='test')
+            processed_frames = []
+            for position, frame in enumerate(test_frames):
+                if not hasattr(frame, "index") or not hasattr(frame, "to_numpy"):
+                    raise TypeError(
+                        "Raw TCN inference chunks must be pandas objects with indexes."
+                    )
+                raw = frame.to_numpy()
+                if np.iscomplexobj(raw):
+                    raise TypeError(
+                        f"Inference mains chunk {position} must be real numeric data."
+                    )
+                try:
+                    values = np.asarray(raw, dtype=np.float64)
+                except (TypeError, ValueError) as exc:
+                    raise TypeError(
+                        f"Inference mains chunk {position} must be real numeric data."
+                    ) from exc
+                if values.ndim == 1:
+                    pass
+                elif values.ndim == 2 and values.shape[1] == 1:
+                    values = values[:, 0]
+                else:
+                    raise ValueError(
+                        f"Inference mains chunk {position} must contain exactly "
+                        "one power column."
+                    )
+                if not np.isfinite(values).all():
+                    raise ValueError(
+                        f"Inference mains chunk {position} must contain only "
+                        "finite values."
+                    )
+                output_indexes.append(frame.index.copy())
+                if len(values):
+                    processed_frames.append(
+                        self.call_preprocessing([frame], None, "test")[0]
+                    )
+                else:
+                    processed_frames.append(
+                        pd.DataFrame(
+                            np.empty((0, self.sequence_length), dtype=np.float32)
+                        )
+                    )
+        else:
+            processed_frames = test_frames
 
-        test_predictions = []
-        for test_main in test_main_list:
-            test_main = test_main.values
-            test_main = test_main.reshape((-1, self.sequence_length, 1))
-            
-            # Convert to tensor for Conv1d
-            test_main_tensor = torch.tensor(test_main, dtype=torch.float32).permute(0, 2, 1).to(self.device)
-            
-            disggregation_dict = {}
-            for appliance in self.models:
-                model = self.models[appliance]
-                model.eval()
-                with torch.no_grad():
-                    prediction = model(test_main_tensor).cpu().numpy()
-                    # Denormalize predictions
-                    app_mean = self.appliance_params[appliance]['mean']
-                    app_std = self.appliance_params[appliance]['std']
-                    prediction = prediction * app_std + app_mean
-                    valid_predictions = prediction.flatten()
-                    valid_predictions[valid_predictions < 0] = 0
-                    df = pd.Series(valid_predictions)
-                    disggregation_dict[appliance] = df
-            results = pd.DataFrame(disggregation_dict, dtype='float32')
-            test_predictions.append(results)
-        return test_predictions
+        results = []
+        for position, frame in enumerate(processed_frames):
+            try:
+                raw_windows = (
+                    frame.to_numpy()
+                    if hasattr(frame, "to_numpy")
+                    else np.asarray(frame)
+                )
+                if np.iscomplexobj(raw_windows):
+                    raise ValueError("complex values are unsupported")
+                with np.errstate(over="ignore", invalid="ignore"):
+                    windows = np.asarray(raw_windows, dtype=np.float32)
+            except (TypeError, ValueError) as exc:
+                raise TypeError(
+                    f"Inference windows for chunk {position} must be real numeric data."
+                ) from exc
+            if windows.ndim != 2 or windows.shape[1] != self.sequence_length:
+                raise ValueError(
+                    f"Inference windows for chunk {position} must have shape "
+                    f"[samples, {self.sequence_length}]."
+                )
+            if not np.isfinite(windows).all():
+                raise ValueError(
+                    f"Inference windows for chunk {position} must contain only "
+                    "finite values."
+                )
+
+            output_index = (
+                output_indexes[position]
+                if do_preprocessing
+                else getattr(frame, "index", pd.RangeIndex(len(windows)))
+            )
+            if len(output_index) != len(windows):
+                raise ValueError(
+                    f"Inference mains chunk {position} index length does not match "
+                    "its windows."
+                )
+            loader = DataLoader(
+                TensorDataset(torch.from_numpy(windows).unsqueeze(1)),
+                batch_size=self.batch_size,
+                shuffle=False,
+            )
+
+            predictions = {}
+            for appliance_name, network in models.items():
+                batches = []
+                network.eval()
+                with torch.inference_mode():
+                    for (batch,) in loader:
+                        batch = batch.to(self.device)
+                        prediction = network(batch)
+                        if not isinstance(prediction, torch.Tensor):
+                            raise TypeError(
+                                f"Model for {appliance_name!r} must return "
+                                "a torch.Tensor."
+                            )
+                        expected_shape = (len(batch), 1)
+                        if prediction.shape != expected_shape:
+                            raise ValueError(
+                                f"Model for {appliance_name!r} returned shape "
+                                f"{tuple(prediction.shape)}; expected {expected_shape}."
+                            )
+                        if not torch.is_floating_point(prediction) or torch.is_complex(
+                            prediction
+                        ):
+                            raise TypeError(
+                                f"Model for {appliance_name!r} must return real "
+                                "floating values."
+                            )
+                        if prediction.device != batch.device:
+                            raise ValueError(
+                                f"Model for {appliance_name!r} returned values on "
+                                f"{prediction.device}; expected {batch.device}."
+                            )
+                        if not torch.isfinite(prediction).all():
+                            raise FloatingPointError(
+                                f"Model for {appliance_name!r} returned non-finite "
+                                "values."
+                            )
+                        batches.append(prediction.detach().cpu())
+                normalized = (
+                    torch.cat(batches).numpy().reshape(-1)
+                    if batches
+                    else np.empty(0, dtype=np.float32)
+                )
+                statistics = self.appliance_params[appliance_name]
+                with np.errstate(over="ignore", invalid="ignore"):
+                    denormalized = (
+                        statistics["mean"]
+                        + normalized.astype(np.float64) * statistics["std"]
+                    )
+                    denormalized = np.clip(denormalized, 0, None)
+                if not np.isfinite(denormalized).all():
+                    raise FloatingPointError(
+                        f"Predictions for {appliance_name!r} became non-finite."
+                    )
+                with np.errstate(over="ignore", invalid="ignore"):
+                    public_values = denormalized.astype(np.float32)
+                if not np.isfinite(public_values).all():
+                    raise ValueError(
+                        f"Predictions for {appliance_name!r} overflow float32."
+                    )
+                predictions[appliance_name] = pd.Series(
+                    public_values, index=output_index
+                )
+            results.append(pd.DataFrame(predictions, index=output_index))
+        return results

--- a/nilmtk_contrib/torch/WindowGRU.py
+++ b/nilmtk_contrib/torch/WindowGRU.py
@@ -257,9 +257,11 @@ class WindowGRU(TorchDisaggregator):
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         self.require_models(model)
 
+        raw_indexes = None
         if do_preprocessing:
-            test_main_list = self.call_preprocessing(
-                test_main_list, submeters_lst=None, method='test')
+            test_main_list, raw_indexes = self.preprocess_raw_inference_chunks(
+                test_main_list
+            )
         
         test_predictions = []
         for mains in test_main_list:
@@ -288,6 +290,8 @@ class WindowGRU(TorchDisaggregator):
                 disggregation_dict[appliance] = df
             results = pd.DataFrame(disggregation_dict, dtype='float32')
             test_predictions.append(results)
+        if raw_indexes is not None:
+            return self.align_raw_inference_predictions(test_predictions, raw_indexes)
         return test_predictions
 
     def call_preprocessing(self, mains_lst, submeters_lst, method):

--- a/nilmtk_contrib/torch/WindowGRU.py
+++ b/nilmtk_contrib/torch/WindowGRU.py
@@ -292,7 +292,7 @@ class WindowGRU(TorchDisaggregator):
             test_predictions.append(results)
         if raw_indexes is not None:
             return self.align_raw_inference_predictions(test_predictions, raw_indexes)
-        return test_predictions
+        return self.validate_inference_predictions(test_predictions)
 
     def call_preprocessing(self, mains_lst, submeters_lst, method):
         if method == 'train':

--- a/nilmtk_contrib/torch/_base.py
+++ b/nilmtk_contrib/torch/_base.py
@@ -12,6 +12,7 @@ import math
 from numbers import Integral, Real
 
 import numpy as np
+import pandas as pd
 import torch
 from nilmtk.disaggregate import Disaggregator
 
@@ -448,6 +449,110 @@ class TorchDisaggregator(Disaggregator):
             include_extrema=self.INCLUDE_APPLIANCE_EXTREMA,
         )
         self.appliance_params.update(statistics)
+
+    def preprocess_raw_inference_chunks(self, test_main_list):
+        """Preprocess raw pandas chunks while retaining their output indexes.
+
+        NILMTK expects one prediction row for every raw mains row. Legacy torch
+        preprocessors replace the caller's index while constructing windows, so
+        inference must retain that index separately and restore it only after the
+        model has produced an exactly matching number of rows.
+        """
+        if isinstance(test_main_list, (str, bytes, pd.Series, pd.DataFrame)):
+            raise TypeError(
+                "Raw inference chunks must be an iterable of pandas objects."
+            )
+        try:
+            raw_chunks = list(test_main_list)
+        except TypeError as exc:
+            raise TypeError(
+                "Raw inference chunks must be an iterable of pandas objects."
+            ) from exc
+
+        raw_indexes = []
+        for position, chunk in enumerate(raw_chunks):
+            if not isinstance(chunk, (pd.Series, pd.DataFrame)):
+                raise TypeError(
+                    f"Raw inference chunk {position} must be a pandas Series or "
+                    "DataFrame."
+                )
+            raw_indexes.append(chunk.index.copy())
+
+        processed_chunks = self.call_preprocessing(
+            raw_chunks, submeters_lst=None, method="test"
+        )
+        if isinstance(processed_chunks, (str, bytes, pd.Series, pd.DataFrame)):
+            raise TypeError("Test preprocessing must return an iterable of chunks.")
+        try:
+            processed_chunks = list(processed_chunks)
+        except TypeError as exc:
+            raise TypeError(
+                "Test preprocessing must return an iterable of chunks."
+            ) from exc
+        if len(processed_chunks) != len(raw_chunks):
+            raise ValueError(
+                "Test preprocessing changed the number of inference chunks: "
+                f"expected {len(raw_chunks)}, got {len(processed_chunks)}."
+            )
+        return processed_chunks, tuple(raw_indexes)
+
+    @staticmethod
+    def align_raw_inference_predictions(predictions, raw_indexes):
+        """Restore raw indexes, failing closed on missing or extra rows/chunks."""
+        if isinstance(predictions, (str, bytes, pd.Series, pd.DataFrame)):
+            raise TypeError("Inference predictions must be an iterable of DataFrames.")
+        try:
+            predictions = list(predictions)
+        except TypeError as exc:
+            raise TypeError(
+                "Inference predictions must be an iterable of DataFrames."
+            ) from exc
+        if len(predictions) != len(raw_indexes):
+            raise ValueError(
+                "Inference changed the number of chunks: "
+                f"expected {len(raw_indexes)}, got {len(predictions)}."
+            )
+
+        aligned = []
+        for position, (prediction, raw_index) in enumerate(
+            zip(predictions, raw_indexes, strict=True)
+        ):
+            if not isinstance(prediction, pd.DataFrame):
+                raise TypeError(
+                    f"Inference prediction {position} must be a pandas DataFrame."
+                )
+            if len(prediction) != len(raw_index):
+                raise ValueError(
+                    f"Inference prediction {position} has {len(prediction)} rows; "
+                    f"expected {len(raw_index)} raw rows."
+                )
+            for column in prediction.columns:
+                values = prediction[column].to_numpy()
+                if (
+                    pd.api.types.is_bool_dtype(values.dtype)
+                    or pd.api.types.is_complex_dtype(values.dtype)
+                    or not pd.api.types.is_numeric_dtype(values.dtype)
+                ):
+                    raise TypeError(
+                        f"Inference prediction {position} column {column!r} must "
+                        "contain real numeric values."
+                    )
+                try:
+                    finite = np.isfinite(values)
+                except TypeError as exc:
+                    raise TypeError(
+                        f"Inference prediction {position} column {column!r} must "
+                        "contain real numeric values."
+                    ) from exc
+                if not finite.all():
+                    raise ValueError(
+                        f"Inference prediction {position} column {column!r} "
+                        "contains non-finite values."
+                    )
+            prediction = prediction.copy()
+            prediction.index = raw_index
+            aligned.append(prediction)
+        return aligned
 
     def _validated_appliance_stats(self, appliance_name, required_fields):
         """Return validated statistics required by one model appliance."""

--- a/nilmtk_contrib/torch/_base.py
+++ b/nilmtk_contrib/torch/_base.py
@@ -16,6 +16,7 @@ import pandas as pd
 import torch
 from nilmtk.disaggregate import Disaggregator
 
+from nilmtk_contrib.torch._data import power_vector
 from nilmtk_contrib.utils.model import initialize_runtime
 from nilmtk_contrib.utils.params import (
     DEFAULT_ALIASES,
@@ -471,11 +472,11 @@ class TorchDisaggregator(Disaggregator):
 
         raw_indexes = []
         for position, chunk in enumerate(raw_chunks):
-            if not isinstance(chunk, (pd.Series, pd.DataFrame)):
+            if not isinstance(chunk, pd.DataFrame):
                 raise TypeError(
-                    f"Raw inference chunk {position} must be a pandas Series or "
-                    "DataFrame."
+                    f"Raw inference chunk {position} must be a pandas DataFrame."
                 )
+            power_vector(chunk, f"Raw inference chunk {position}")
             raw_indexes.append(chunk.index.copy())
 
         processed_chunks = self.call_preprocessing(
@@ -497,8 +498,8 @@ class TorchDisaggregator(Disaggregator):
         return processed_chunks, tuple(raw_indexes)
 
     @staticmethod
-    def align_raw_inference_predictions(predictions, raw_indexes):
-        """Restore raw indexes, failing closed on missing or extra rows/chunks."""
+    def validate_inference_predictions(predictions):
+        """Validate public prediction frames for every inference path."""
         if isinstance(predictions, (str, bytes, pd.Series, pd.DataFrame)):
             raise TypeError("Inference predictions must be an iterable of DataFrames.")
         try:
@@ -507,26 +508,17 @@ class TorchDisaggregator(Disaggregator):
             raise TypeError(
                 "Inference predictions must be an iterable of DataFrames."
             ) from exc
-        if len(predictions) != len(raw_indexes):
-            raise ValueError(
-                "Inference changed the number of chunks: "
-                f"expected {len(raw_indexes)}, got {len(predictions)}."
-            )
-
-        aligned = []
-        for position, (prediction, raw_index) in enumerate(
-            zip(predictions, raw_indexes, strict=True)
-        ):
+        for position, prediction in enumerate(predictions):
             if not isinstance(prediction, pd.DataFrame):
                 raise TypeError(
                     f"Inference prediction {position} must be a pandas DataFrame."
                 )
-            if len(prediction) != len(raw_index):
+            if not len(prediction.columns) or prediction.columns.has_duplicates:
                 raise ValueError(
-                    f"Inference prediction {position} has {len(prediction)} rows; "
-                    f"expected {len(raw_index)} raw rows."
+                    f"Inference prediction {position} must have unique columns."
                 )
             for column in prediction.columns:
+                _validate_appliance_name(column, label="Prediction appliance")
                 values = prediction[column].to_numpy()
                 if (
                     pd.api.types.is_bool_dtype(values.dtype)
@@ -549,6 +541,27 @@ class TorchDisaggregator(Disaggregator):
                         f"Inference prediction {position} column {column!r} "
                         "contains non-finite values."
                     )
+        return predictions
+
+    @classmethod
+    def align_raw_inference_predictions(cls, predictions, raw_indexes):
+        """Restore raw indexes, failing closed on missing or extra rows/chunks."""
+        predictions = cls.validate_inference_predictions(predictions)
+        if len(predictions) != len(raw_indexes):
+            raise ValueError(
+                "Inference changed the number of chunks: "
+                f"expected {len(raw_indexes)}, got {len(predictions)}."
+            )
+
+        aligned = []
+        for position, (prediction, raw_index) in enumerate(
+            zip(predictions, raw_indexes, strict=True)
+        ):
+            if len(prediction) != len(raw_index):
+                raise ValueError(
+                    f"Inference prediction {position} has {len(prediction)} rows; "
+                    f"expected {len(raw_index)} raw rows."
+                )
             prediction = prediction.copy()
             prediction.index = raw_index
             aligned.append(prediction)

--- a/nilmtk_contrib/torch/bert.py
+++ b/nilmtk_contrib/torch/bert.py
@@ -338,7 +338,7 @@ class BERT(TorchDisaggregator):
             
         if raw_indexes is not None:
             return self.align_raw_inference_predictions(test_predictions, raw_indexes)
-        return test_predictions
+        return self.validate_inference_predictions(test_predictions)
 
     def call_preprocessing(self, mains_lst, submeters_lst, method):
         if method == 'train':            

--- a/nilmtk_contrib/torch/bert.py
+++ b/nilmtk_contrib/torch/bert.py
@@ -285,10 +285,12 @@ class BERT(TorchDisaggregator):
     # Remaining methods keep the legacy backend behavior.
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         self.require_models(model)
-            
+
+        raw_indexes = None
         if do_preprocessing:
-            test_main_list = self.call_preprocessing(
-                test_main_list, submeters_lst=None, method='test')
+            test_main_list, raw_indexes = self.preprocess_raw_inference_chunks(
+                test_main_list
+            )
                 
         test_predictions = []
         for test_mains_df in test_main_list:
@@ -334,6 +336,8 @@ class BERT(TorchDisaggregator):
             results = pd.DataFrame(disggregation_dict, dtype='float32')
             test_predictions.append(results)
             
+        if raw_indexes is not None:
+            return self.align_raw_inference_predictions(test_predictions, raw_indexes)
         return test_predictions
 
     def call_preprocessing(self, mains_lst, submeters_lst, method):

--- a/nilmtk_contrib/torch/conv_lstm.py
+++ b/nilmtk_contrib/torch/conv_lstm.py
@@ -333,4 +333,4 @@ class ConvLSTM(TorchDisaggregator):
             test_predictions.append(results)
         if raw_indexes is not None:
             return self.align_raw_inference_predictions(test_predictions, raw_indexes)
-        return test_predictions
+        return self.validate_inference_predictions(test_predictions)

--- a/nilmtk_contrib/torch/conv_lstm.py
+++ b/nilmtk_contrib/torch/conv_lstm.py
@@ -303,8 +303,11 @@ class ConvLSTM(TorchDisaggregator):
         self.require_models(model)
 
         # Preprocess the test mains such as windowing and normalizing
+        raw_indexes = None
         if do_preprocessing:
-            test_main_list = self.call_preprocessing(test_main_list, submeters_lst=None, method='test')
+            test_main_list, raw_indexes = self.preprocess_raw_inference_chunks(
+                test_main_list
+            )
 
         test_predictions = []
         for test_main in test_main_list:
@@ -328,4 +331,6 @@ class ConvLSTM(TorchDisaggregator):
                     disggregation_dict[appliance] = df
             results = pd.DataFrame(disggregation_dict, dtype='float32')
             test_predictions.append(results)
+        if raw_indexes is not None:
+            return self.align_raw_inference_predictions(test_predictions, raw_indexes)
         return test_predictions

--- a/nilmtk_contrib/torch/msdc.py
+++ b/nilmtk_contrib/torch/msdc.py
@@ -576,21 +576,22 @@ class MSDC(TorchDisaggregator):
         """Disaggregates a chunk of mains data using the trained models."""
         self.require_models(model)
         test_main_list = list(test_main_list)
-        output_indexes = [
-            getattr(frame, "index", pd.RangeIndex(len(frame))).copy()
-            for frame in test_main_list
-        ]
-        
+
         # Preprocess test data
+        raw_indexes = None
+        preprocessed_indexes = None
         if do_preprocessing:
-            test_main_list = self.call_preprocessing(
-                test_main_list, submeters_lst=None, method="test"
+            test_main_list, raw_indexes = self.preprocess_raw_inference_chunks(
+                test_main_list
             )
-        
+        else:
+            preprocessed_indexes = tuple(
+                getattr(frame, "index", pd.RangeIndex(len(frame))).copy()
+                for frame in test_main_list
+            )
+
         test_predictions = []
-        for chunk_index, (test_main, output_index) in enumerate(
-            zip(test_main_list, output_indexes, strict=True)
-        ):
+        for chunk_index, test_main in enumerate(test_main_list):
             test_main = test_main.values
             test_main = test_main.reshape((-1, self.sequence_length, 1))
             disaggregation = {}
@@ -627,19 +628,17 @@ class MSDC(TorchDisaggregator):
                 
                 disaggregation[appliance] = pred
 
-            if any(
-                len(prediction) != len(output_index)
-                for _, prediction in disaggregation.items()
-            ):
-                raise RuntimeError(
-                    f"MSDC prediction length does not match input chunk {chunk_index}."
-                )
+            output_index = (
+                None
+                if preprocessed_indexes is None
+                else preprocessed_indexes[chunk_index]
+            )
             test_predictions.append(
-                pd.DataFrame(
-                    disaggregation, index=output_index, dtype="float32"
-                )
+                pd.DataFrame(disaggregation, index=output_index, dtype="float32")
             )
         
+        if raw_indexes is not None:
+            return self.align_raw_inference_predictions(test_predictions, raw_indexes)
         return test_predictions
     
     def call_preprocessing(self, mains_lst, submeters_lst, method):

--- a/nilmtk_contrib/torch/msdc.py
+++ b/nilmtk_contrib/torch/msdc.py
@@ -605,6 +605,33 @@ class MSDC(TorchDisaggregator):
                 with torch.no_grad():
                     # Forward pass
                     emissions, power_preds = model(test_main_tensor)
+                    for output_name, output in (
+                        ("emissions", emissions),
+                        ("power predictions", power_preds),
+                    ):
+                        if not isinstance(output, torch.Tensor):
+                            raise TypeError(
+                                f"MSDC {output_name} for {appliance!r} must be a "
+                                "tensor."
+                            )
+                        if (
+                            not torch.is_floating_point(output)
+                            or torch.is_complex(output)
+                        ):
+                            raise TypeError(
+                                f"MSDC {output_name} for {appliance!r} must contain "
+                                "real floating values."
+                            )
+                        if output.device != test_main_tensor.device:
+                            raise ValueError(
+                                f"MSDC {output_name} for {appliance!r} uses "
+                                f"{output.device}; expected {test_main_tensor.device}."
+                            )
+                        if not torch.isfinite(output).all():
+                            raise FloatingPointError(
+                                f"MSDC {output_name} for {appliance!r} contains "
+                                "non-finite values."
+                            )
                     
                     # Decode state sequence using Viterbi
                     best_states = model.crf.viterbi_decode(emissions)
@@ -620,7 +647,7 @@ class MSDC(TorchDisaggregator):
                     
                     # Extract center values (middle of each window)
                     center_idx = self.sequence_length // 2
-                    pred = predicted_power[:, center_idx].cpu().numpy()
+                    pred = predicted_power[:, center_idx].float().cpu().numpy()
                     
                     # Denormalize predictions
                     pred = pred * self.appliance_params[appliance]['std'] + self.appliance_params[appliance]['mean']
@@ -639,7 +666,7 @@ class MSDC(TorchDisaggregator):
         
         if raw_indexes is not None:
             return self.align_raw_inference_predictions(test_predictions, raw_indexes)
-        return test_predictions
+        return self.validate_inference_predictions(test_predictions)
     
     def call_preprocessing(self, mains_lst, submeters_lst, method):
         """

--- a/nilmtk_contrib/torch/msdc_without_crf.py
+++ b/nilmtk_contrib/torch/msdc_without_crf.py
@@ -507,21 +507,22 @@ class MSDC(TorchDisaggregator):
         """Disaggregate power consumption using the trained MSDC model."""
         self.require_models(model)
         test_main_list = list(test_main_list)
-        output_indexes = [
-            getattr(frame, "index", pd.RangeIndex(len(frame))).copy()
-            for frame in test_main_list
-        ]
-        
+
         # Preprocess the test mains
+        raw_indexes = None
+        preprocessed_indexes = None
         if do_preprocessing:
-            test_main_list = self.call_preprocessing(
-                test_main_list, submeters_lst=None, method="test"
+            test_main_list, raw_indexes = self.preprocess_raw_inference_chunks(
+                test_main_list
             )
-        
+        else:
+            preprocessed_indexes = tuple(
+                getattr(frame, "index", pd.RangeIndex(len(frame))).copy()
+                for frame in test_main_list
+            )
+
         test_predictions = []
-        for chunk_index, (test_main, output_index) in enumerate(
-            zip(test_main_list, output_indexes, strict=True)
-        ):
+        for chunk_index, test_main in enumerate(test_main_list):
             test_main = test_main.values
             test_main = test_main.reshape((-1, self.sequence_length))
             disaggregation = {}
@@ -564,19 +565,17 @@ class MSDC(TorchDisaggregator):
                 
                 disaggregation[appliance] = pred
 
-            if any(
-                len(prediction) != len(output_index)
-                for _, prediction in disaggregation.items()
-            ):
-                raise RuntimeError(
-                    f"MSDC prediction length does not match input chunk {chunk_index}."
-                )
+            output_index = (
+                None
+                if preprocessed_indexes is None
+                else preprocessed_indexes[chunk_index]
+            )
             test_predictions.append(
-                pd.DataFrame(
-                    disaggregation, index=output_index, dtype="float32"
-                )
+                pd.DataFrame(disaggregation, index=output_index, dtype="float32")
             )
         
+        if raw_indexes is not None:
+            return self.align_raw_inference_predictions(test_predictions, raw_indexes)
         return test_predictions
     
     def call_preprocessing(self, mains_lst, submeters_lst, method):

--- a/nilmtk_contrib/torch/msdc_without_crf.py
+++ b/nilmtk_contrib/torch/msdc_without_crf.py
@@ -543,6 +543,33 @@ class MSDC(TorchDisaggregator):
                 with torch.no_grad():
                     # Forward pass through MSDC
                     power_preds, state_preds = model(test_main_tensor)
+                    for output_name, output in (
+                        ("power predictions", power_preds),
+                        ("state predictions", state_preds),
+                    ):
+                        if not isinstance(output, torch.Tensor):
+                            raise TypeError(
+                                f"MSDC {output_name} for {appliance!r} must be a "
+                                "tensor."
+                            )
+                        if (
+                            not torch.is_floating_point(output)
+                            or torch.is_complex(output)
+                        ):
+                            raise TypeError(
+                                f"MSDC {output_name} for {appliance!r} must contain "
+                                "real floating values."
+                            )
+                        if output.device != test_main_tensor.device:
+                            raise ValueError(
+                                f"MSDC {output_name} for {appliance!r} uses "
+                                f"{output.device}; expected {test_main_tensor.device}."
+                            )
+                        if not torch.isfinite(output).all():
+                            raise FloatingPointError(
+                                f"MSDC {output_name} for {appliance!r} contains "
+                                "non-finite values."
+                            )
                     
                     # Reshape predictions
                     batch_size = power_preds.shape[0]
@@ -557,7 +584,7 @@ class MSDC(TorchDisaggregator):
                     
                     # Extract center values (middle of each window)
                     center_idx = self.out_len // 2
-                    pred = predicted_power[:, center_idx].cpu().numpy()
+                    pred = predicted_power[:, center_idx].float().cpu().numpy()
                     
                     # Denormalize predictions
                     pred = pred * self.appliance_params[appliance]['std'] + self.appliance_params[appliance]['mean']
@@ -576,7 +603,7 @@ class MSDC(TorchDisaggregator):
         
         if raw_indexes is not None:
             return self.align_raw_inference_predictions(test_predictions, raw_indexes)
-        return test_predictions
+        return self.validate_inference_predictions(test_predictions)
     
     def call_preprocessing(self, mains_lst, submeters_lst, method):
         """

--- a/nilmtk_contrib/torch/nilmformer.py
+++ b/nilmtk_contrib/torch/nilmformer.py
@@ -832,21 +832,26 @@ class NILMFormer(TorchDisaggregator):
         
         self.require_models(model)
 
+        raw_indexes = None
+        if do_preprocessing:
+            test_main_list, raw_indexes = self.preprocess_raw_inference_chunks(
+                test_main_list
+            )
+
         test_predictions = []
-        for test_mains_df in test_main_list:
+        for chunk_position, test_mains_df in enumerate(test_main_list):
             disggregation_dict = {}
             
             # Store original length before any preprocessing
-            original_length = len(test_mains_df)
+            original_length = (
+                len(raw_indexes[chunk_position])
+                if raw_indexes is not None
+                else len(test_mains_df)
+            )
             
             if do_preprocessing:
-                # Use the standard preprocessing pipeline
-                processed_mains_list = self.call_preprocessing(
-                    [test_mains_df], submeters_lst=None, method='test')
-                processed_mains_df = processed_mains_list[0]
-                
                 # Convert preprocessed data to proper format
-                test_main_values = processed_mains_df.values  # Already shaped correctly
+                test_main_values = test_mains_df.values  # Already shaped correctly
                 test_main_tensor = torch.tensor(
                     test_main_values.reshape((-1, 1, self.sequence_length)), 
                     dtype=torch.float32
@@ -930,6 +935,8 @@ class NILMFormer(TorchDisaggregator):
             results = pd.DataFrame(disggregation_dict, dtype='float32')
             test_predictions.append(results)
 
+        if raw_indexes is not None:
+            return self.align_raw_inference_predictions(test_predictions, raw_indexes)
         return test_predictions
 
     def call_preprocessing(self, mains_lst, submeters_lst, method):

--- a/nilmtk_contrib/torch/nilmformer.py
+++ b/nilmtk_contrib/torch/nilmformer.py
@@ -42,6 +42,7 @@ import torch.nn.functional as F
 from torch.utils.data import Dataset, DataLoader
 from tqdm import tqdm
 from nilmtk_contrib.torch._base import TorchDisaggregator, torch_defaults
+from nilmtk_contrib.torch._data import _float32_array
 from nilmtk_contrib.utils.model import legacy_print, module_logger, checkpoint_path
 
 logger = module_logger(__name__)
@@ -826,118 +827,119 @@ class NILMFormer(TorchDisaggregator):
         _log_print(f"Training completed for {appliance_name}")
 
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
-        """
-        Disaggregate power consumption for test data using NILMFormer
-        """
-        
-        self.require_models(model)
+        """Disaggregate one point per supplied or preprocessed input window."""
+        models = self.require_models(model)
 
         raw_indexes = None
         if do_preprocessing:
             test_main_list, raw_indexes = self.preprocess_raw_inference_chunks(
                 test_main_list
             )
+        else:
+            test_main_list = list(test_main_list)
 
         test_predictions = []
         for chunk_position, test_mains_df in enumerate(test_main_list):
-            disggregation_dict = {}
-            
-            # Store original length before any preprocessing
+            windows = _float32_array(
+                test_mains_df, f"Inference windows for chunk {chunk_position}"
+            )
+            if windows.ndim != 2 or windows.shape[1] != self.sequence_length:
+                raise ValueError(
+                    f"Inference windows for chunk {chunk_position} must have shape "
+                    f"[samples, {self.sequence_length}]."
+                )
             original_length = (
                 len(raw_indexes[chunk_position])
                 if raw_indexes is not None
-                else len(test_mains_df)
+                else len(windows)
             )
-            
-            if do_preprocessing:
-                # Convert preprocessed data to proper format
-                test_main_values = test_mains_df.values  # Already shaped correctly
-                test_main_tensor = torch.tensor(
-                    test_main_values.reshape((-1, 1, self.sequence_length)), 
-                    dtype=torch.float32
-                )  # (N, 1, L)
-            else:
-                # Manual preprocessing if needed
-                test_main_values = test_mains_df.values.flatten()
-                n = self.sequence_length
-                units_to_pad = n // 2
-                test_main_values = np.pad(
-                    test_main_values, (units_to_pad, units_to_pad),
-                    'constant', constant_values=(0, 0)
+            if raw_indexes is not None and len(windows) != original_length:
+                raise ValueError(
+                    f"NILMFormer preprocessing produced {len(windows)} windows for "
+                    f"{original_length} raw rows in chunk {chunk_position}."
                 )
-                test_main_values = np.array([
-                    test_main_values[i:i + n] for i in range(len(test_main_values) - n + 1)
-                ])
-                test_main_values = (test_main_values - self.mains_mean) / self.mains_std
-                test_main_tensor = torch.tensor(
-                    test_main_values.reshape((-1, 1, self.sequence_length)),
-                    dtype=torch.float32
-                )
-            
+            test_main_tensor = torch.from_numpy(windows).unsqueeze(1)
+
             # Create exogenous temporal features for test data
-            n_samples = test_main_tensor.shape[0]
-            test_exogenous = self.create_exogene_features(n_samples, self.sequence_length)
-            
+            test_exogenous = self.create_exogene_features(
+                len(test_main_tensor), self.sequence_length
+            )
+
             # Prepare input: concatenate main power with exogenous features
-            test_input = torch.cat([test_main_tensor, test_exogenous], dim=1)  # (B, 1 + c_embedding, L)
+            test_input = torch.cat([test_main_tensor, test_exogenous], dim=1)
             test_input_tensor = test_input.to(self.device)
 
-            for appliance in self.models:
-                model = self.models[appliance]
-                model.eval()
-                
-                with torch.no_grad():
-                    # Process in batches to avoid memory issues
-                    predictions = []
+            disaggregation = {}
+            for appliance, network in models.items():
+                network.eval()
+                predictions = []
+                with torch.inference_mode():
                     for i in range(0, len(test_input_tensor), self.batch_size):
-                        batch = test_input_tensor[i:i+self.batch_size]
-                        pred_batch = model(batch)  # Shape: (B, c_out, L)
-                        predictions.append(pred_batch.cpu().numpy())
-                    
-                    prediction = np.concatenate(predictions, axis=0)  # (N, c_out, L)
-
-                # Extract middle predictions for sequence-to-point conversion
-                middle_idx = self.sequence_length // 2
-                point_predictions = prediction[:, 0, middle_idx]  # (N,)
-                
-                # Reconstruct full sequence using correct overlapping window logic
-                padding = self.sequence_length // 2
-                reconstructed_length = original_length  # Use original length!
-                sum_arr = np.zeros(reconstructed_length + 2 * padding)
-                counts_arr = np.zeros(reconstructed_length + 2 * padding)
-                
-                # Place predictions at correct positions
-                for i, pred_value in enumerate(point_predictions):
-                    target_idx = i + padding  # Account for padding offset
-                    if target_idx < len(sum_arr):
-                        sum_arr[target_idx] += pred_value
-                        counts_arr[target_idx] += 1
-                
-                # Average overlapping predictions and extract original sequence
-                valid_mask = counts_arr > 0
-                final_prediction = np.zeros_like(sum_arr)
-                final_prediction[valid_mask] = sum_arr[valid_mask] / counts_arr[valid_mask]
-                
-                # Extract the original sequence (remove padding)
-                final_prediction = final_prediction[padding:padding + original_length]
-                
+                        batch = test_input_tensor[i : i + self.batch_size]
+                        prediction = network(batch)
+                        expected_shape = (
+                            len(batch),
+                            1,
+                            self.sequence_length,
+                        )
+                        if not isinstance(prediction, torch.Tensor):
+                            raise TypeError(
+                                f"Model for {appliance!r} must return a tensor."
+                            )
+                        if tuple(prediction.shape) != expected_shape:
+                            raise ValueError(
+                                f"Model for {appliance!r} returned shape "
+                                f"{tuple(prediction.shape)}; expected {expected_shape}."
+                            )
+                        if (
+                            not torch.is_floating_point(prediction)
+                            or torch.is_complex(prediction)
+                        ):
+                            raise TypeError(
+                                f"Model for {appliance!r} must return real floating "
+                                "values."
+                            )
+                        if prediction.device != batch.device:
+                            raise ValueError(
+                                f"Model for {appliance!r} returned values on "
+                                f"{prediction.device}; expected {batch.device}."
+                            )
+                        if not torch.isfinite(prediction).all():
+                            raise FloatingPointError(
+                                f"Model for {appliance!r} returned non-finite values."
+                            )
+                        predictions.append(prediction.detach().float().cpu())
+                point_predictions = (
+                    torch.cat(predictions)[:, 0, self.sequence_length // 2].numpy()
+                    if predictions
+                    else np.empty(0, dtype=np.float32)
+                )
+                if len(point_predictions) != original_length:
+                    raise ValueError(
+                        f"NILMFormer produced {len(point_predictions)} predictions "
+                        f"for {original_length} rows in chunk {chunk_position}."
+                    )
                 # Denormalize the predictions
-                if appliance in self.appliance_params:
-                    app_mean = self.appliance_params[appliance]['mean']
-                    app_std = self.appliance_params[appliance]['std']
-                    final_prediction = final_prediction * app_std + app_mean
-                
-                # Clip negative values
-                final_prediction_clipped = np.where(final_prediction > 0, final_prediction, 0)
-                df = pd.Series(final_prediction_clipped)
-                disggregation_dict[appliance] = df
+                statistics = self.appliance_params[appliance]
+                with np.errstate(over="ignore", invalid="ignore"):
+                    values = np.clip(
+                        point_predictions.astype(np.float64) * statistics["std"]
+                        + statistics["mean"],
+                        0,
+                        None,
+                    ).astype(np.float32)
+                if not np.isfinite(values).all():
+                    raise FloatingPointError(
+                        f"Predictions for {appliance!r} became non-finite."
+                    )
+                disaggregation[appliance] = values
 
-            results = pd.DataFrame(disggregation_dict, dtype='float32')
+            results = pd.DataFrame(disaggregation, dtype="float32")
             test_predictions.append(results)
 
         if raw_indexes is not None:
             return self.align_raw_inference_predictions(test_predictions, raw_indexes)
-        return test_predictions
+        return self.validate_inference_predictions(test_predictions)
 
     def call_preprocessing(self, mains_lst, submeters_lst, method):
         """Preprocess data for training or testing"""

--- a/nilmtk_contrib/torch/reformer.py
+++ b/nilmtk_contrib/torch/reformer.py
@@ -523,8 +523,11 @@ class Reformer(TorchDisaggregator):
         self.require_models(model)
 
         # Preprocess the test mains such as windowing and normalizing
+        raw_indexes = None
         if do_preprocessing:
-            test_main_list = self.call_preprocessing(test_main_list, submeters_lst=None, method='test')
+            test_main_list, raw_indexes = self.preprocess_raw_inference_chunks(
+                test_main_list
+            )
 
         test_predictions = []
         for test_main in test_main_list:
@@ -548,4 +551,6 @@ class Reformer(TorchDisaggregator):
                     disggregation_dict[appliance] = df
             results = pd.DataFrame(disggregation_dict, dtype='float32')
             test_predictions.append(results)
+        if raw_indexes is not None:
+            return self.align_raw_inference_predictions(test_predictions, raw_indexes)
         return test_predictions

--- a/nilmtk_contrib/torch/reformer.py
+++ b/nilmtk_contrib/torch/reformer.py
@@ -553,4 +553,4 @@ class Reformer(TorchDisaggregator):
             test_predictions.append(results)
         if raw_indexes is not None:
             return self.align_raw_inference_predictions(test_predictions, raw_indexes)
-        return test_predictions
+        return self.validate_inference_predictions(test_predictions)

--- a/nilmtk_contrib/torch/resnet.py
+++ b/nilmtk_contrib/torch/resnet.py
@@ -356,11 +356,13 @@ class ResNet(TorchDisaggregator):
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """Disaggregates a chunk of mains data."""
         self.require_models(model)
-        
+
+        raw_indexes = None
         if do_preprocessing:
             _log_print("Preprocessing test data...")
-            test_main_list = self.call_preprocessing(
-                test_main_list, submeters_lst=None, method='test')
+            test_main_list, raw_indexes = self.preprocess_raw_inference_chunks(
+                test_main_list
+            )
         
         test_predictions = []
         
@@ -411,6 +413,8 @@ class ResNet(TorchDisaggregator):
             results = pd.DataFrame(disggregation_dict, dtype='float32')
             test_predictions.append(results)
         
+        if raw_indexes is not None:
+            return self.align_raw_inference_predictions(test_predictions, raw_indexes)
         return test_predictions
     
     def return_network(self):

--- a/nilmtk_contrib/torch/resnet.py
+++ b/nilmtk_contrib/torch/resnet.py
@@ -415,7 +415,7 @@ class ResNet(TorchDisaggregator):
         
         if raw_indexes is not None:
             return self.align_raw_inference_predictions(test_predictions, raw_indexes)
-        return test_predictions
+        return self.validate_inference_predictions(test_predictions)
     
     def return_network(self):
         """Returns a new, initialized ResNet model."""

--- a/nilmtk_contrib/torch/resnet_classification.py
+++ b/nilmtk_contrib/torch/resnet_classification.py
@@ -499,7 +499,7 @@ class ResNet_classification(TorchDisaggregator):
             test_predictions.append(results)
         if raw_indexes is not None:
             return self.align_raw_inference_predictions(test_predictions, raw_indexes)
-        return test_predictions
+        return self.validate_inference_predictions(test_predictions)
 
     def classification_output_plot(self, prediction_classification, appliance):
         """Optional plotting function for classification output (matching TensorFlow)"""

--- a/nilmtk_contrib/torch/resnet_classification.py
+++ b/nilmtk_contrib/torch/resnet_classification.py
@@ -455,9 +455,11 @@ class ResNet_classification(TorchDisaggregator):
         """Disaggregates a chunk of mains data."""
         self.require_models(model)
 
+        raw_indexes = None
         if do_preprocessing:
-            test_main_list = self.call_preprocessing(
-                test_main_list, submeters_lst=None, method='test')
+            test_main_list, raw_indexes = self.preprocess_raw_inference_chunks(
+                test_main_list
+            )
 
         test_predictions = []
         for test_mains_df in test_main_list:
@@ -495,6 +497,8 @@ class ResNet_classification(TorchDisaggregator):
                 disggregation_dict[appliance] = df
             results = pd.DataFrame(disggregation_dict, dtype='float32')
             test_predictions.append(results)
+        if raw_indexes is not None:
+            return self.align_raw_inference_predictions(test_predictions, raw_indexes)
         return test_predictions
 
     def classification_output_plot(self, prediction_classification, appliance):

--- a/nilmtk_contrib/torch/rnn.py
+++ b/nilmtk_contrib/torch/rnn.py
@@ -193,9 +193,11 @@ class RNN(TorchDisaggregator):
         """Disaggregates a chunk of mains data."""
         self.require_models(model)
 
+        raw_indexes = None
         if do_preprocessing:
-            test_main_list = self.call_preprocessing(
-                test_main_list, submeters_lst=None, method='test')
+            test_main_list, raw_indexes = self.preprocess_raw_inference_chunks(
+                test_main_list
+            )
 
         test_predictions = []
         for test_mains_df in test_main_list:
@@ -227,6 +229,8 @@ class RNN(TorchDisaggregator):
                 
             results = pd.DataFrame(disggregation_dict, dtype='float32')
             test_predictions.append(results)
+        if raw_indexes is not None:
+            return self.align_raw_inference_predictions(test_predictions, raw_indexes)
         return test_predictions
 
     def return_network(self):

--- a/nilmtk_contrib/torch/rnn.py
+++ b/nilmtk_contrib/torch/rnn.py
@@ -231,7 +231,7 @@ class RNN(TorchDisaggregator):
             test_predictions.append(results)
         if raw_indexes is not None:
             return self.align_raw_inference_predictions(test_predictions, raw_indexes)
-        return test_predictions
+        return self.validate_inference_predictions(test_predictions)
 
     def return_network(self):
         """Returns a new, initialized RNNModel instance."""

--- a/nilmtk_contrib/torch/rnn_attention.py
+++ b/nilmtk_contrib/torch/rnn_attention.py
@@ -245,10 +245,12 @@ class RNN_attention(TorchDisaggregator):
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         """Disaggregates a chunk of mains data."""
         self.require_models(model)
-        
+
+        raw_indexes = None
         if do_preprocessing:
-            test_main_list = self.call_preprocessing(
-                test_main_list, submeters_lst=None, method='test')
+            test_main_list, raw_indexes = self.preprocess_raw_inference_chunks(
+                test_main_list
+            )
         
         test_predictions = []
         
@@ -286,6 +288,8 @@ class RNN_attention(TorchDisaggregator):
             results = pd.DataFrame(disggregation_dict, dtype='float32')
             test_predictions.append(results)
         
+        if raw_indexes is not None:
+            return self.align_raw_inference_predictions(test_predictions, raw_indexes)
         return test_predictions
     
     def return_network(self):

--- a/nilmtk_contrib/torch/rnn_attention.py
+++ b/nilmtk_contrib/torch/rnn_attention.py
@@ -290,7 +290,7 @@ class RNN_attention(TorchDisaggregator):
         
         if raw_indexes is not None:
             return self.align_raw_inference_predictions(test_predictions, raw_indexes)
-        return test_predictions
+        return self.validate_inference_predictions(test_predictions)
     
     def return_network(self):
         """Returns a new, initialized RNNAttentionModel instance."""

--- a/nilmtk_contrib/torch/rnn_attention_classification.py
+++ b/nilmtk_contrib/torch/rnn_attention_classification.py
@@ -435,9 +435,11 @@ class RNN_attention_classification(TorchDisaggregator):
         """Disaggregates a chunk of mains data."""
         self.require_models(model)
 
+        raw_indexes = None
         if do_preprocessing:
-            test_main_list = self.call_preprocessing(
-                test_main_list, submeters_lst=None, method='test')
+            test_main_list, raw_indexes = self.preprocess_raw_inference_chunks(
+                test_main_list
+            )
 
         test_predictions = []
         for test_mains_df in test_main_list:
@@ -479,4 +481,6 @@ class RNN_attention_classification(TorchDisaggregator):
             results = pd.DataFrame(disggregation_dict, dtype='float32')
             test_predictions.append(results)
 
+        if raw_indexes is not None:
+            return self.align_raw_inference_predictions(test_predictions, raw_indexes)
         return test_predictions

--- a/nilmtk_contrib/torch/rnn_attention_classification.py
+++ b/nilmtk_contrib/torch/rnn_attention_classification.py
@@ -483,4 +483,4 @@ class RNN_attention_classification(TorchDisaggregator):
 
         if raw_indexes is not None:
             return self.align_raw_inference_predictions(test_predictions, raw_indexes)
-        return test_predictions
+        return self.validate_inference_predictions(test_predictions)

--- a/nilmtk_contrib/torch/seq2point.py
+++ b/nilmtk_contrib/torch/seq2point.py
@@ -278,4 +278,4 @@ class Seq2PointTorch(TorchDisaggregator):
             test_predictions.append(results)
         if raw_indexes is not None:
             return self.align_raw_inference_predictions(test_predictions, raw_indexes)
-        return test_predictions
+        return self.validate_inference_predictions(test_predictions)

--- a/nilmtk_contrib/torch/seq2point.py
+++ b/nilmtk_contrib/torch/seq2point.py
@@ -245,8 +245,11 @@ class Seq2PointTorch(TorchDisaggregator):
         """Disaggregates a chunk of mains data."""
         self.require_models(model)
 
+        raw_indexes = None
         if do_preprocessing:
-            test_main_list = self.call_preprocessing(test_main_list, submeters_lst=None, method='test')
+            test_main_list, raw_indexes = self.preprocess_raw_inference_chunks(
+                test_main_list
+            )
 
         test_predictions = []
         for test_mains_df in test_main_list:
@@ -273,4 +276,6 @@ class Seq2PointTorch(TorchDisaggregator):
                     
             results = pd.DataFrame(disggregation_dict, dtype='float32')
             test_predictions.append(results)
+        if raw_indexes is not None:
+            return self.align_raw_inference_predictions(test_predictions, raw_indexes)
         return test_predictions

--- a/nilmtk_contrib/torch/seq2seq.py
+++ b/nilmtk_contrib/torch/seq2seq.py
@@ -210,9 +210,11 @@ class Seq2Seq(TorchDisaggregator):
         """Disaggregates a chunk of mains data."""
         self.require_models(model)
 
+        raw_indexes = None
         if do_preprocessing:
-            test_main_list = self.call_preprocessing(
-                test_main_list, submeters_lst=None, method='test')
+            test_main_list, raw_indexes = self.preprocess_raw_inference_chunks(
+                test_main_list
+            )
 
         test_predictions = []
         for test_mains_df in test_main_list:
@@ -259,6 +261,8 @@ class Seq2Seq(TorchDisaggregator):
             results = pd.DataFrame(disggregation_dict, dtype='float32')
             test_predictions.append(results)
 
+        if raw_indexes is not None:
+            return self.align_raw_inference_predictions(test_predictions, raw_indexes)
         return test_predictions
 
     def call_preprocessing(self, mains_lst, submeters_lst, method):

--- a/nilmtk_contrib/torch/seq2seq.py
+++ b/nilmtk_contrib/torch/seq2seq.py
@@ -263,7 +263,7 @@ class Seq2Seq(TorchDisaggregator):
 
         if raw_indexes is not None:
             return self.align_raw_inference_predictions(test_predictions, raw_indexes)
-        return test_predictions
+        return self.validate_inference_predictions(test_predictions)
 
     def call_preprocessing(self, mains_lst, submeters_lst, method):
         """

--- a/tests/test_legacy_inference_alignment.py
+++ b/tests/test_legacy_inference_alignment.py
@@ -1,0 +1,302 @@
+from collections import OrderedDict
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+torch = pytest.importorskip("torch")
+WindowGRU = pytest.importorskip("nilmtk_contrib.torch.WindowGRU").WindowGRU
+torch_base = pytest.importorskip("nilmtk_contrib.torch._base")
+TorchDisaggregator = torch_base.TorchDisaggregator
+torch_defaults = torch_base.torch_defaults
+BERT = pytest.importorskip("nilmtk_contrib.torch.bert").BERT
+ConvLSTM = pytest.importorskip("nilmtk_contrib.torch.conv_lstm").ConvLSTM
+MSDC = pytest.importorskip("nilmtk_contrib.torch.msdc").MSDC
+MSDCWithoutCRF = pytest.importorskip(
+    "nilmtk_contrib.torch.msdc_without_crf"
+).MSDC
+NILMFormer = pytest.importorskip("nilmtk_contrib.torch.nilmformer").NILMFormer
+Reformer = pytest.importorskip("nilmtk_contrib.torch.reformer").Reformer
+ResNet = pytest.importorskip("nilmtk_contrib.torch.resnet").ResNet
+ResNet_classification = pytest.importorskip(
+    "nilmtk_contrib.torch.resnet_classification"
+).ResNet_classification
+RNN = pytest.importorskip("nilmtk_contrib.torch.rnn").RNN
+RNN_attention = pytest.importorskip("nilmtk_contrib.torch.rnn_attention").RNN_attention
+RNN_attention_classification = pytest.importorskip(
+    "nilmtk_contrib.torch.rnn_attention_classification"
+).RNN_attention_classification
+Seq2PointTorch = pytest.importorskip(
+    "nilmtk_contrib.torch.seq2point"
+).Seq2PointTorch
+Seq2Seq = pytest.importorskip("nilmtk_contrib.torch.seq2seq").Seq2Seq
+
+
+SEQUENCE_LENGTH = 3
+RAW_LENGTH = 7
+APPLIANCE_PARAMS = {
+    "fridge": {"mean": 10.0, "std": 2.0, "min": 0.0, "max": 20.0}
+}
+
+
+class FakeNetwork(torch.nn.Module):
+    """Cheap deterministic outputs matching the legacy adapters' signatures."""
+
+    def __init__(self, mode, sequence_length=SEQUENCE_LENGTH, num_states=2):
+        super().__init__()
+        self.bias = torch.nn.Parameter(torch.zeros(1))
+        self.mode = mode
+        self.sequence_length = sequence_length
+        self.num_states = num_states
+        if mode == "msdc":
+            self.crf = FakeCRF()
+
+    def forward(self, values):
+        batch_size = len(values)
+        point = torch.zeros((batch_size, 1), device=values.device) + self.bias
+        sequence = torch.zeros(
+            (batch_size, self.sequence_length), device=values.device
+        ) + self.bias
+        if self.mode == "point":
+            return point
+        if self.mode == "sequence":
+            return sequence
+        if self.mode == "resnet_classification":
+            return sequence, sequence
+        if self.mode == "rnn_attention_classification":
+            return sequence, sequence, sequence
+        if self.mode == "nilmformer":
+            return sequence.unsqueeze(1)
+        if self.mode == "msdc":
+            shape = (batch_size, self.sequence_length, self.num_states)
+            emissions = torch.zeros(shape, device=values.device) + self.bias
+            power = torch.zeros(shape, device=values.device) + self.bias
+            return emissions, power
+        if self.mode == "msdc_without_crf":
+            shape = (batch_size, self.sequence_length, self.num_states)
+            power = torch.zeros(shape, device=values.device) + self.bias
+            states = torch.zeros(shape, device=values.device) + self.bias
+            return power, states
+        raise AssertionError(f"Unknown fake-network mode {self.mode!r}.")
+
+
+class FakeCRF:
+    @staticmethod
+    def viterbi_decode(emissions):
+        return torch.zeros(emissions.shape[:2], dtype=torch.long, device=emissions.device)
+
+
+MODEL_CASES = [
+    pytest.param(BERT, "sequence", id="bert"),
+    pytest.param(ConvLSTM, "point", id="conv-lstm"),
+    pytest.param(MSDC, "msdc", id="msdc"),
+    pytest.param(
+        MSDCWithoutCRF, "msdc_without_crf", id="msdc-without-crf"
+    ),
+    pytest.param(NILMFormer, "nilmformer", id="nilmformer"),
+    pytest.param(Reformer, "point", id="reformer"),
+    pytest.param(ResNet, "sequence", id="resnet"),
+    pytest.param(
+        ResNet_classification,
+        "resnet_classification",
+        id="resnet-classification",
+    ),
+    pytest.param(RNN, "point", id="rnn"),
+    pytest.param(RNN_attention, "point", id="rnn-attention"),
+    pytest.param(
+        RNN_attention_classification,
+        "rnn_attention_classification",
+        id="rnn-attention-classification",
+    ),
+    pytest.param(Seq2PointTorch, "point", id="seq2point"),
+    pytest.param(Seq2Seq, "sequence", id="seq2seq"),
+    pytest.param(WindowGRU, "point", id="window-gru"),
+]
+ROW_COUNT_CASES = [case for case in MODEL_CASES if case.values[0] is not NILMFormer]
+
+
+def _model(model_class, mode):
+    params = {
+        "device": "cpu",
+        "sequence_length": SEQUENCE_LENGTH,
+        "batch_size": 2,
+        "appliance_params": APPLIANCE_PARAMS,
+    }
+    if model_class is MSDCWithoutCRF:
+        params["out_len"] = SEQUENCE_LENGTH
+        params["num_states"] = 2
+    model = model_class(params)
+    if model_class in {MSDC, MSDCWithoutCRF}:
+        model.num_states = 2
+        model._get_appliance_config = lambda appliance: None
+    model.models = OrderedDict(
+        fridge=FakeNetwork(mode, num_states=getattr(model, "num_states", 2))
+    )
+    return model
+
+
+def _raw_chunk(length=RAW_LENGTH):
+    index = pd.Index(
+        np.arange(100, 100 + 5 * length, 5, dtype=np.int64), name="sample"
+    )
+    return pd.DataFrame(
+        {"power": np.linspace(40.0, 60.0, length, dtype=np.float32)},
+        index=index,
+    )
+
+
+def _install_fake_preprocessor(model, mode, *, row_delta=0):
+    sequence_output = mode in {
+        "sequence",
+        "resnet_classification",
+        "rnn_attention_classification",
+    }
+
+    def preprocess(chunks, submeters_lst, method):
+        assert submeters_lst is None
+        assert method == "test"
+        rows = []
+        for chunk in chunks:
+            count = len(chunk)
+            if sequence_output:
+                count -= model.sequence_length - 1
+            count += row_delta
+            rows.append(
+                pd.DataFrame(
+                    np.zeros((count, model.sequence_length), dtype=np.float32)
+                )
+            )
+        return rows
+
+    model.call_preprocessing = preprocess
+
+
+@pytest.mark.parametrize("model_class,mode", MODEL_CASES)
+def test_raw_partial_inference_preserves_exact_non_range_index(model_class, mode):
+    model = _model(model_class, mode)
+    _install_fake_preprocessor(model, mode)
+    mains = _raw_chunk()
+
+    result = model.disaggregate_chunk([mains])[0]
+
+    assert len(result) == len(mains)
+    assert result.index.equals(mains.index)
+    assert result.columns.tolist() == ["fridge"]
+    assert result.dtypes.tolist() == [np.dtype("float32")]
+    assert np.isfinite(result.to_numpy()).all()
+
+
+@pytest.mark.parametrize("model_class,mode", MODEL_CASES)
+def test_real_preprocessor_preserves_hostile_2448_row_timezone_index(
+    model_class, mode
+):
+    model = _model(model_class, mode)
+    model.batch_size = 512
+    index = pd.date_range(
+        "2026-01-01 00:00:00",
+        periods=2448,
+        freq="6s",
+        tz="Asia/Kolkata",
+        name="timestamp",
+    )
+    mains = pd.DataFrame(
+        {"power": np.linspace(40.0, 80.0, len(index), dtype=np.float32)},
+        index=index,
+    )
+
+    result = model.disaggregate_chunk([mains])[0]
+
+    assert len(result) == len(mains)
+    assert result.index.equals(mains.index)
+    assert result.index is not mains.index
+    assert result.dtypes.tolist() == [np.dtype("float32")]
+    assert np.isfinite(result.to_numpy()).all()
+
+
+@pytest.mark.parametrize("model_class,mode", ROW_COUNT_CASES)
+def test_raw_inference_fails_closed_when_model_returns_wrong_row_count(
+    model_class, mode
+):
+    model = _model(model_class, mode)
+    _install_fake_preprocessor(model, mode, row_delta=-1)
+
+    with pytest.raises(ValueError, match="expected 7 raw rows"):
+        model.disaggregate_chunk([_raw_chunk()])
+
+
+class MinimalDisaggregator(TorchDisaggregator):
+    def __init__(self):
+        super().__init__({"device": "cpu"}, defaults=torch_defaults())
+
+
+def test_helper_fails_closed_on_invalid_raw_chunks_and_preprocessor_chunk_count():
+    model = MinimalDisaggregator()
+    model.call_preprocessing = lambda chunks, submeters_lst, method: []
+
+    with pytest.raises(TypeError, match="iterable of pandas objects"):
+        model.preprocess_raw_inference_chunks(pd.DataFrame({"power": [1.0]}))
+    with pytest.raises(TypeError, match="chunk 0"):
+        model.preprocess_raw_inference_chunks([np.zeros(3)])
+    with pytest.raises(ValueError, match="expected 1, got 0"):
+        model.preprocess_raw_inference_chunks([_raw_chunk(1)])
+
+
+@pytest.mark.parametrize(
+    "values,error,message",
+    [
+        (["bad"], TypeError, "real numeric"),
+        ([True], TypeError, "real numeric"),
+        ([1 + 2j], TypeError, "real numeric"),
+        ([np.nan], ValueError, "non-finite"),
+        ([np.inf], ValueError, "non-finite"),
+    ],
+)
+def test_helper_rejects_invalid_prediction_values(values, error, message):
+    prediction = pd.DataFrame({"fridge": values})
+
+    with pytest.raises(error, match=message):
+        TorchDisaggregator.align_raw_inference_predictions(
+            [prediction], (pd.Index([17]),)
+        )
+
+
+def test_helper_fails_closed_on_prediction_chunk_and_row_count():
+    index = pd.Index([10, 20])
+
+    with pytest.raises(ValueError, match="expected 1, got 0"):
+        TorchDisaggregator.align_raw_inference_predictions([], (index,))
+    with pytest.raises(ValueError, match="has 1 rows; expected 2"):
+        TorchDisaggregator.align_raw_inference_predictions(
+            [pd.DataFrame({"fridge": [1.0]})], (index,)
+        )
+
+
+@pytest.mark.parametrize("model_class,mode", MODEL_CASES)
+def test_preprocessed_inference_does_not_apply_raw_alignment(model_class, mode):
+    model = _model(model_class, mode)
+    model.preprocess_raw_inference_chunks = lambda chunks: pytest.fail(
+        "raw alignment must not run for preprocessed inference"
+    )
+    if mode in {
+        "sequence",
+        "resnet_classification",
+        "rnn_attention_classification",
+    }:
+        rows = RAW_LENGTH - SEQUENCE_LENGTH + 1
+        windows = pd.DataFrame(
+            np.zeros((rows, SEQUENCE_LENGTH), dtype=np.float32),
+            index=pd.Index(np.arange(50, 50 + rows), name="window"),
+        )
+    elif mode == "nilmformer":
+        windows = _raw_chunk()
+    else:
+        windows = pd.DataFrame(
+            np.zeros((RAW_LENGTH, SEQUENCE_LENGTH), dtype=np.float32),
+            index=pd.Index(np.arange(50, 50 + RAW_LENGTH), name="window"),
+        )
+
+    result = model.disaggregate_chunk([windows], do_preprocessing=False)[0]
+
+    assert len(result) == RAW_LENGTH
+    assert isinstance(result.index, pd.RangeIndex)

--- a/tests/test_legacy_inference_alignment.py
+++ b/tests/test_legacy_inference_alignment.py
@@ -43,9 +43,11 @@ APPLIANCE_PARAMS = {
 class FakeNetwork(torch.nn.Module):
     """Cheap deterministic outputs matching the legacy adapters' signatures."""
 
-    def __init__(self, mode, sequence_length=SEQUENCE_LENGTH, num_states=2):
+    def __init__(
+        self, mode, sequence_length=SEQUENCE_LENGTH, num_states=2, value=0.0
+    ):
         super().__init__()
-        self.bias = torch.nn.Parameter(torch.zeros(1))
+        self.bias = torch.nn.Parameter(torch.tensor([value], dtype=torch.float32))
         self.mode = mode
         self.sequence_length = sequence_length
         self.num_states = num_states
@@ -113,10 +115,10 @@ MODEL_CASES = [
     pytest.param(Seq2Seq, "sequence", id="seq2seq"),
     pytest.param(WindowGRU, "point", id="window-gru"),
 ]
-ROW_COUNT_CASES = [case for case in MODEL_CASES if case.values[0] is not NILMFormer]
+ROW_COUNT_CASES = MODEL_CASES
 
 
-def _model(model_class, mode):
+def _model(model_class, mode, *, value=0.0):
     params = {
         "device": "cpu",
         "sequence_length": SEQUENCE_LENGTH,
@@ -131,7 +133,11 @@ def _model(model_class, mode):
         model.num_states = 2
         model._get_appliance_config = lambda appliance: None
     model.models = OrderedDict(
-        fridge=FakeNetwork(mode, num_states=getattr(model, "num_states", 2))
+        fridge=FakeNetwork(
+            mode,
+            num_states=getattr(model, "num_states", 2),
+            value=value,
+        )
     )
     return model
 
@@ -221,7 +227,7 @@ def test_raw_inference_fails_closed_when_model_returns_wrong_row_count(
     model = _model(model_class, mode)
     _install_fake_preprocessor(model, mode, row_delta=-1)
 
-    with pytest.raises(ValueError, match="expected 7 raw rows"):
+    with pytest.raises(ValueError, match="(expected 7 raw rows|for 7 raw rows)"):
         model.disaggregate_chunk([_raw_chunk()])
 
 
@@ -238,6 +244,20 @@ def test_helper_fails_closed_on_invalid_raw_chunks_and_preprocessor_chunk_count(
         model.preprocess_raw_inference_chunks(pd.DataFrame({"power": [1.0]}))
     with pytest.raises(TypeError, match="chunk 0"):
         model.preprocess_raw_inference_chunks([np.zeros(3)])
+    with pytest.raises(TypeError, match="chunk 0"):
+        model.preprocess_raw_inference_chunks([pd.Series([1.0])])
+    with pytest.raises(ValueError, match="one power column"):
+        model.preprocess_raw_inference_chunks(
+            [pd.DataFrame({"a": [1.0], "b": [2.0]})]
+        )
+    with pytest.raises(ValueError, match="finite"):
+        model.preprocess_raw_inference_chunks(
+            [pd.DataFrame({"power": [np.nan]})]
+        )
+    with pytest.raises(ValueError, match="at least one sample"):
+        model.preprocess_raw_inference_chunks(
+            [pd.DataFrame({"power": pd.Series(dtype="float32")})]
+        )
     with pytest.raises(ValueError, match="expected 1, got 0"):
         model.preprocess_raw_inference_chunks([_raw_chunk(1)])
 
@@ -288,8 +308,6 @@ def test_preprocessed_inference_does_not_apply_raw_alignment(model_class, mode):
             np.zeros((rows, SEQUENCE_LENGTH), dtype=np.float32),
             index=pd.Index(np.arange(50, 50 + rows), name="window"),
         )
-    elif mode == "nilmformer":
-        windows = _raw_chunk()
     else:
         windows = pd.DataFrame(
             np.zeros((RAW_LENGTH, SEQUENCE_LENGTH), dtype=np.float32),
@@ -298,5 +316,28 @@ def test_preprocessed_inference_does_not_apply_raw_alignment(model_class, mode):
 
     result = model.disaggregate_chunk([windows], do_preprocessing=False)[0]
 
-    assert len(result) == RAW_LENGTH
-    assert isinstance(result.index, pd.RangeIndex)
+    expected_length = len(windows) if mode == "nilmformer" else RAW_LENGTH
+    assert len(result) == expected_length
+    if model_class in {MSDC, MSDCWithoutCRF}:
+        assert result.index.equals(windows.index)
+    else:
+        assert isinstance(result.index, pd.RangeIndex)
+
+
+@pytest.mark.parametrize("model_class,mode", MODEL_CASES)
+def test_preprocessed_inference_rejects_nonfinite_predictions(model_class, mode):
+    model = _model(model_class, mode, value=float("inf"))
+    if mode in {
+        "sequence",
+        "resnet_classification",
+        "rnn_attention_classification",
+    }:
+        rows = RAW_LENGTH - SEQUENCE_LENGTH + 1
+    else:
+        rows = RAW_LENGTH
+    windows = pd.DataFrame(
+        np.zeros((rows, SEQUENCE_LENGTH), dtype=np.float32)
+    )
+
+    with pytest.raises((FloatingPointError, ValueError), match="non-finite"):
+        model.disaggregate_chunk([windows], do_preprocessing=False)

--- a/tests/test_model_registry_comprehensive.py
+++ b/tests/test_model_registry_comprehensive.py
@@ -259,6 +259,7 @@ def test_model_self_method_calls_are_defined_or_known_runtime_methods(repo_root)
         "save_model",
         "set_appliance_params",
         "train",
+        "validate_inference_predictions",
         "_validated_appliance_stats",
         "_checked_model_output",
     }

--- a/tests/test_model_registry_comprehensive.py
+++ b/tests/test_model_registry_comprehensive.py
@@ -246,11 +246,14 @@ def _attach_ast_parents(tree):
 def test_model_self_method_calls_are_defined_or_known_runtime_methods(repo_root):
     known_runtime_methods = {
         "apply",
+        "align_raw_inference_predictions",
         "appliance_minmax_params",
         "eval",
+        "call_preprocessing",
         "load_model",
         "modules",
         "named_parameters",
+        "preprocess_raw_inference_chunks",
         "register_buffer",
         "require_models",
         "save_model",

--- a/tests/test_tcn_inference_alignment.py
+++ b/tests/test_tcn_inference_alignment.py
@@ -1,0 +1,178 @@
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+torch = pytest.importorskip("torch")
+tcn_module = pytest.importorskip("nilmtk_contrib.torch.TCN")
+TCN = tcn_module.TCN
+
+
+class RecordingPoint(torch.nn.Module):
+    def __init__(self, value=0.0):
+        super().__init__()
+        self.bias = torch.nn.Parameter(torch.tensor(float(value)))
+        self.batch_sizes = []
+
+    def forward(self, values):
+        self.batch_sizes.append(len(values))
+        return torch.ones((len(values), 1), device=values.device) * self.bias
+
+
+class BadShape(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.bias = torch.nn.Parameter(torch.zeros(1))
+
+    def forward(self, values):
+        return torch.ones((len(values),), device=values.device) + self.bias
+
+
+class NonFinitePoint(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.bias = torch.nn.Parameter(torch.tensor(float("nan")))
+
+    def forward(self, values):
+        return torch.ones((len(values), 1), device=values.device) * self.bias
+
+
+class NonTensorPoint(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.bias = torch.nn.Parameter(torch.zeros(1))
+
+    def forward(self, values):
+        return np.zeros((len(values), 1), dtype=np.float32)
+
+
+def _model(sequence_length=99, batch_size=512, appliance_params=None):
+    if appliance_params is None:
+        appliance_params = {"fridge": {"mean": 11.0, "std": 2.0}}
+    return TCN(
+        {
+            "device": "cpu",
+            "sequence_length": sequence_length,
+            "batch_size": batch_size,
+            "num_levels": 1,
+            "num_filters": 2,
+            "kernel_size": 3,
+            "dropout": 0.0,
+            "appliance_params": appliance_params,
+        }
+    )
+
+
+def _frame(length, start=0):
+    index = pd.Index(
+        np.arange(start, start + 3 * length, 3, dtype=np.int64), name="sample"
+    )
+    values = np.linspace(20.0, 40.0, length, dtype=np.float32)
+    return pd.DataFrame({"power": values}, index=index)
+
+
+@pytest.mark.parametrize("length", [0, 1, 98, 99, 100, 2448])
+def test_raw_inference_preserves_every_length_and_original_index(length):
+    model = _model()
+    mains = _frame(length, start=1000)
+
+    prediction = model.disaggregate_chunk(
+        [mains], model={"fridge": RecordingPoint(0.5)}
+    )[0]
+
+    assert len(prediction) == length
+    assert prediction.index.equals(mains.index)
+    assert prediction.columns.tolist() == ["fridge"]
+    assert prediction.dtypes.tolist() == [np.dtype("float32")]
+    assert np.isfinite(prediction.to_numpy()).all()
+    np.testing.assert_array_equal(
+        prediction["fridge"].to_numpy(), np.full(length, 12.0, dtype=np.float32)
+    )
+
+
+def test_multiple_chunks_preserve_independent_indexes_and_partial_batches():
+    lengths = [1, 100, 2448]
+    mains = [
+        _frame(length, start=position * 10_000)
+        for position, length in enumerate(lengths)
+    ]
+    model = _model(batch_size=512)
+    network = RecordingPoint()
+
+    predictions = model.disaggregate_chunk(mains, model={"fridge": network})
+
+    assert network.batch_sizes == [1, 100, 512, 512, 512, 512, 400]
+    for source, prediction in zip(mains, predictions, strict=True):
+        assert len(prediction) == len(source)
+        assert prediction.index.equals(source.index)
+
+
+def test_preprocessed_inference_keeps_one_point_per_window_and_its_index():
+    model = _model(sequence_length=7, batch_size=2)
+    index = pd.Index(["a", "c", "f"], name="window")
+    windows = pd.DataFrame(np.zeros((3, 7), dtype=np.float32), index=index)
+
+    prediction = model.disaggregate_chunk(
+        [windows], do_preprocessing=False, model={"fridge": RecordingPoint()}
+    )[0]
+
+    assert len(prediction) == len(windows)
+    assert prediction.index.equals(index)
+
+
+@pytest.mark.parametrize("bad_value", [math.nan, math.inf, -math.inf])
+def test_raw_inference_rejects_nonfinite_mains(bad_value):
+    mains = _frame(8)
+    mains.iloc[3, 0] = bad_value
+
+    with pytest.raises(ValueError, match="finite"):
+        _model(sequence_length=7).disaggregate_chunk(
+            [mains], model={"fridge": RecordingPoint()}
+        )
+
+
+def test_raw_inference_rejects_ambiguous_multiple_power_columns():
+    mains = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
+
+    with pytest.raises(ValueError, match="one power column"):
+        _model(sequence_length=7).disaggregate_chunk(
+            [mains], model={"fridge": RecordingPoint()}
+        )
+
+
+def test_inference_rejects_invalid_model_outputs():
+    mains = _frame(8)
+    model = _model(sequence_length=7)
+
+    with pytest.raises(ValueError, match="returned shape"):
+        model.disaggregate_chunk([mains], model={"fridge": BadShape()})
+    with pytest.raises(FloatingPointError, match="non-finite"):
+        model.disaggregate_chunk([mains], model={"fridge": NonFinitePoint()})
+    with pytest.raises(TypeError, match="torch.Tensor"):
+        model.disaggregate_chunk([mains], model={"fridge": NonTensorPoint()})
+
+
+def test_public_float32_output_overflow_is_rejected():
+    model = _model(
+        sequence_length=7,
+        appliance_params={"fridge": {"mean": 0.0, "std": 1e300}},
+    )
+
+    with pytest.raises(ValueError, match="overflow float32"):
+        model.disaggregate_chunk([_frame(1)], model={"fridge": RecordingPoint(1.0)})
+
+
+def test_real_tcn_network_preserves_2448_row_chunk_alignment():
+    model = _model()
+    mains = _frame(2448, start=50_000)
+
+    prediction = model.disaggregate_chunk(
+        [mains], model={"fridge": model.return_network()}
+    )[0]
+
+    assert len(prediction) == len(mains)
+    assert prediction.index.equals(mains.index)
+    assert prediction.dtypes.tolist() == [np.dtype("float32")]
+    assert np.isfinite(prediction.to_numpy()).all()

--- a/tests/test_tcn_inference_alignment.py
+++ b/tests/test_tcn_inference_alignment.py
@@ -109,7 +109,7 @@ def test_multiple_chunks_preserve_independent_indexes_and_partial_batches():
         assert prediction.index.equals(source.index)
 
 
-def test_preprocessed_inference_keeps_one_point_per_window_and_its_index():
+def test_preprocessed_inference_keeps_legacy_range_index():
     model = _model(sequence_length=7, batch_size=2)
     index = pd.Index(["a", "c", "f"], name="window")
     windows = pd.DataFrame(np.zeros((3, 7), dtype=np.float32), index=index)
@@ -119,7 +119,28 @@ def test_preprocessed_inference_keeps_one_point_per_window_and_its_index():
     )[0]
 
     assert len(prediction) == len(windows)
-    assert prediction.index.equals(index)
+    assert prediction.index.equals(pd.RangeIndex(len(windows)))
+
+
+def test_bfloat16_model_output_is_converted_to_public_float32():
+    class BFloat16Point(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.bias = torch.nn.Parameter(torch.zeros(1))
+
+        def forward(self, values):
+            return torch.ones(
+                (len(values), 1), dtype=torch.bfloat16, device=values.device
+            ) + self.bias.to(dtype=torch.bfloat16)
+
+    prediction = _model(sequence_length=7).disaggregate_chunk(
+        [_frame(8)], model={"fridge": BFloat16Point()}
+    )[0]
+
+    assert prediction.dtypes.tolist() == [np.dtype("float32")]
+    np.testing.assert_array_equal(
+        prediction["fridge"].to_numpy(), np.full(8, 13.0, dtype=np.float32)
+    )
 
 
 @pytest.mark.parametrize("bad_value", [math.nan, math.inf, -math.inf])


### PR DESCRIPTION
## What changed
- add one shared fail-closed raw-inference alignment contract for the 14 legacy Torch adapters
- preserve exact row counts and pandas indexes after preprocessing
- validate raw input as one finite numeric power column and validate public predictions on raw and preprocessed paths
- harden TCN batching, dtype conversion, output shapes, device checks, and partial chunks
- make NILMFormer consume supplied windows directly and reject preprocessing/prediction cardinality drift
- retain the already-merged MSDC preprocessed-index behavior while routing its raw path through the shared contract

## Why
The new 900-second real-REDD campaign caught TCN returning a fresh RangeIndex. An all-model audit showed the same duplicated pattern across the legacy adapters, so fixing only TCN would have caused repeated failures and repeated image rebuilds.

## Verification
- full suite: 1,022 passed, 107 skipped
- focused alignment/registry suite: 183 passed
- Ruff, lock, diff, wheel, and sdist checks pass
- diagnostic real REDD/A100 900-second smokes pass for TCN and NILMFormer at the recovered 19-sample context
- tests cover multiple chunks, 2,448-row timezone indexes, wrong row/chunk counts, invalid columns, non-finite raw/preprocessed values, partial batches, and the real model paths

Diagnostic bundles are quarantined. NILMbench will rebuild a new immutable image from the merged commit before the three-seed campaign resumes.