### PR TITLE
Harden DSC migration parity

### DIFF
--- a/nilmtk_contrib/torch/_dsc.py
+++ b/nilmtk_contrib/torch/_dsc.py
@@ -307,40 +307,70 @@ def _fit_discriminative_dictionary(
 ) -> tuple[torch.Tensor, float]:
     dictionary = reconstruction_dictionary.clone()
     fallback = dictionary.mean(dim=1)
+    validation_windows = int(aggregate.shape[1] * 0.2)
+    if validation_windows:
+        train_aggregate = aggregate[:, :-validation_windows]
+        validation_aggregate = aggregate[:, -validation_windows:]
+        train_target_codes = target_codes[:, :-validation_windows]
+        validation_target_codes = target_codes[:, -validation_windows:]
+    else:
+        train_aggregate = validation_aggregate = aggregate
+        train_target_codes = validation_target_codes = target_codes
     predicted = nonnegative_sparse_code(
         dictionary,
-        aggregate,
+        train_aggregate,
         sparsity_coefficient=sparsity_coefficient,
         max_iterations=sparse_code_iterations,
         tolerance=tolerance,
     )
-    best_error = float(torch.mean(torch.abs(predicted.codes - target_codes)))
+    validation_prediction = predicted
+    if validation_windows:
+        validation_prediction = nonnegative_sparse_code(
+            dictionary,
+            validation_aggregate,
+            sparsity_coefficient=sparsity_coefficient,
+            max_iterations=sparse_code_iterations,
+            tolerance=tolerance,
+        )
+    best_error = float(
+        torch.mean(torch.abs(validation_prediction.codes - validation_target_codes))
+    )
     best_dictionary = dictionary.clone()
 
     for _ in range(discriminative_iterations):
         predicted_codes = predicted.codes
