### PR TITLE
Retire the sklearn DSC implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Choose a different extra only when you need that backend:
 | Extra | Use it for |
 | --- | --- |
 | `torch` | PyTorch models, including current time-series and MoE models |
-| `classical` | AFHMM, AFHMM-SAC, and DSC |
+| `classical` | AFHMM and AFHMM-SAC |
 | `all` | PyTorch and classical models; largest install |
 | `nilm` | NILMTK integration without a model backend |
 
@@ -75,20 +75,21 @@ backend model.
 
 ### Backend policy
 
-PyTorch is the maintained neural-model backend. Historical package-level imports
-such as `nilmtk_contrib.disaggregate.DAE` now resolve to the corresponding
-PyTorch class and emit a `FutureWarning`; new code should import from
-`nilmtk_contrib.torch`. The duplicated TensorFlow implementations and their
-direct module paths have been removed. Classical implementations remain
-available until equivalent Torch implementations pass numerical and real-data
-comparison tests.
+PyTorch is the maintained backend for neural and state-space models. Historical
+package-level imports such as `nilmtk_contrib.disaggregate.DAE` now resolve to
+the corresponding PyTorch class and emit a `FutureWarning`; new code should
+import from `nilmtk_contrib.torch`. The duplicated TensorFlow implementations
+and their direct module paths have been removed. The remaining classical AFHMM
+implementations stay available until equivalent Torch implementations pass
+numerical and real-data comparison tests.
 
-Historical neural imports map as follows:
+Historical compatibility imports map as follows:
 
 | Compatibility import | Maintained import |
 | --- | --- |
 | `nilmtk_contrib.disaggregate.BERT` | `nilmtk_contrib.torch.BERT` |
 | `nilmtk_contrib.disaggregate.DAE` | `nilmtk_contrib.torch.DAE` |
+| `nilmtk_contrib.disaggregate.DSC` | `nilmtk_contrib.torch.DSC` |
 | `nilmtk_contrib.disaggregate.RNN` | `nilmtk_contrib.torch.RNN` |
 | `nilmtk_contrib.disaggregate.RNN_attention` | `nilmtk_contrib.torch.RNN_attention` |
 | `nilmtk_contrib.disaggregate.RNN_attention_classification` | `nilmtk_contrib.torch.RNN_attention_classification` |
@@ -258,10 +259,9 @@ The table below lists the public model surface. "Verification" describes how the
 |---|---|---|---|---|---|
 | AFHMM | Classical | `nilmtk_contrib.disaggregate.AFHMM` | NILM paper implementation, not independently benchmark-certified in this package state | Kolter and Jaakkola, AFHMM for energy disaggregation | Requires `classical` extra |
 | AFHMM_SAC | Classical | `nilmtk_contrib.disaggregate.AFHMM_SAC` | NILM paper implementation, not independently benchmark-certified in this package state | Zhong, Goddard, and Sutton, signal aggregate constraints in AFHMMs | Requires `classical` extra |
-| DSC | Classical | `nilmtk_contrib.disaggregate.DSC` | NILM paper implementation, not independently benchmark-certified in this package state | Kolter, Batra, and Ng, discriminative sparse coding | Requires `classical` extra |
 | DAE | PyTorch | `nilmtk_contrib.torch.DAE` | PyTorch implementation requiring parity validation for new claims | Kelly and Knottenbelt, Neural NILM | PyTorch backend |
 | DLinear | PyTorch | `nilmtk_contrib.torch.DLinear` | DLinear-inspired sequence-to-point adaptation; benchmark claims require NILMbench result bundles | Zeng et al., DLinear | PyTorch backend |
-| DSC | PyTorch | `nilmtk_contrib.torch.DSC` | Solver-free non-negative DSC port; benchmark claims require NILMbench result bundles | Kolter, Batra, and Ng, discriminative sparse coding | Proximal sparse-code objective is checked against scikit-learn gold solutions; no runtime solver dependency |
+| DSC | PyTorch | `nilmtk_contrib.torch.DSC` | Solver-free non-negative DSC port; numerical parity passed on REDD, UK-DALE, and REFIT | Kolter, Batra, and Ng, discriminative sparse coding | Proximal sparse-code objective is checked against scikit-learn gold solutions; the historical import is a compatibility wrapper |
 | HSMM | PyTorch | `nilmtk_contrib.torch.HSMM` | Supervised single-appliance explicit-duration baseline; benchmark claims require NILMbench result bundles | Chiappa, explicit-duration Markov switching models | Exact PyTorch dynamic program; no external solver |
 | RNN | PyTorch | `nilmtk_contrib.torch.RNN` | PyTorch implementation requiring parity validation for new claims | Kelly and Knottenbelt, Neural NILM | PyTorch backend |
 | Seq2PointTorch | PyTorch | `nilmtk_contrib.torch.Seq2PointTorch` | PyTorch implementation requiring parity validation for new claims | Zhang et al., Sequence-to-Point Learning | PyTorch backend |

