### PR TITLE
Align ecosystem responsibilities in the contrib README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 This repository contains maintained NILMTK-compatible disaggregation models.
 Use it to run, test, or contribute an algorithm.
 
-## Which repository should I use?
+## Ecosystem repositories
 
-| Task | Repository |
+| Research task | Repository |
 | --- | --- |
-| Convert or inspect data; work with meters, preprocessing, or metrics | [NILMTK core](https://github.com/nilmtk/nilmtk) |
-| Define appliance names, synonyms, meter relationships, or dataset schema | [NILM Metadata](https://github.com/nilmtk/nilm_metadata) |
-| Run or contribute a disaggregation model | **nilmtk-contrib — this repository** |
-| Run T1/T2/T3 protocols or publish a leaderboard result | [NILMbench](https://github.com/nilmtk/nilmbench) |
+| Dataset conversion, meter access, preprocessing, and metrics | [NILMTK core](https://github.com/nilmtk/nilmtk) |
+| Appliance taxonomy, synonyms, meter relationships, and dataset schema | [NILM Metadata](https://github.com/nilmtk/nilm_metadata) |
+| Disaggregation model implementation and testing | **nilmtk-contrib — this repository** |
+| Fixed T1/T2/T3 evaluation and published result bundles | [NILMbench](https://github.com/nilmtk/nilmbench) |
 
 The [NILMTK start page](https://nilmtk.github.io/) gives the supported install,
 Docker, citation, and contribution routes for the whole ecosystem.

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -14,6 +14,10 @@ ROOT = Path(__file__).resolve().parents[1]
 README = ROOT / "README.md"
 
 REQUIRED_TEXT = (
+    "Dataset conversion, meter access, preprocessing, and metrics",
+    "Appliance taxonomy, synonyms, meter relationships, and dataset schema",
+    "Disaggregation model implementation and testing",
+    "Fixed T1/T2/T3 evaluation and published result bundles",
     "https://nilmtk.github.io/",
     "https://github.com/nilmtk/nilmtk",
     "https://github.com/nilmtk/nilm_metadata",


### PR DESCRIPTION
Use the shared academic description of the four NILMTK repository responsibilities and enforce those descriptions in the documentation contract check.

Verification:
- `python scripts/check_docs.py`
- `git diff --check`