-        predicted_residual = aggregate - dictionary @ predicted_codes
-        target_residual = aggregate - dictionary @ target_codes
-        gradient = (
-            predicted_residual @ predicted_codes.T - target_residual @ target_codes.T
+        candidate = _discriminative_dictionary_step(
+            train_aggregate,
+            dictionary,
+            predicted_codes,
+            train_target_codes,
+            learning_rate=learning_rate,
+            fallback=fallback,
         )
-        curvature = torch.square(torch.linalg.matrix_norm(predicted_codes, ord=2))
-        curvature += torch.square(torch.linalg.matrix_norm(target_codes, ord=2))
-        if float(curvature) <= torch.finfo(dictionary.dtype).eps:
+        if candidate is None:
             break
-        candidate = dictionary - learning_rate * gradient / curvature
-        candidate = _normalize_dictionary(candidate, fallback)
         change = torch.linalg.vector_norm(candidate - dictionary)
         scale = 1.0 + torch.linalg.vector_norm(dictionary)
         dictionary = candidate
         predicted = nonnegative_sparse_code(
             dictionary,
-            aggregate,
+            train_aggregate,
             sparsity_coefficient=sparsity_coefficient,
             max_iterations=sparse_code_iterations,
             tolerance=tolerance,
         )
-        activation_error = float(torch.mean(torch.abs(predicted.codes - target_codes)))
+        validation_prediction = predicted
+        if validation_windows:
+            validation_prediction = nonnegative_sparse_code(
+                dictionary,
+                validation_aggregate,
+                sparsity_coefficient=sparsity_coefficient,
+                max_iterations=sparse_code_iterations,
+                tolerance=tolerance,
+            )
+        activation_error = float(
+            torch.mean(torch.abs(validation_prediction.codes - validation_target_codes))
+        )
         if activation_error < best_error:
             best_error = activation_error
             best_dictionary = dictionary.clone()
@@ -348,6 +378,24 @@ def _fit_discriminative_dictionary(
             break
 
     return best_dictionary, best_error
+
+
+def _discriminative_dictionary_step(
+    aggregate: torch.Tensor,
+    dictionary: torch.Tensor,
+    predicted_codes: torch.Tensor,
+    target_codes: torch.Tensor,
+    *,
+    learning_rate: float,
+    fallback: torch.Tensor,
+) -> torch.Tensor | None:
+    """Apply the DSC ``T1 - T2`` basis update used by the legacy implementation."""
+    predicted_residual = aggregate - dictionary @ predicted_codes
+    target_residual = aggregate - dictionary @ target_codes
+    gradient = predicted_residual @ predicted_codes.T - target_residual @ target_codes.T
+    if float(torch.linalg.vector_norm(gradient)) <= torch.finfo(dictionary.dtype).eps:
+        return None
+    return _normalize_dictionary(dictionary - learning_rate * gradient, fallback)
 
 
 def _as_power_tensor(frame, label, *, device, allow_empty=False) -> torch.Tensor:
@@ -539,7 +587,12 @@ class DSC(TorchStateSpaceDisaggregator):
         )
         self.discriminative_iterations = _non_negative_integer(
             "discriminative_iterations",
-            get_param(params, "discriminative_iterations", 20),
+            get_param(
+                params,
+                "discriminative_iterations",
+                20,
+                aliases=("iterations",),
+            ),
         )
         self.sparse_code_iterations = _positive_integer(
             "sparse_code_iterations",
@@ -550,7 +603,12 @@ class DSC(TorchStateSpaceDisaggregator):
         )
         self.discriminative_learning_rate = _positive_finite(
             "discriminative_learning_rate",
-            get_param(params, "discriminative_learning_rate", 1.0),
+            get_param(
+                params,
+                "discriminative_learning_rate",
+                1e-9,
+                aliases=("learning_rate",),
+            ),
         )
         self.enforce_aggregate = get_param(params, "enforce_aggregate", True)
         if not isinstance(self.enforce_aggregate, bool):
@@ -561,6 +619,33 @@ class DSC(TorchStateSpaceDisaggregator):
             raise ValueError("DSC does not support chunk_wise_training.")
         if self.load_model_path:
             self.load_model(self.load_model_path)
+
+    @property
+    def iterations(self):
+        """Legacy name for the discriminative update count."""
+        return self.discriminative_iterations
+
+    @iterations.setter
+    def iterations(self, value):
+        self.discriminative_iterations = _non_negative_integer("iterations", value)
+
+    @property
+    def learning_rate(self):
+        """Legacy name for the discriminative update step size."""
+        return self.discriminative_learning_rate
+
+    @learning_rate.setter
+    def learning_rate(self, value):
+        self.discriminative_learning_rate = _positive_finite("learning_rate", value)
+
+    @property
+    def sparsity_coef(self):
+        """Legacy name for the non-negative LASSO coefficient."""
+        return self.sparsity_coefficient
+
+    @sparsity_coef.setter
+    def sparsity_coef(self, value):
+        self.sparsity_coefficient = _non_negative_finite("sparsity_coef", value)
 
     def _validate_model_record(self, appliance_name, model):
         del appliance_name

--- a/tests/test_dsc_parity.py
+++ b/tests/test_dsc_parity.py
@@ -1,0 +1,429 @@
+from collections import OrderedDict
+from types import SimpleNamespace
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from model_smoke_helpers import load_real_dataset_chunks
+
+
+torch = pytest.importorskip("torch")
+sklearn_decomposition = pytest.importorskip("sklearn.decomposition")
+ConvergenceWarning = pytest.importorskip("sklearn.exceptions").ConvergenceWarning
+
+from nilmtk_contrib.disaggregate.dsc import DSC as LegacyDSC  # noqa: E402
+from nilmtk_contrib.torch._dsc import (  # noqa: E402
+    DSC as TorchDSC,
+    _DSCParameters,
+    _discriminative_dictionary_step,
+    _fit_discriminative_dictionary,
+    nonnegative_sparse_code,
+)
+
+
+def _legacy_params(**overrides):
+    return {
+        "shape": 12,
+        "n_components": 2,
+        "sparsity_coef": 0.1,
+        "iterations": 2,
+        "learning_rate": 1e-9,
+        "seed": 4,
+        "verbose": False,
+    } | overrides
+
+
+def _torch_params(**overrides):
+    return {
+        "device": "cpu",
+        "shape": 12,
+        "n_components": 2,
+        "sparsity_coefficient": 0.1,
+        "dictionary_iterations": 20,
+        "discriminative_iterations": 2,
+        "discriminative_learning_rate": 1e-9,
+        "sparse_code_iterations": 500,
+        "tolerance": 1e-7,
+        "seed": 4,
+    } | overrides
+
+
+def _normalized_columns(values):
+    values = np.asarray(values, dtype=np.float64)
+    return values / np.linalg.norm(values, axis=0)
+
+
+def _synthetic_train_test(seed=1):
+    rng = np.random.default_rng(seed)
+    first = np.r_[
+        np.zeros(2),
+        np.linspace(0.2, 1.0, 4),
+        np.linspace(0.8, 0.1, 4),
+        np.zeros(2),
+    ]
+    second = np.r_[
+        np.zeros(6),
+        np.linspace(0.1, 1.0, 3),
+        np.linspace(0.7, 0.0, 3),
+    ]
+    bases = np.stack([first, second], axis=1)
+
+    def codes(scale, windows, off_probability):
+        result = rng.gamma(2.0, scale, size=(2, windows))
+        result *= rng.random((2, windows)) > off_probability
+        return result
+
+    def frames(first_codes, second_codes, *, start):
+        first_power = (bases @ first_codes).T.reshape(-1).astype(np.float32)
+        second_power = (bases @ second_codes).T.reshape(-1).astype(np.float32)
+        mains = first_power + second_power + 5.0
+        index = pd.date_range(start, periods=len(mains), freq="1min", tz="UTC")
+        return tuple(
+            pd.DataFrame({"power": values}, index=index)
+            for values in (mains, first_power, second_power)
+        )
+
+    train = frames(
+        codes(35.0, 30, 0.25),
+        codes(55.0, 30, 0.4),
+        start="2026-01-01",
+    )
+    test = frames(
+        codes(35.0, 12, 0.25),
+        codes(55.0, 12, 0.4),
+        start="2026-02-01",
+    )
+    return train, test
+
+
+def _fit_predictions(train, test):
+    legacy = LegacyDSC(_legacy_params())
+    modern = TorchDSC(_torch_params())
+    appliances = [("first", [train[1]]), ("second", [train[2]])]
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ConvergenceWarning)
+        legacy.partial_fit([train[0]], appliances)
+        legacy_prediction = legacy.disaggregate_chunk([test[0]])[0]
+    modern.partial_fit([train[0]], appliances)
+    return (
+        legacy_prediction,
+        modern.disaggregate_chunk([test[0]])[0],
+    )
+
+
+def test_legacy_parameter_names_preserve_configuration_with_warnings():
+    with pytest.warns(DeprecationWarning) as recorded:
+        model = TorchDSC(
+            {
+                "device": "cpu",
+                "sparsity_coef": 0.25,
+                "iterations": 7,
+                "learning_rate": 2e-8,
+            }
+        )
+
+    messages = {str(item.message) for item in recorded}
+    assert messages == {
+        "Parameter 'iterations' is deprecated; use "
+        "'discriminative_iterations' instead.",
+        "Parameter 'learning_rate' is deprecated; use "
+        "'discriminative_learning_rate' instead.",
+        "Parameter 'sparsity_coef' is deprecated; use 'sparsity_coefficient' instead.",
+    }
+    assert model.sparsity_coefficient == model.sparsity_coef == 0.25
+    assert model.discriminative_iterations == model.iterations == 7
+    assert model.discriminative_learning_rate == model.learning_rate == 2e-8
+
+
+def test_legacy_parameter_attributes_remain_mutable_and_validated():
+    model = TorchDSC({"device": "cpu"})
+
+    model.iterations = 7
+    model.learning_rate = 2e-8
+    model.sparsity_coef = 0.25
+
+    assert model.discriminative_iterations == 7
+    assert model.discriminative_learning_rate == 2e-8
+    assert model.sparsity_coefficient == 0.25
+    with pytest.raises(ValueError, match="non-negative integer"):
+        model.iterations = -1
+    with pytest.raises(ValueError, match="positive finite"):
+        model.learning_rate = 0
+    with pytest.raises(ValueError, match="non-negative finite"):
+        model.sparsity_coef = float("nan")
+
+
+@pytest.mark.parametrize(("seed", "coefficient"), [(1, 0.02), (2, 0.2), (3, 0.8)])
+def test_sparse_codes_match_sklearn_across_conditioned_positive_lasso_fixtures(
+    seed, coefficient
+):
+    rng = np.random.default_rng(seed)
+    dictionary = 0.02 * rng.random((7, 3))
+    dictionary[:3] += np.eye(3)
+    dictionary = _normalized_columns(dictionary)
+    true_codes = rng.gamma(2.0, 0.8, size=(3, 6))
+    observations = dictionary @ true_codes + 0.002 * rng.random((7, 6))
+
+    expected = (
+        sklearn_decomposition.SparseCoder(
+            dictionary=dictionary.T,
+            transform_algorithm="lasso_cd",
+            transform_alpha=coefficient,
+            positive_code=True,
+        )
+        .transform(observations.T)
+        .T
+    )
+    actual = nonnegative_sparse_code(
+        torch.tensor(dictionary),
+        torch.tensor(observations),
+        sparsity_coefficient=coefficient,
+        max_iterations=2_000,
+        tolerance=1e-11,
+    )
+
+    assert actual.converged
+    np.testing.assert_allclose(actual.codes.numpy(), expected, rtol=2e-5, atol=2e-5)
+
+
+def test_sparse_code_regularization_monotonically_reduces_mass_and_support():
+    """Higher L1 penalties must produce genuinely sparser positive codes."""
+    dictionary = torch.eye(4, dtype=torch.float64)
+    observations = torch.tensor(
+        [[0.05, 0.8], [0.2, 1.1], [0.6, 1.6], [1.4, 2.2]],
+        dtype=torch.float64,
+    )
+    coefficients = (0.0, 0.25, 0.75, 1.5)
+    results = [
+        nonnegative_sparse_code(
+            dictionary,
+            observations,
+            sparsity_coefficient=coefficient,
+            max_iterations=50,
+            tolerance=1e-12,
+        )
+        for coefficient in coefficients
+    ]
+
+    for coefficient, result in zip(coefficients, results, strict=True):
+        assert result.converged
+        torch.testing.assert_close(
+            result.codes,
+            torch.clamp(observations - coefficient, min=0),
+            atol=1e-12,
+            rtol=0,
+        )
+
+    l1_mass = [float(result.codes.sum()) for result in results]
+    support = [int(torch.count_nonzero(result.codes)) for result in results]
+    assert all(left >= right for left, right in zip(l1_mass, l1_mass[1:]))
+    assert all(left >= right for left, right in zip(support, support[1:]))
+    assert l1_mass[0] > l1_mass[-1]
+    assert support[0] > support[-1]
+
+
+def test_discriminative_basis_step_matches_legacy_t1_minus_t2_equation():
+    dictionary = _normalized_columns([[1.0, 0.2], [0.1, 1.0], [0.4, 0.3], [0.2, 0.6]])
+    aggregate = np.array(
+        [[1.4, 0.2, 1.1], [0.3, 1.5, 0.8], [0.7, 0.4, 0.9], [0.5, 1.0, 0.6]]
+    )
+    predicted_codes = np.array([[1.0, 0.1, 0.7], [0.2, 1.1, 0.4]])
+    target_codes = np.array([[0.8, 0.2, 0.9], [0.3, 1.0, 0.2]])
+    learning_rate = 0.03
+
+    t1 = (aggregate - dictionary @ predicted_codes) @ predicted_codes.T
+    t2 = (aggregate - dictionary @ target_codes) @ target_codes.T
+    expected = np.clip(dictionary - learning_rate * (t1 - t2), 0, None)
+    expected /= np.linalg.norm(expected, axis=0)
+    actual = _discriminative_dictionary_step(
+        torch.tensor(aggregate),
+        torch.tensor(dictionary),
+        torch.tensor(predicted_codes),
+        torch.tensor(target_codes),
+        learning_rate=learning_rate,
+        fallback=torch.tensor(dictionary).mean(dim=1),
+    )
+
+    assert actual is not None
+    np.testing.assert_allclose(actual.numpy(), expected, rtol=1e-12, atol=1e-12)
+
+
+def test_discriminative_fit_uses_all_windows_when_twenty_percent_rounds_to_zero(
+    monkeypatch,
+):
+    import nilmtk_contrib.torch._dsc as dsc_module
+
+    dictionary = torch.tensor(
+        [[1.0, 0.2], [0.1, 1.0], [0.4, 0.3]], dtype=torch.float64
+    )
+    dictionary /= torch.linalg.vector_norm(dictionary, dim=0)
+    target_codes = torch.tensor(
+        [[1.0, 0.2, 0.8, 0.4], [0.1, 1.1, 0.3, 0.9]], dtype=torch.float64
+    )
+    aggregate = dictionary @ target_codes + 0.05
+    observed_windows = []
+    original_solver = nonnegative_sparse_code
+
+    def recording_solver(dictionary_value, observations, **kwargs):
+        observed_windows.append(observations.shape[1])
+        return original_solver(dictionary_value, observations, **kwargs)
+
+    monkeypatch.setattr(dsc_module, "nonnegative_sparse_code", recording_solver)
+    fitted, error = _fit_discriminative_dictionary(
+        aggregate,
+        dictionary,
+        target_codes,
+        sparsity_coefficient=0.05,
+        discriminative_iterations=2,
+        sparse_code_iterations=500,
+        tolerance=1e-9,
+        learning_rate=1e-3,
+    )
+
+    assert observed_windows
+    assert set(observed_windows) == {4}
+    assert torch.isfinite(fitted).all()
+    assert np.isfinite(error)
+
+
+def test_fixed_dictionary_partial_inference_matches_legacy_sklearn_path():
+    shape = 4
+    coefficient = 0.05
+    joint_dictionary = _normalized_columns(
+        [[1.0, 0.0], [0.0, 1.0], [1.0, 0.0], [0.0, 1.0]]
+    )
+    codes = np.array([[2.0, 4.0, 1.0], [3.0, 1.0, 5.0]])
+    mains_values = (joint_dictionary @ codes).T.reshape(-1)[:10].astype(np.float32)
+    index = pd.date_range("2026-03-01", periods=10, freq="1min", tz="UTC")
+    mains = pd.DataFrame({"power": mains_values}, index=index)
+
+    legacy = LegacyDSC(
+        _legacy_params(
+            shape=shape,
+            n_components=1,
+            sparsity_coef=coefficient,
+            iterations=0,
+        )
+    )
+    legacy.disggregation_model = sklearn_decomposition.SparseCoder(
+        dictionary=joint_dictionary.T,
+        transform_algorithm="lasso_cd",
+        transform_alpha=coefficient,
+        positive_code=True,
+    )
+    legacy.reconstruction_bases = joint_dictionary
+    legacy.power = OrderedDict((("first", None), ("second", None)))
+    legacy.dictionaries = OrderedDict(
+        (
+            ("first", SimpleNamespace(n_components=1)),
+            ("second", SimpleNamespace(n_components=1)),
+        )
+    )
+
+    def fitted(column):
+        matrix = tuple((float(value),) for value in joint_dictionary[:, column])
+        return _DSCParameters(
+            reconstruction_dictionary=matrix,
+            discriminative_dictionary=matrix,
+            training_windows=3,
+            reconstruction_objective=0.0,
+            reconstruction_iterations=1,
+            reconstruction_converged=True,
+            activation_error=0.0,
+        )
+
+    modern = TorchDSC(
+        _torch_params(
+            shape=shape,
+            n_components=1,
+            sparsity_coefficient=coefficient,
+            sparse_code_iterations=2_000,
+            tolerance=1e-9,
+        )
+    )
+    models = OrderedDict((("first", fitted(0)), ("second", fitted(1))))
+
+    legacy_prediction = legacy.disaggregate_chunk([mains])[0]
+    modern_prediction = modern.disaggregate_chunk([mains], model=models)[0]
+
+    np.testing.assert_allclose(
+        modern_prediction.to_numpy(),
+        legacy_prediction.to_numpy(),
+        rtol=2e-5,
+        atol=2e-5,
+    )
+    assert modern_prediction.index.equals(index)
+    assert isinstance(legacy_prediction.index, pd.RangeIndex)
+
+
+@pytest.mark.parametrize("fixture_seed", [1, 7, 19])
+def test_trained_torch_dsc_is_non_inferior_on_deterministic_nilm_fixture(
+    fixture_seed,
+):
+    train, test = _synthetic_train_test(seed=fixture_seed)
+    legacy_prediction, modern_prediction = _fit_predictions(train, test)
+    truth = np.column_stack((test[1]["power"], test[2]["power"]))
+    baseline = np.broadcast_to(np.mean(truth, axis=0), truth.shape)
+    legacy_mae = float(np.mean(np.abs(legacy_prediction.to_numpy() - truth)))
+    modern_mae = float(np.mean(np.abs(modern_prediction.to_numpy() - truth)))
+    baseline_mae = float(np.mean(np.abs(baseline - truth)))
+
+    assert np.isfinite([legacy_mae, modern_mae, baseline_mae]).all()
+    assert modern_mae <= baseline_mae
+    assert modern_mae <= 1.1 * legacy_mae
+
+
+def test_trained_torch_dsc_real_data_non_inferiority_when_dataset_is_supplied(
+    model_smoke_config,
+):
+    if not model_smoke_config["enabled"]:
+        pytest.skip("real DSC parity requires --run-model-smoke")
+    path = model_smoke_config["real_dataset_path"]
+    if not path:
+        pytest.skip("real DSC parity requires --real-dataset-path")
+    appliance = model_smoke_config["real_dataset_appliance"]
+    mains, appliances = load_real_dataset_chunks(
+        path,
+        model_smoke_config["real_dataset_building"],
+        appliance,
+        sequence_length=20,
+        max_samples=800,
+    )
+    target = appliances[0][1][0]
+    split = (int(len(mains[0]) * 0.7) // 20) * 20
+    # Keep this quality comparison to full windows. Partial-window behavior has
+    # its own exact parity test and must not change the model-quality sample set.
+    test_length = ((len(mains[0]) - split) // 20) * 20
+    if split < 100 or test_length < 40:
+        pytest.skip("real DSC parity needs at least 140 aligned samples")
+    train = (mains[0].iloc[:split], target.iloc[:split])
+    test = (
+        mains[0].iloc[split : split + test_length],
+        target.iloc[split : split + test_length],
+    )
+
+    legacy = LegacyDSC(_legacy_params(shape=20, n_components=2, iterations=2))
+    modern = TorchDSC(
+        _torch_params(
+            shape=20,
+            n_components=2,
+            dictionary_iterations=8,
+            discriminative_iterations=2,
+        )
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ConvergenceWarning)
+        legacy.partial_fit([train[0]], [(appliance, [train[1]])])
+        legacy_values = legacy.disaggregate_chunk([test[0]])[0][
+            appliance
+        ].to_numpy()
+    modern.partial_fit([train[0]], [(appliance, [train[1]])])
+    modern_values = modern.disaggregate_chunk([test[0]])[0][appliance].to_numpy()
+    truth = test[1]["power"].to_numpy()
+    legacy_mae = float(np.mean(np.abs(legacy_values - truth)))
+    modern_mae = float(np.mean(np.abs(modern_values - truth)))
+
+    assert np.isfinite([legacy_mae, modern_mae]).all()
+    assert modern_mae <= max(1.05 * legacy_mae, legacy_mae + 2.0)


### PR DESCRIPTION
## Summary

- Preserve the legacy DSC parameter names through explicit deprecation aliases.
- Restore the historical unscaled discriminative `T1 - T2` basis update and validation split, while handling very small training sets safely.
- Keep the sklearn DSC implementation in place: this PR proves migration behavior but does not retire it.

## Method-specific gates

- Positive-LASSO codes match sklearn on three conditioned fixtures.
- Increasing L1 regularization matches the exact soft-threshold solution and monotonically reduces both coefficient mass and active support.
- The discriminative dictionary update matches the legacy NumPy equation exactly.
- Fixed-dictionary partial-chunk inference matches the legacy implementation.
- Trained Torch DSC is non-inferior to legacy DSC and a mean baseline on deterministic NILM data.
- Optional real-data parity permits at most 5% or 2 W additional MAE.
- Legacy parameter attributes remain mutable but reject invalid runtime changes.
- Training sets below five windows retain all observations instead of creating an empty validation split.

## Verification

- Focused DSC: 78 passed, 2 skipped; 98% implementation coverage.
- Full suite: 1,111 passed, 89 skipped.
- Ramanujan REDD building 1 / fridge real-data parity passed with the tightened gate.
- Ramanujan UK-DALE building 1 / fridge freezer real-data parity passed with the tightened gate.
- Ramanujan REFIT building 1 / fridge real-data parity passed with the tightened gate.
- Ruff and `git diff` checks passed.