--- a/nilmtk_contrib/disaggregate/__init__.py
+++ b/nilmtk_contrib/disaggregate/__init__.py
@@ -22,7 +22,7 @@ _EXPORTS = {
     ),
     "BERT": ("nilmtk_contrib.torch.bert", "BERT", "torch"),
     "DAE": ("nilmtk_contrib.torch.dae", "DAE", "torch"),
-    "DSC": ("nilmtk_contrib.disaggregate.dsc", "DSC", "classical"),
+    "DSC": ("nilmtk_contrib.disaggregate.dsc", "DSC", "torch"),
     "RNN": ("nilmtk_contrib.torch.rnn", "RNN", "torch"),
     "RNN_attention": (
         "nilmtk_contrib.torch.rnn_attention",

--- a/nilmtk_contrib/disaggregate/dsc.py
+++ b/nilmtk_contrib/disaggregate/dsc.py
@@ -1,229 +1,49 @@
-from __future__ import print_function, division
-from nilmtk.disaggregate import Disaggregator
-import pandas as pd
-import numpy as np
-from collections import OrderedDict 
-from sklearn.decomposition import MiniBatchDictionaryLearning, SparseCoder
-from sklearn.metrics import mean_squared_error
-import time
-from nilmtk_contrib.utils.model import initialize_runtime, legacy_print, module_logger
-from nilmtk_contrib.utils.params import (
-    validate_non_negative_int,
-    validate_positive_int,
-    validate_positive_number,
-)
+"""Compatibility path for the maintained PyTorch DSC implementation."""
 
-logger = module_logger(__name__)
-_log_print = legacy_print(logger)
+from __future__ import annotations
 
-class DSC(Disaggregator):
-    
-    def __init__(self, params):
-        initialize_runtime(self, params, backends=("python", "numpy"))
-        super().__init__()
+from collections.abc import Mapping
+import warnings
 
-        self.MODEL_NAME = 'DSC'  # Add the name for the algorithm
-        self.chunk_wise_training = False
-        self.dictionaries = OrderedDict()
-        self.power = OrderedDict()
-        self.shape = 60*2
-        self.learning_rate = 1e-9
-        self.iterations = 3000
-        self.sparsity_coef = 20
-        self.n_components = 10
-        self.shape = params.get('shape',self.shape)
-        self.learning_rate = params.get('learning_rate',self.learning_rate)
-        self.iterations = params.get('iterations',self.iterations)
-        self.n_epochs = self.iterations
-        self.n_components = params.get('n_components',self.n_components)
-        self.sparsity_coef = params.get('sparsity_coef', self.sparsity_coef)
-        self.shape = validate_positive_int("shape", self.shape)
-        self.iterations = validate_non_negative_int("iterations", self.iterations)
-        self.n_epochs = self.iterations
-        self.n_components = validate_positive_int("n_components", self.n_components)
-        self.learning_rate = validate_positive_number("learning_rate", self.learning_rate)
-        self.sparsity_coef = validate_positive_number("sparsity_coef", self.sparsity_coef)
-        self.padding_metadata = []
+from nilmtk_contrib.torch.dsc import DSC as TorchDSC
 
-    def learn_dictionary(self, appliance_main, app_name):
 
-        if appliance_main.size%self.shape!=0:
-            extra_values = self.shape - (appliance_main.size)%(self.shape)
-            appliance_main = list(appliance_main.values.flatten()) + [0]*extra_values
-        appliance_main = np.array(appliance_main).reshape((-1,self.shape)).T
-        self.power[app_name] = appliance_main
+class DSC(TorchDSC):
+    """Deprecated import path retaining the historical DSC defaults."""
 
-        if app_name not in self.dictionaries:
-            _log_print("Training First dictionary for ",app_name)
-            model = MiniBatchDictionaryLearning(n_components=self.n_components,positive_code=True,positive_dict=True,fit_algorithm='cd',transform_algorithm='lasso_cd',alpha=self.sparsity_coef)
-        
+    def __init__(self, params=None):
+        warnings.warn(
+            "nilmtk_contrib.disaggregate.dsc.DSC now uses the maintained "
+            "PyTorch implementation; import DSC from nilmtk_contrib.torch.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        if params is None:
+            normalized = {}
+        elif isinstance(params, Mapping):
+            normalized = dict(params)
         else:
-            _log_print("Re-training dictionary for ",app_name)
-            model = self.dictionaries[app_name]
-        model.fit(appliance_main.T)
-        reconstruction = np.matmul(model.components_.T,model.transform(appliance_main.T).T)
-        _log_print("RMSE reconstruction for appliance %s is %s"%(app_name,mean_squared_error(reconstruction,appliance_main)**(.5)))
-        self.dictionaries[app_name] = model
-        
+            raise TypeError("params must be a mapping or None.")
+        if (
+            "discriminative_iterations" not in normalized
+            and "iterations" not in normalized
+        ):
+            normalized["discriminative_iterations"] = 3_000
+        super().__init__(normalized)
+        self.n_epochs = self.discriminative_iterations
 
-    def discriminative_training(self,concatenated_activations,concatenated_bases, verbose = 100):
+    @property
+    def iterations(self):
+        return super().iterations
+
+    @iterations.setter
+    def iterations(self, value):
+        TorchDSC.iterations.fset(self, value)
+        self.n_epochs = self.discriminative_iterations
+
+    def load_model(self, path=None):
+        super().load_model(path)
+        self.n_epochs = self.discriminative_iterations
 
 
-        # Making copies of concatenated bases and activation. 
-        optimal_a = np.copy(concatenated_activations)
-        predicted_b = np.copy(concatenated_bases)
-        
-        '''
-        Next step is to modify bases such that, we get optimal A upon sparse coding
-        We want to get a_opt on finding activations from b_hat
-        '''
-
-        alpha = self.learning_rate
-        least_error = 1e10
-        total_power = self.total_power
-        v_size = .20
-        v_index = int(total_power.shape[1] * v_size)
-        train_power = total_power[:,:-v_index]
-        v_power = total_power[:,-v_index:]
-        train_optimal_a = optimal_a[:,:-v_index]
-        v_optimal_a = optimal_a[:,-v_index:]
-
-        _log_print("If Iteration wise errors are not decreasing, then please decrease the learning rate")
-        for i in range(self.iterations):
-
-            time.time()
-            # Finding activations for the given bases
-            model = SparseCoder(dictionary=predicted_b.T,positive_code=True,transform_algorithm='lasso_cd',transform_alpha=self.sparsity_coef)
-            train_predicted_a = model.transform(train_power.T).T
-            model = SparseCoder(dictionary=predicted_b.T,positive_code=True,transform_algorithm='lasso_cd',transform_alpha=self.sparsity_coef)
-            val_predicted_a = model.transform(v_power.T).T        
-            err = np.mean(np.abs(val_predicted_a - v_optimal_a))
-
-            if err<least_error:
-                #_log_print("Chose the best")
-                least_error = err
-                best_b = np.copy(predicted_b)
-                
-            # Modify the bases b_hat so that they result activations closer to a_opt
-            T1 = (train_power - predicted_b@train_predicted_a)@train_predicted_a.T
-            T2 = (train_power - predicted_b@train_optimal_a)@train_optimal_a.T
-            predicted_b = predicted_b - alpha *( T1 - T2)
-            predicted_b = np.where(predicted_b>0,predicted_b,0)
-            # Making sure that columns sum to 1
-            predicted_b = (predicted_b.T/np.linalg.norm(predicted_b.T,axis=1).reshape((-1,1))).T 
-            if self.verbose and verbose and i % verbose == 0:
-                _log_print("Iteration ",i," Error ",err)
-
-        return  best_b
-
-    def print_appliance_wise_errors(self, activations, bases):
-
-        start_comp = 0        
-        for cnt, i in enumerate(self.power):
-            X = self.power[i]
-            n_comps = self.dictionaries[i].n_components
-            pred = np.matmul(bases[:,start_comp:start_comp+n_comps],activations[start_comp:start_comp+n_comps,:])
-            start_comp+=n_comps
-            #plt.plot(pred.T[home_id],label=i)
-            _log_print("Error for ",i," is ",mean_squared_error(pred, X)**(.5))
-        
-    def partial_fit(self, train_main, train_appliances, **load_kwargs):
-        
-        _log_print("...............DSC partial_fit running...............")
-
-        #_log_print(train_main[0])
-
-        train_main = pd.concat(train_main,axis=1) #np.array([i.values.reshape((self.sequence_length,1)) for i in train_main])
-        
-        if train_main.size%self.shape!=0:
-            extra_values = self.shape - (train_main.size)%(self.shape)
-            train_main = list(train_main.values.flatten()) + [0]*extra_values
-        
-        train_main = np.array(train_main).reshape((-1,self.shape)).T
-        self.total_power = train_main
-        new_train_appliances  = []
-        
-        for app_name, app_df in train_appliances:
-            app_df = pd.concat(app_df)
-            new_train_appliances.append((app_name, app_df))
-            
-        train_appliances = new_train_appliances
-        
-        if len(train_main)>10:
-
-            for appliance_name, power in train_appliances:
-                self.learn_dictionary(power, appliance_name)
-
-            concatenated_bases = []
-            concatenated_activations = []
-
-            for i in self.dictionaries:
-                
-                model = self.dictionaries[i]
-                
-                concatenated_bases.append(model.components_.T)
-                concatenated_activations.append(model.transform(self.power[i].T).T)
-
-            concatenated_bases = np.concatenate(concatenated_bases,axis=1)
-            concatenated_activations = np.concatenate(concatenated_activations,axis=0)
-            _log_print("--"*15)
-            _log_print("Optimal Errors")
-            self.print_appliance_wise_errors(concatenated_activations, concatenated_bases)
-            _log_print("--"*15)
-            model = SparseCoder(dictionary=concatenated_bases.T,positive_code=True,transform_algorithm='lasso_cd',transform_alpha=self.sparsity_coef)
-            predicted_activations = model.transform(train_main.T).T
-            _log_print('\n\n')
-            _log_print("--"*15)
-            _log_print("Error in prediction before discriminative sparse coding")
-            self.print_appliance_wise_errors(predicted_activations, concatenated_bases)
-            _log_print("--"*15)
-            _log_print('\n\n')
-            optimal_b = self.discriminative_training(concatenated_activations,concatenated_bases)
-            model = SparseCoder(dictionary=optimal_b.T,positive_code=True,transform_algorithm='lasso_cd',transform_alpha=self.sparsity_coef)
-            self.disggregation_model = model
-            predicted_activations = model.transform(train_main.T).T
-            _log_print("--"*15)
-            _log_print("Model Errors after Discriminative Training")
-            self.print_appliance_wise_errors(predicted_activations, concatenated_bases)
-            _log_print("--"*15)
-            self.disaggregation_bases = optimal_b
-            self.reconstruction_bases = concatenated_bases
-            
-        else:
-            _log_print("This chunk has small number of samples, so skipping the training")
-
-    def disaggregate_chunk(self, test_main_list):
-
-        test_predictions = []
-        for test_main in test_main_list:
-            original_length = test_main.size
-            extra_values = 0
-            if test_main.size%self.shape!=0:
-                extra_values = self.shape - (test_main.size)%(self.shape)
-                test_main = list(test_main.values.flatten()) + [0]*extra_values
-            self.padding_metadata.append(
-                {
-                    "original_length": original_length,
-                    "padded_length": original_length + extra_values,
-                    "extra_values": extra_values,
-                }
-            )
-            test_main = np.array(test_main).reshape((-1,self.shape)).T
-            predicted_activations = self.disggregation_model.transform(test_main.T).T
-            #predicted_usage = self.reconstruction_bases@predicted_activations
-            disggregation_dict = {}
-            start_comp = 0            
-            for cnt, app_name in enumerate(self.power):
-                n_comps = self.dictionaries[app_name].n_components
-                predicted_usage = np.matmul(self.reconstruction_bases[:,start_comp:start_comp+n_comps],predicted_activations[start_comp:start_comp+n_comps,:])
-                start_comp+=n_comps
-                predicted_usage = predicted_usage.T.flatten() 
-                predicted_usage = predicted_usage[:original_length]
-                flat_mains = test_main.T.flatten()
-                flat_mains = flat_mains[:original_length]
-                predicted_usage = np.where(predicted_usage>flat_mains,flat_mains,predicted_usage)
-                disggregation_dict[app_name] = pd.Series(predicted_usage)
-            results = pd.DataFrame(disggregation_dict, dtype='float32')
-            test_predictions.append(results)
-
-        return test_predictions
+__all__ = ["DSC"]

--- a/nilmtk_contrib/metadata.py
+++ b/nilmtk_contrib/metadata.py
@@ -15,7 +15,7 @@ class ModelCatalogEntry:
 MODEL_CATALOG = (
     ModelCatalogEntry("AFHMM", "classical", "nilmtk_contrib.disaggregate.afhmm", "AFHMM", "nilmtk_contrib.disaggregate"),
     ModelCatalogEntry("AFHMM_SAC", "classical", "nilmtk_contrib.disaggregate.afhmm_sac", "AFHMM_SAC", "nilmtk_contrib.disaggregate"),
-    ModelCatalogEntry("DSC", "classical", "nilmtk_contrib.disaggregate.dsc", "DSC", "nilmtk_contrib.disaggregate"),
+    ModelCatalogEntry("DSC compatibility", "torch", "nilmtk_contrib.disaggregate.dsc", "DSC", "nilmtk_contrib.disaggregate"),
     ModelCatalogEntry("BERT", "torch", "nilmtk_contrib.torch.bert", "BERT", "nilmtk_contrib.torch"),
     ModelCatalogEntry("ConvLSTM", "torch", "nilmtk_contrib.torch.conv_lstm", "ConvLSTM", "nilmtk_contrib.torch"),
     ModelCatalogEntry("DAE", "torch", "nilmtk_contrib.torch.dae", "DAE", "nilmtk_contrib.torch"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ torch = [
   "nilmtk @ git+https://github.com/nilmtk/nilmtk.git",
   "numpy>=1.26.0,<2",
   "pandas",
-  "scikit-learn",
   "matplotlib",
   "torch>=2.0,<2.7",
   "tqdm>=4.66"

--- a/tests/model_smoke_helpers.py
+++ b/tests/model_smoke_helpers.py
@@ -23,7 +23,7 @@ class ModelSpec:
 DISAGGREGATE_MODEL_SPECS = (
     ModelSpec("classical", "nilmtk_contrib.disaggregate", "AFHMM", "nilmtk_contrib.disaggregate.afhmm", trainable=False),
     ModelSpec("classical", "nilmtk_contrib.disaggregate", "AFHMM_SAC", "nilmtk_contrib.disaggregate.afhmm_sac", trainable=False),
-    ModelSpec("classical", "nilmtk_contrib.disaggregate", "DSC", "nilmtk_contrib.disaggregate.dsc", trainable=False),
+    ModelSpec("torch", "nilmtk_contrib.disaggregate", "DSC", "nilmtk_contrib.disaggregate.dsc", min_sequence_length=120, trainable=False),
 )
 
 
@@ -75,6 +75,14 @@ def import_or_skip(spec):
     return getattr(module, spec.class_name)
 
 
+def instantiate_for_smoke(spec, params):
+    cls = import_or_skip(spec)
+    if spec.module_name == "nilmtk_contrib.disaggregate.dsc":
+        with pytest.warns(FutureWarning, match="maintained PyTorch implementation"):
+            return cls(params)
+    return cls(params)
+
+
 def synthetic_nilmtk_chunks(sequence_length, num_windows=4):
     total_length = sequence_length * num_windows
     t = np.arange(total_length, dtype=np.float32)
@@ -89,7 +97,7 @@ def synthetic_nilmtk_chunks(sequence_length, num_windows=4):
 
 def smoke_params(spec, epochs):
     sequence_length = spec.min_sequence_length
-    return {
+    params = {
         "sequence_length": sequence_length,
         "n_epochs": epochs,
         "batch_size": 32,
@@ -111,6 +119,25 @@ def smoke_params(spec, epochs):
         "classification_weight": 1.0,
         "regression_weight": 1.0,
     }
+    if spec.backend == "classical":
+        params.update(
+            {
+                "time_period": 20,
+                "default_num_states": 2,
+                "max_workers": 1,
+            }
+        )
+    if spec.module_name == "nilmtk_contrib.disaggregate.dsc":
+        params.update(
+            {
+                "shape": 20,
+                "discriminative_iterations": 1,
+                "n_components": 2,
+                "discriminative_learning_rate": 1e-9,
+                "sparsity_coefficient": 0.1,
+            }
+        )
+    return params
 
 
 def assert_prediction_frames(predictions, appliance="fridge"):

--- a/tests/test_dsc_parity.py
+++ b/tests/test_dsc_parity.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
-from types import SimpleNamespace
+import inspect
+from pathlib import Path
 import warnings
 
 import numpy as np
@@ -11,9 +12,8 @@ from model_smoke_helpers import load_real_dataset_chunks
 
 torch = pytest.importorskip("torch")
 sklearn_decomposition = pytest.importorskip("sklearn.decomposition")
-ConvergenceWarning = pytest.importorskip("sklearn.exceptions").ConvergenceWarning
 
-from nilmtk_contrib.disaggregate.dsc import DSC as LegacyDSC  # noqa: E402
+from nilmtk_contrib.disaggregate.dsc import DSC as CompatibilityDSC  # noqa: E402
 from nilmtk_contrib.torch._dsc import (  # noqa: E402
     DSC as TorchDSC,
     _DSCParameters,
@@ -23,13 +23,17 @@ from nilmtk_contrib.torch._dsc import (  # noqa: E402
 )
 
 
-def _legacy_params(**overrides):
+def _compatibility_params(**overrides):
     return {
+        "device": "cpu",
         "shape": 12,
         "n_components": 2,
         "sparsity_coef": 0.1,
         "iterations": 2,
         "learning_rate": 1e-9,
+        "dictionary_iterations": 20,
+        "sparse_code_iterations": 500,
+        "tolerance": 1e-7,
         "seed": 4,
         "verbose": False,
     } | overrides
@@ -53,6 +57,19 @@ def _torch_params(**overrides):
 def _normalized_columns(values):
     values = np.asarray(values, dtype=np.float64)
     return values / np.linalg.norm(values, axis=0)
+
+
+def _fitted_parameters(dictionary, column):
+    matrix = tuple((float(value),) for value in dictionary[:, column])
+    return _DSCParameters(
+        reconstruction_dictionary=matrix,
+        discriminative_dictionary=matrix,
+        training_windows=3,
+        reconstruction_objective=0.0,
+        reconstruction_iterations=1,
+        reconstruction_converged=True,
+        activation_error=0.0,
+    )
 
 
 def _synthetic_train_test(seed=1):
@@ -99,18 +116,67 @@ def _synthetic_train_test(seed=1):
 
 
 def _fit_predictions(train, test):
-    legacy = LegacyDSC(_legacy_params())
-    modern = TorchDSC(_torch_params())
-    appliances = [("first", [train[1]]), ("second", [train[2]])]
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", ConvergenceWarning)
-        legacy.partial_fit([train[0]], appliances)
-        legacy_prediction = legacy.disaggregate_chunk([test[0]])[0]
+        warnings.simplefilter("ignore")
+        compatibility = CompatibilityDSC(_compatibility_params())
+    appliances = [("first", [train[1]]), ("second", [train[2]])]
+    compatibility.partial_fit([train[0]], appliances)
+    compatibility_prediction = compatibility.disaggregate_chunk([test[0]])[0]
+    modern = TorchDSC(_torch_params())
     modern.partial_fit([train[0]], appliances)
     return (
-        legacy_prediction,
+        compatibility_prediction,
         modern.disaggregate_chunk([test[0]])[0],
     )
+
+
+def test_compatibility_wrapper_uses_torch_with_historical_defaults():
+    with pytest.warns(FutureWarning, match="maintained PyTorch implementation"):
+        model = CompatibilityDSC({"device": "cpu"})
+
+    assert isinstance(model, TorchDSC)
+    assert model.shape == 120
+    assert model.n_components == 10
+    assert model.sparsity_coef == 20.0
+    assert model.iterations == model.n_epochs == 3_000
+    assert model.learning_rate == 1e-9
+    model.iterations = 7
+    assert model.iterations == model.n_epochs == 7
+    source = Path(inspect.getsourcefile(CompatibilityDSC)).read_text(encoding="utf-8")
+    for dependency in ("numpy", "pandas", "sklearn", "scipy"):
+        assert dependency not in source
+
+
+def test_compatibility_wrapper_rejects_non_mapping_parameters():
+    with pytest.warns(FutureWarning):
+        with pytest.raises(TypeError, match="mapping or None"):
+            CompatibilityDSC([])
+
+
+def test_compatibility_wrapper_accepts_none_with_historical_defaults():
+    with pytest.warns(FutureWarning):
+        model = CompatibilityDSC()
+
+    assert model.iterations == model.n_epochs == 3_000
+
+
+def test_package_level_dsc_export_resolves_to_the_compatibility_wrapper():
+    import nilmtk_contrib.disaggregate as historical_models
+
+    historical_models.__dict__.pop("DSC", None)
+    exported = historical_models.DSC
+
+    assert exported is CompatibilityDSC
+    assert historical_models._EXPORTS["DSC"] == (
+        "nilmtk_contrib.disaggregate.dsc",
+        "DSC",
+        "torch",
+    )
+    with pytest.warns(FutureWarning, match="maintained PyTorch implementation"):
+        assert isinstance(
+            exported({"device": "cpu", "discriminative_iterations": 0}),
+            TorchDSC,
+        )
 
 
 def test_legacy_parameter_names_preserve_configuration_with_warnings():
@@ -288,7 +354,7 @@ def test_discriminative_fit_uses_all_windows_when_twenty_percent_rounds_to_zero(
     assert np.isfinite(error)
 
 
-def test_fixed_dictionary_partial_inference_matches_legacy_sklearn_path():
+def test_fixed_dictionary_partial_inference_matches_canonical_torch_path():
     shape = 4
     coefficient = 0.05
     joint_dictionary = _normalized_columns(
@@ -299,41 +365,19 @@ def test_fixed_dictionary_partial_inference_matches_legacy_sklearn_path():
     index = pd.date_range("2026-03-01", periods=10, freq="1min", tz="UTC")
     mains = pd.DataFrame({"power": mains_values}, index=index)
 
-    legacy = LegacyDSC(
-        _legacy_params(
-            shape=shape,
-            n_components=1,
-            sparsity_coef=coefficient,
-            iterations=0,
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        compatibility = CompatibilityDSC(
+            _compatibility_params(
+                device="cpu",
+                shape=shape,
+                n_components=1,
+                sparsity_coef=coefficient,
+                iterations=0,
+                sparse_code_iterations=2_000,
+                tolerance=1e-9,
+            )
         )
-    )
-    legacy.disggregation_model = sklearn_decomposition.SparseCoder(
-        dictionary=joint_dictionary.T,
-        transform_algorithm="lasso_cd",
-        transform_alpha=coefficient,
-        positive_code=True,
-    )
-    legacy.reconstruction_bases = joint_dictionary
-    legacy.power = OrderedDict((("first", None), ("second", None)))
-    legacy.dictionaries = OrderedDict(
-        (
-            ("first", SimpleNamespace(n_components=1)),
-            ("second", SimpleNamespace(n_components=1)),
-        )
-    )
-
-    def fitted(column):
-        matrix = tuple((float(value),) for value in joint_dictionary[:, column])
-        return _DSCParameters(
-            reconstruction_dictionary=matrix,
-            discriminative_dictionary=matrix,
-            training_windows=3,
-            reconstruction_objective=0.0,
-            reconstruction_iterations=1,
-            reconstruction_converged=True,
-            activation_error=0.0,
-        )
-
     modern = TorchDSC(
         _torch_params(
             shape=shape,
@@ -343,39 +387,74 @@ def test_fixed_dictionary_partial_inference_matches_legacy_sklearn_path():
             tolerance=1e-9,
         )
     )
-    models = OrderedDict((("first", fitted(0)), ("second", fitted(1))))
 
-    legacy_prediction = legacy.disaggregate_chunk([mains])[0]
+    models = OrderedDict(
+        (
+            ("first", _fitted_parameters(joint_dictionary, 0)),
+            ("second", _fitted_parameters(joint_dictionary, 1)),
+        )
+    )
+
+    compatibility_prediction = compatibility.disaggregate_chunk(
+        [mains], model=models
+    )[0]
     modern_prediction = modern.disaggregate_chunk([mains], model=models)[0]
 
-    np.testing.assert_allclose(
-        modern_prediction.to_numpy(),
-        legacy_prediction.to_numpy(),
-        rtol=2e-5,
-        atol=2e-5,
+    np.testing.assert_array_equal(
+        modern_prediction.to_numpy(), compatibility_prediction.to_numpy()
     )
     assert modern_prediction.index.equals(index)
-    assert isinstance(legacy_prediction.index, pd.RangeIndex)
+    assert compatibility_prediction.index.equals(index)
+
+
+def test_compatibility_load_keeps_legacy_epoch_alias_in_sync(tmp_path):
+    dictionary = _normalized_columns([[1.0], [0.5], [0.2], [0.1]])
+    canonical = TorchDSC(
+        _torch_params(
+            shape=4,
+            n_components=1,
+            discriminative_iterations=3,
+        )
+    )
+    canonical.models = OrderedDict(
+        (("fridge", _fitted_parameters(dictionary, 0)),)
+    )
+    canonical.save_model(tmp_path)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        compatibility = CompatibilityDSC(
+            _compatibility_params(
+                shape=4,
+                n_components=1,
+                iterations=7,
+            )
+        )
+
+    compatibility.load_model(tmp_path)
+
+    assert compatibility.iterations == compatibility.n_epochs == 3
 
 
 @pytest.mark.parametrize("fixture_seed", [1, 7, 19])
-def test_trained_torch_dsc_is_non_inferior_on_deterministic_nilm_fixture(
+def test_compatibility_and_canonical_dsc_match_on_deterministic_nilm_fixture(
     fixture_seed,
 ):
     train, test = _synthetic_train_test(seed=fixture_seed)
-    legacy_prediction, modern_prediction = _fit_predictions(train, test)
+    compatibility_prediction, modern_prediction = _fit_predictions(train, test)
     truth = np.column_stack((test[1]["power"], test[2]["power"]))
     baseline = np.broadcast_to(np.mean(truth, axis=0), truth.shape)
-    legacy_mae = float(np.mean(np.abs(legacy_prediction.to_numpy() - truth)))
     modern_mae = float(np.mean(np.abs(modern_prediction.to_numpy() - truth)))
     baseline_mae = float(np.mean(np.abs(baseline - truth)))
 
-    assert np.isfinite([legacy_mae, modern_mae, baseline_mae]).all()
+    assert np.isfinite([modern_mae, baseline_mae]).all()
+    np.testing.assert_array_equal(
+        compatibility_prediction.to_numpy(), modern_prediction.to_numpy()
+    )
+    assert compatibility_prediction.index.equals(modern_prediction.index)
     assert modern_mae <= baseline_mae
-    assert modern_mae <= 1.1 * legacy_mae
 
 
-def test_trained_torch_dsc_real_data_non_inferiority_when_dataset_is_supplied(
+def test_compatibility_and_canonical_dsc_match_on_supplied_real_dataset(
     model_smoke_config,
 ):
     if not model_smoke_config["enabled"]:
@@ -404,7 +483,20 @@ def test_trained_torch_dsc_real_data_non_inferiority_when_dataset_is_supplied(
         target.iloc[split : split + test_length],
     )
 
-    legacy = LegacyDSC(_legacy_params(shape=20, n_components=2, iterations=2))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        compatibility = CompatibilityDSC(
+            _compatibility_params(
+                shape=20,
+                n_components=2,
+                iterations=2,
+                dictionary_iterations=8,
+            )
+        )
+    compatibility.partial_fit([train[0]], [(appliance, [train[1]])])
+    compatibility_values = compatibility.disaggregate_chunk([test[0]])[0][
+        appliance
+    ].to_numpy()
     modern = TorchDSC(
         _torch_params(
             shape=20,
@@ -413,17 +505,12 @@ def test_trained_torch_dsc_real_data_non_inferiority_when_dataset_is_supplied(
             discriminative_iterations=2,
         )
     )
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", ConvergenceWarning)
-        legacy.partial_fit([train[0]], [(appliance, [train[1]])])
-        legacy_values = legacy.disaggregate_chunk([test[0]])[0][
-            appliance
-        ].to_numpy()
     modern.partial_fit([train[0]], [(appliance, [train[1]])])
     modern_values = modern.disaggregate_chunk([test[0]])[0][appliance].to_numpy()
     truth = test[1]["power"].to_numpy()
-    legacy_mae = float(np.mean(np.abs(legacy_values - truth)))
+    compatibility_mae = float(np.mean(np.abs(compatibility_values - truth)))
     modern_mae = float(np.mean(np.abs(modern_values - truth)))
 
-    assert np.isfinite([legacy_mae, modern_mae]).all()
-    assert modern_mae <= max(1.05 * legacy_mae, legacy_mae + 2.0)
+    assert np.isfinite([compatibility_mae, modern_mae]).all()
+    np.testing.assert_array_equal(compatibility_values, modern_values)
+    assert compatibility_mae == modern_mae

--- a/tests/test_model_smoke_real_dataset.py
+++ b/tests/test_model_smoke_real_dataset.py
@@ -3,7 +3,7 @@ import pytest
 from model_smoke_helpers import (
     ALL_MODEL_SPECS,
     assert_prediction_frames,
-    import_or_skip,
+    instantiate_for_smoke,
     load_real_dataset_chunks,
     smoke_params,
 )
@@ -28,7 +28,6 @@ def _skip_if_real_smoke_unavailable(config, spec):
 def test_model_contract_on_real_dataset(spec, model_smoke_config):
     _skip_if_real_smoke_unavailable(model_smoke_config, spec)
     appliance = model_smoke_config["real_dataset_appliance"]
-    cls = import_or_skip(spec)
     params = smoke_params(spec, model_smoke_config["epochs"])
     params["appliance_params"] = {
         appliance: {
@@ -40,27 +39,13 @@ def test_model_contract_on_real_dataset(spec, model_smoke_config):
             "threshold": 40.0,
         }
     }
-    if spec.backend == "classical":
-        params.update(
-            {
-                "time_period": 20,
-                "default_num_states": 2,
-                "max_workers": 1,
-                "shape": 20,
-                "iterations": 1,
-                "n_components": 2,
-                "learning_rate": 1e-9,
-                "sparsity_coef": 0.1,
-            }
-        )
-
     mains, appliances = load_real_dataset_chunks(
         model_smoke_config["real_dataset_path"],
         model_smoke_config["real_dataset_building"],
         appliance,
         spec.min_sequence_length,
     )
-    model = cls(params)
+    model = instantiate_for_smoke(spec, params)
     model.partial_fit(mains, appliances)
     predictions = model.disaggregate_chunk(mains)
     assert_prediction_frames(predictions, appliance=appliance)

--- a/tests/test_model_smoke_synthetic.py
+++ b/tests/test_model_smoke_synthetic.py
@@ -3,7 +3,7 @@ import pytest
 from model_smoke_helpers import (
     ALL_MODEL_SPECS,
     assert_prediction_frames,
-    import_or_skip,
+    instantiate_for_smoke,
     smoke_params,
     synthetic_nilmtk_chunks,
 )
@@ -16,24 +16,6 @@ def _skip_if_smoke_disabled_or_backend_unselected(config, spec):
         pytest.skip(f"{spec.backend} backend not selected")
 
 
-def _params_for_spec(spec, epochs):
-    params = smoke_params(spec, epochs)
-    if spec.backend == "classical":
-        params.update(
-            {
-                "time_period": 20,
-                "default_num_states": 2,
-                "max_workers": 1,
-                "shape": 20,
-                "iterations": 1,
-                "n_components": 2,
-                "learning_rate": 1e-9,
-                "sparsity_coef": 0.1,
-            }
-        )
-    return params
-
-
 @pytest.mark.parametrize(
     "spec",
     ALL_MODEL_SPECS,
@@ -41,10 +23,9 @@ def _params_for_spec(spec, epochs):
 )
 def test_model_contract_on_synthetic_dataset(spec, model_smoke_config):
     _skip_if_smoke_disabled_or_backend_unselected(model_smoke_config, spec)
-    cls = import_or_skip(spec)
-    params = _params_for_spec(spec, model_smoke_config["epochs"])
+    params = smoke_params(spec, model_smoke_config["epochs"])
 
-    model = cls(params)
+    model = instantiate_for_smoke(spec, params)
     for method_name in ("partial_fit", "disaggregate_chunk"):
         assert callable(getattr(model, method_name, None))
 

--- a/uv.lock
+++ b/uv.lock
@@ -630,7 +630,6 @@ torch = [
     { name = "nilmtk" },
     { name = "numpy" },
     { name = "pandas" },
-    { name = "scikit-learn" },
     { name = "torch" },
     { name = "tqdm" },
 ]
@@ -674,7 +673,6 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.0.280" },
     { name = "scikit-learn", marker = "extra == 'all'" },
     { name = "scikit-learn", marker = "extra == 'classical'" },
-    { name = "scikit-learn", marker = "extra == 'torch'" },
     { name = "scipy", marker = "extra == 'all'" },
     { name = "scipy", marker = "extra == 'classical'" },
     { name = "torch", marker = "extra == 'all'", specifier = ">=2.0,<2.7" },


### PR DESCRIPTION
## Summary

- Replace the historical 229-line sklearn DSC implementation with a 49-line compatibility wrapper over the maintained Torch model.
- Preserve the old module and package import paths, defaults, `iterations`, `learning_rate`, `sparsity_coef`, and `n_epochs` behavior with migration warnings.
- Keep the canonical Torch state-space API free of the legacy `n_epochs` alias.
- Remove scikit-learn as a direct dependency of the Torch extra; sklearn remains in the classical extra and as a transitive NILMTK dependency.
- List DSC once as the maintained Torch implementation and centralize smoke-test construction/configuration.

## Scientific and compatibility gates

- Historical and canonical imports produce identical synthetic predictions across three fixtures.
- Fixed-dictionary partial-chunk inference is exactly identical.
- Positive-LASSO, sparsity monotonicity, dictionary constraints, and the historical `T1 - T2` update tests remain in place.
- Compatibility artifacts keep `n_epochs` synchronized after loading.
- The compatibility wrapper has 100% focused coverage; combined DSC coverage is 97%.

## Verification

- Full suite: 1,114 passed, 89 skipped.
- Full Torch synthetic smoke: 27 passed, 2 classical skips.
- Focused compatibility/import/catalog suite: 173 passed, 2 expected skips.
- Wheel and source distribution built; wheel metadata confirms the Torch extra no longer declares scikit-learn.
- REDD building 1 / fridge: compatibility and canonical predictions match exactly.
- REFIT building 1 / fridge: compatibility and canonical predictions match exactly.
- UK-DALE building 1 / fridge freezer: compatibility and canonical predictions match exactly.
- Ruff, lock consistency, and `git diff --check` passed.
