### PR TITLE
Normalize real smoke samples to float32

### DIFF
--- a/tests/model_smoke_helpers.py
+++ b/tests/model_smoke_helpers.py
@@ -156,7 +156,7 @@ def _bounded_power_series(meter, max_samples, **load_kwargs):
         # A benchmark needs one deterministic power value per timestamp before
         # mains and appliance series can be aligned.
         result = result.groupby(level=0, sort=True).mean()
-    return result.iloc[:max_samples]
+    return result.iloc[:max_samples].astype(np.float32, copy=False)
 
 
 def load_real_dataset_chunks(path, building, appliance, sequence_length, max_samples=512):

--- a/tests/test_real_dataset_loader.py
+++ b/tests/test_real_dataset_loader.py
@@ -108,6 +108,19 @@ def test_bounded_loader_coalesces_duplicate_timestamps_by_mean():
     assert result.index.is_monotonic_increasing
 
 
+def test_bounded_loader_normalizes_float64_meter_output_to_float32():
+    values = pd.Series(
+        [1.25, 2.5],
+        index=pd.date_range("2026-01-01", periods=2, freq="1min", tz="UTC"),
+        dtype=np.float64,
+    )
+
+    result = _bounded_power_series(_Meter([values]), 2)
+
+    assert result.dtype == np.float32
+    assert result.tolist() == pytest.approx([1.25, 2.5])
+
+
 def test_bounded_loader_closes_generator_when_iteration_fails():
     meter = _Meter([_series([1.0], "2026-01-01")], error=RuntimeError("broken"))
 


### PR DESCRIPTION
## Summary
- normalize bounded NILMTK meter samples to float32 before mains/appliance alignment
- cover float64 source streams with a focused regression test

This prevents mixed-dtype UK-DALE data from crashing the legacy sklearn DSC path while keeping Torch and legacy parity inputs identical.

## Verification
- focused loader: 11 passed
- full suite: 1,099 passed, 88 skipped
- Ruff and git diff checks passed