### PR TITLE
Make historical neural imports PyTorch-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ Replace `torch` in the install command with the required extra. A bare install
 contains package metadata and dependency-light utilities; it cannot train a
 backend model.
 
+### Backend policy
+
+PyTorch is the maintained neural-model backend. Historical package-level imports
+such as `nilmtk_contrib.disaggregate.DAE` now resolve to the corresponding
+PyTorch class and emit a `FutureWarning`; new code should import from
+`nilmtk_contrib.torch`. Direct TensorFlow module paths remain available during
+the migration and will be removed after their compatibility imports and
+benchmark coverage have moved to PyTorch. Classical implementations remain
+available until equivalent Torch implementations pass numerical and real-data
+comparison tests.
+
 ## Run a model
 
 Public model imports are listed in the [model table](#models). For example:

--- a/nilmtk_contrib/disaggregate/__init__.py
+++ b/nilmtk_contrib/disaggregate/__init__.py
@@ -1,39 +1,61 @@
-"""Lazy exports for TensorFlow and classical NILMTK disaggregators.
+"""Compatibility exports for historical and classical NILMTK disaggregators.
 
 These classes require optional backend dependencies. Importing this package does
-not import TensorFlow, cvxpy, hmmlearn, or NILMTK until a class is requested.
+not import PyTorch, cvxpy, hmmlearn, or NILMTK until a class is requested.
+
+Historical package-level neural exports resolve to the maintained PyTorch
+implementations. Direct TensorFlow module paths remain temporarily available for
+source compatibility while the TensorFlow backend is retired.
 """
 
+import warnings
 from importlib import import_module
 
 from nilmtk_contrib.utils.optional_imports import OptionalDependencyError
 
 _EXPORTS = {
-    "AFHMM": ("nilmtk_contrib.disaggregate.afhmm", "classical", "AFHMM"),
-    "AFHMM_SAC": ("nilmtk_contrib.disaggregate.afhmm_sac", "classical", "AFHMM_SAC"),
-    "BERT": ("nilmtk_contrib.disaggregate.bert", "tensorflow", "BERT"),
-    "DAE": ("nilmtk_contrib.disaggregate.dae", "tensorflow", "DAE"),
-    "DSC": ("nilmtk_contrib.disaggregate.dsc", "classical", "DSC"),
-    "RNN": ("nilmtk_contrib.disaggregate.rnn", "tensorflow", "RNN"),
+    "AFHMM": ("nilmtk_contrib.disaggregate.afhmm", "AFHMM", "classical"),
+    "AFHMM_SAC": (
+        "nilmtk_contrib.disaggregate.afhmm_sac",
+        "AFHMM_SAC",
+        "classical",
+    ),
+    "BERT": ("nilmtk_contrib.torch.bert", "BERT", "torch"),
+    "DAE": ("nilmtk_contrib.torch.dae", "DAE", "torch"),
+    "DSC": ("nilmtk_contrib.disaggregate.dsc", "DSC", "classical"),
+    "RNN": ("nilmtk_contrib.torch.rnn", "RNN", "torch"),
     "RNN_attention": (
-        "nilmtk_contrib.disaggregate.rnn_attention",
-        "tensorflow",
+        "nilmtk_contrib.torch.rnn_attention",
         "RNN_attention",
+        "torch",
     ),
     "RNN_attention_classification": (
-        "nilmtk_contrib.disaggregate.rnn_attention_classification",
-        "tensorflow",
+        "nilmtk_contrib.torch.rnn_attention_classification",
         "RNN_attention_classification",
+        "torch",
     ),
-    "ResNet": ("nilmtk_contrib.disaggregate.resnet", "tensorflow", "ResNet"),
+    "ResNet": ("nilmtk_contrib.torch.resnet", "ResNet", "torch"),
     "ResNet_classification": (
-        "nilmtk_contrib.disaggregate.resnet_classification",
-        "tensorflow",
+        "nilmtk_contrib.torch.resnet_classification",
         "ResNet_classification",
+        "torch",
     ),
-    "Seq2Point": ("nilmtk_contrib.disaggregate.seq2point", "tensorflow", "Seq2Point"),
-    "Seq2Seq": ("nilmtk_contrib.disaggregate.seq2seq", "tensorflow", "Seq2Seq"),
-    "WindowGRU": ("nilmtk_contrib.disaggregate.WindowGRU", "tensorflow", "WindowGRU"),
+    "Seq2Point": ("nilmtk_contrib.torch.seq2point", "Seq2PointTorch", "torch"),
+    "Seq2Seq": ("nilmtk_contrib.torch.seq2seq", "Seq2Seq", "torch"),
+    "WindowGRU": ("nilmtk_contrib.torch.WindowGRU", "WindowGRU", "torch"),
+}
+
+_TORCH_REDIRECTS = {
+    "BERT",
+    "DAE",
+    "RNN",
+    "RNN_attention",
+    "RNN_attention_classification",
+    "ResNet",
+    "ResNet_classification",
+    "Seq2Point",
+    "Seq2Seq",
+    "WindowGRU",
 }
 
 _DEPENDENCY_EXTRAS = {
@@ -41,7 +63,8 @@ _DEPENDENCY_EXTRAS = {
     "hmmlearn": "classical",
     "nilmtk": "nilm",
     "sklearn": "classical",
-    "tensorflow": "tensorflow",
+    "torch": "torch",
+    "tqdm": "torch",
 }
 
 __all__ = sorted([*_EXPORTS, "Disaggregator"])
@@ -64,18 +87,26 @@ def __getattr__(name):
     if name not in _EXPORTS:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-    module_name, extra_name, purpose = _EXPORTS[name]
+    module_name, class_name, extra_name = _EXPORTS[name]
+    if name in _TORCH_REDIRECTS:
+        warnings.warn(
+            f"nilmtk_contrib.disaggregate.{name} now resolves to its maintained "
+            f"PyTorch implementation; import {class_name} from "
+            "nilmtk_contrib.torch.",
+            FutureWarning,
+            stacklevel=2,
+        )
     try:
         module = import_module(module_name)
     except ModuleNotFoundError as exc:
         missing_package = exc.name or "required dependency"
         install_extra = _DEPENDENCY_EXTRAS.get(missing_package, extra_name)
         message = (
-            f"{purpose} requires '{missing_package}'. "
+            f"{name} requires '{missing_package}'. "
             f"Install nilmtk-contrib[{install_extra}]."
         )
         raise OptionalDependencyError(message) from exc
 
-    value = getattr(module, name)
+    value = getattr(module, class_name)
     globals()[name] = value
     return value

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -14,6 +14,25 @@ from nilmtk_contrib.utils.optional_imports import OptionalDependencyError, requi
 
 BACKEND_MODULES = {"tensorflow", "torch", "cvxpy", "hmmlearn", "nilmtk", "pandas"}
 
+TORCH_REDIRECTS = {
+    "BERT": ("nilmtk_contrib.torch.bert", "BERT"),
+    "DAE": ("nilmtk_contrib.torch.dae", "DAE"),
+    "RNN": ("nilmtk_contrib.torch.rnn", "RNN"),
+    "RNN_attention": ("nilmtk_contrib.torch.rnn_attention", "RNN_attention"),
+    "RNN_attention_classification": (
+        "nilmtk_contrib.torch.rnn_attention_classification",
+        "RNN_attention_classification",
+    ),
+    "ResNet": ("nilmtk_contrib.torch.resnet", "ResNet"),
+    "ResNet_classification": (
+        "nilmtk_contrib.torch.resnet_classification",
+        "ResNet_classification",
+    ),
+    "Seq2Point": ("nilmtk_contrib.torch.seq2point", "Seq2PointTorch"),
+    "Seq2Seq": ("nilmtk_contrib.torch.seq2seq", "Seq2Seq"),
+    "WindowGRU": ("nilmtk_contrib.torch.WindowGRU", "WindowGRU"),
+}
+
 
 def _imported_modules_after(statement):
     code = (
@@ -43,6 +62,28 @@ def test_torch_package_import_is_lightweight():
 def test_mains_stats_import_does_not_import_nilmtk():
     imported = _imported_modules_after("import nilmtk_contrib.mains_stats")
     assert imported == set()
+
+
+def test_historical_neural_exports_target_only_torch_modules():
+    for public_name in TORCH_REDIRECTS:
+        module_name, _class_name, extra_name = disaggregate_exports._EXPORTS[
+            public_name
+        ]
+        assert module_name.startswith("nilmtk_contrib.torch.")
+        assert "tensorflow" not in module_name
+        assert extra_name == "torch"
+
+
+@pytest.mark.parametrize("name", sorted(TORCH_REDIRECTS))
+def test_historical_neural_exports_resolve_to_canonical_torch_classes(name):
+    module_name, class_name = TORCH_REDIRECTS[name]
+    disaggregate_exports.__dict__.pop(name, None)
+    canonical = getattr(importlib.import_module(module_name), class_name)
+
+    with pytest.warns(FutureWarning, match="maintained PyTorch implementation"):
+        redirected = getattr(disaggregate_exports, name)
+
+    assert redirected is canonical
 
 
 def test_require_optional_error_message():

--- a/tests/test_model_registry_comprehensive.py
+++ b/tests/test_model_registry_comprehensive.py
@@ -1,6 +1,7 @@
 import ast
 import importlib
 import importlib.util
+import warnings
 
 import pytest
 
@@ -81,13 +82,20 @@ def test_model_class_access_succeeds_or_reports_optional_dependency(spec):
             cls = getattr(module, spec.class_name)
         else:
             package.__dict__.pop(spec.class_name, None)
-            cls = getattr(package, spec.class_name)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", FutureWarning)
+                cls = getattr(package, spec.class_name)
     except OptionalDependencyError as exc:
         message = str(exc)
         assert "requires '" in message
         assert "Install nilmtk-contrib[" in message
     else:
-        assert cls.__name__ == spec.class_name
+        expected_class_name = (
+            package._EXPORTS[spec.class_name][1]
+            if spec.package == "nilmtk_contrib.disaggregate"
+            else spec.class_name
+        )
+        assert cls.__name__ == expected_class_name
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- resolve the ten historical package-level neural exports to their maintained PyTorch implementations
- retain direct TensorFlow module paths during the staged retirement and emit a visible `FutureWarning` from compatibility imports
- document the PyTorch-first backend policy and require numerical/real-data comparisons before replacing classical methods
- test every redirect against the exact canonical Torch class, including the historical `Seq2Point`/`Seq2PointTorch` naming difference

This is intentionally the first small migration PR. It changes the public compatibility surface without deleting TensorFlow files or dependencies.

## Verification

- `pytest -q`: 1,033 passed, 107 skipped
- Torch synthetic train/disaggregate smoke: 25 passed, 13 skipped
- documentation contract: passed
- Ruff: passed
- `uv lock --check`: passed
- source distribution and wheel build: passed
- `git diff --check`: passed