### PR TITLE
Bound real-dataset smoke loading

### DIFF
--- a/tests/model_smoke_helpers.py
+++ b/tests/model_smoke_helpers.py
@@ -124,6 +124,41 @@ def assert_prediction_frames(predictions, appliance="fridge"):
         assert np.isfinite(values).all()
 
 
+def _bounded_power_series(meter, max_samples, **load_kwargs):
+    if (
+        not isinstance(max_samples, int)
+        or isinstance(max_samples, bool)
+        or max_samples <= 0
+    ):
+        raise ValueError("max_samples must be a positive integer")
+    chunks = []
+    remaining = max_samples
+    generator = meter.power_series(chunksize=max_samples, **load_kwargs)
+    try:
+        for chunk in generator:
+            values = chunk.dropna()
+            if values.empty:
+                continue
+            selected = values.iloc[:remaining]
+            chunks.append(selected)
+            remaining -= len(selected)
+            if remaining == 0:
+                break
+    finally:
+        close = getattr(generator, "close", None)
+        if close is not None:
+            close()
+    if not chunks:
+        return pd.Series(dtype=np.float32)
+    result = pd.concat(chunks)
+    if not result.index.is_unique:
+        # Some NILMTK stores repeat samples at meter-group or chunk boundaries.
+        # A benchmark needs one deterministic power value per timestamp before
+        # mains and appliance series can be aligned.
+        result = result.groupby(level=0, sort=True).mean()
+    return result.iloc[:max_samples]
+
+
 def load_real_dataset_chunks(path, building, appliance, sequence_length, max_samples=512):
     nilmtk = pytest.importorskip("nilmtk")
     dataset_path = Path(path)
@@ -133,7 +168,7 @@ def load_real_dataset_chunks(path, building, appliance, sequence_length, max_sam
     data_set = nilmtk.DataSet(str(dataset_path))
     try:
         elec = data_set.buildings[building].elec
-        mains = elec.mains().power_series_all_data().dropna()
+        mains_meter = elec.mains()
         appliance_meter = None
         for meter in elec.submeters().meters:
             for meter_appliance in getattr(meter, "appliances", []):
@@ -145,7 +180,18 @@ def load_real_dataset_chunks(path, building, appliance, sequence_length, max_sam
         if appliance_meter is None:
             pytest.skip(f"appliance {appliance!r} not found in building {building}")
 
-        submeter = appliance_meter.power_series_all_data().dropna()
+        common_timeframe = mains_meter.get_timeframe().intersection(
+            appliance_meter.get_timeframe()
+        )
+        sample_period = max(
+            mains_meter.sample_period(), appliance_meter.sample_period()
+        )
+        load_kwargs = {
+            "sections": [common_timeframe],
+            "sample_period": sample_period,
+        }
+        mains = _bounded_power_series(mains_meter, max_samples, **load_kwargs)
+        submeter = _bounded_power_series(appliance_meter, max_samples, **load_kwargs)
         joined = pd.concat([mains, submeter], axis=1).dropna().iloc[:max_samples]
         if len(joined) < sequence_length:
             pytest.skip(

--- a/tests/test_real_dataset_loader.py
+++ b/tests/test_real_dataset_loader.py
@@ -1,0 +1,123 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from model_smoke_helpers import _bounded_power_series
+
+
+class _TrackingGenerator:
+    def __init__(self, chunks, error=None):
+        self._chunks = iter(chunks)
+        self._error = error
+        self.yielded = 0
+        self.closed = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        try:
+            chunk = next(self._chunks)
+        except StopIteration:
+            if self._error is not None:
+                raise self._error
+            raise
+        self.yielded += 1
+        return chunk
+
+    def close(self):
+        self.closed = True
+
+
+class _Meter:
+    def __init__(self, chunks, error=None):
+        self.generator = _TrackingGenerator(chunks, error=error)
+        self.kwargs = None
+
+    def power_series(self, **kwargs):
+        self.kwargs = kwargs
+        return self.generator
+
+
+def _series(values, start):
+    return pd.Series(
+        values,
+        index=pd.date_range(start, periods=len(values), freq="1min", tz="UTC"),
+        dtype=np.float32,
+    )
+
+
+def test_bounded_loader_stops_without_consuming_the_remaining_meter():
+    meter = _Meter(
+        [
+            _series([1.0, 2.0, np.nan], "2026-01-01"),
+            _series([3.0, 4.0, 5.0, 6.0], "2026-02-01"),
+            _series([999.0], "2026-03-01"),
+        ]
+    )
+
+    result = _bounded_power_series(meter, 5)
+
+    assert result.tolist() == [1.0, 2.0, 3.0, 4.0, 5.0]
+    assert meter.kwargs == {"chunksize": 5}
+    assert meter.generator.yielded == 2
+    assert meter.generator.closed
+
+
+def test_bounded_loader_forwards_alignment_options():
+    meter = _Meter([_series([1.0], "2026-01-01")])
+    section = object()
+
+    _bounded_power_series(
+        meter,
+        1,
+        sections=[section],
+        sample_period=6,
+    )
+
+    assert meter.kwargs == {
+        "chunksize": 1,
+        "sections": [section],
+        "sample_period": 6,
+    }
+
+
+def test_bounded_loader_closes_an_empty_generator():
+    meter = _Meter([_series([], "2026-01-01")])
+
+    result = _bounded_power_series(meter, 5)
+
+    assert result.empty
+    assert result.dtype == np.float32
+    assert meter.generator.closed
+
+
+def test_bounded_loader_coalesces_duplicate_timestamps_by_mean():
+    first = _series([1.0, 2.0], "2026-01-01")
+    second = pd.Series(
+        [4.0, 8.0],
+        index=pd.DatetimeIndex([first.index[1], first.index[1] + pd.Timedelta("1min")]),
+        dtype=np.float32,
+    )
+    meter = _Meter([first, second])
+
+    result = _bounded_power_series(meter, 4)
+
+    assert result.index.is_unique
+    assert result.tolist() == [1.0, 3.0, 8.0]
+    assert result.index.is_monotonic_increasing
+
+
+def test_bounded_loader_closes_generator_when_iteration_fails():
+    meter = _Meter([_series([1.0], "2026-01-01")], error=RuntimeError("broken"))
+
+    with pytest.raises(RuntimeError, match="broken"):
+        _bounded_power_series(meter, 2)
+
+    assert meter.generator.closed
+
+
+@pytest.mark.parametrize("value", [0, -1, True, 1.5, None])
+def test_bounded_loader_rejects_invalid_limits(value):
+    with pytest.raises(ValueError, match="positive integer"):
+        _bounded_power_series(_Meter([]), value)


### PR DESCRIPTION
## Summary
- stream at most the requested meter samples instead of materializing an entire NILMTK dataset
- align mains and appliance loads to their common timeframe and sample period
- deterministically coalesce duplicate timestamps emitted at meter-group or chunk boundaries
- close data generators on success, early exit, and failure

## Verification
- 10 focused loader tests passed
- full suite: 1,098 passed, 88 skipped
- Ruff and git diff checks passed
- Ramanujan UK-DALE building 1 / fridge freezer: Torch DSC real-data contract passed (294.44 s)

The server emitted NILMTK's existing temporary-HDF UnclosedFileWarning after pytest exited; this PR closes both the dataset store and bounded meter generators, so that separate import-time cache issue remains outside this tests-only change.