### PR TITLE
Add exact factorial-HMM property oracle

### DIFF
--- a/nilmtk_contrib/torch/_factorial_hmm.py
+++ b/nilmtk_contrib/torch/_factorial_hmm.py
@@ -1,0 +1,348 @@
+"""Exact factorial-HMM primitives for small models and correctness tests.
+
+This private module is an oracle for the forthcoming PyTorch AFHMM port.  It
+uses exact joint-state Viterbi decoding, so callers must explicitly bound the
+Cartesian state space.  Transition matrices use the conventional
+``[source_state, destination_state]`` orientation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Sequence
+
+import torch
+
+
+_FLOAT_DTYPES = frozenset({torch.float32, torch.float64})
+_INTEGER_DTYPES = frozenset(
+    {torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8}
+)
+
+
+@dataclass(frozen=True)
+class FactorialHMMParameters:
+    """Canonical per-appliance HMM parameters ordered by increasing power."""
+
+    state_means: tuple[torch.Tensor, ...]
+    initial_probabilities: tuple[torch.Tensor, ...]
+    transition_probabilities: tuple[torch.Tensor, ...]
+
+
+@dataclass(frozen=True)
+class FactorialHMMViterbiResult:
+    """Highest-scoring joint path and its reconstructed appliance powers."""
+
+    state_indices: torch.Tensor
+    appliance_power: torch.Tensor
+    aggregate_power: torch.Tensor
+    score: float
+
+
+def _floating_tensor(name: str, value) -> torch.Tensor:
+    if not isinstance(value, torch.Tensor):
+        raise TypeError(f"{name} must be a torch.Tensor.")
+    if value.dtype not in _FLOAT_DTYPES or value.is_complex():
+        raise TypeError(f"{name} must use torch.float32 or torch.float64.")
+    if not bool(torch.isfinite(value).all()):
+        raise ValueError(f"{name} must contain only finite values.")
+    return value
+
+
+def _validate_probability_vector(name: str, value: torch.Tensor) -> None:
+    if bool((value < 0).any()):
+        raise ValueError(f"{name} must be nonnegative.")
+    tolerance = 1e-6 if value.dtype == torch.float32 else 1e-12
+    if not bool(
+        torch.isclose(value.sum(), value.new_tensor(1.0), atol=tolerance, rtol=0)
+    ):
+        raise ValueError(f"{name} must sum to one.")
+
+
+def _validate_transition_matrix(
+    name: str,
+    value: torch.Tensor,
+    states: int,
+) -> None:
+    if tuple(value.shape) != (states, states):
+        raise ValueError(f"{name} must have shape ({states}, {states}).")
+    if bool((value < 0).any()):
+        raise ValueError(f"{name} must be nonnegative.")
+    tolerance = 1e-6 if value.dtype == torch.float32 else 1e-12
+    expected = torch.ones(states, dtype=value.dtype, device=value.device)
+    if not bool(torch.allclose(value.sum(dim=1), expected, atol=tolerance, rtol=0)):
+        raise ValueError(f"Every row of {name} must sum to one.")
+
+
+def canonicalize_factorial_hmm(
+    state_means: Sequence[torch.Tensor],
+    initial_probabilities: Sequence[torch.Tensor],
+    transition_probabilities: Sequence[torch.Tensor],
+) -> FactorialHMMParameters:
+    """Validate parameters and sort every appliance state by increasing power."""
+
+    if not isinstance(state_means, (tuple, list)) or not state_means:
+        raise ValueError("state_means must contain at least one appliance.")
+    appliance_count = len(state_means)
+    if len(initial_probabilities) != appliance_count:
+        raise ValueError("initial_probabilities must have one entry per appliance.")
+    if len(transition_probabilities) != appliance_count:
+        raise ValueError("transition_probabilities must have one entry per appliance.")
+
+    canonical_means = []
+    canonical_initial = []
+    canonical_transition = []
+    reference = None
+    for appliance, (means_value, initial_value, transition_value) in enumerate(
+        zip(state_means, initial_probabilities, transition_probabilities, strict=True)
+    ):
+        means = _floating_tensor(f"state_means[{appliance}]", means_value)
+        initial = _floating_tensor(f"initial_probabilities[{appliance}]", initial_value)
+        transition = _floating_tensor(
+            f"transition_probabilities[{appliance}]", transition_value
+        )
+        if means.ndim != 1 or means.numel() < 2:
+            raise ValueError(
+                f"state_means[{appliance}] must contain at least two states."
+            )
+        if bool((means < 0).any()):
+            raise ValueError(f"state_means[{appliance}] must be nonnegative.")
+        if reference is None:
+            reference = means
+        for name, value in (
+            (f"initial_probabilities[{appliance}]", initial),
+            (f"transition_probabilities[{appliance}]", transition),
+        ):
+            if value.dtype != reference.dtype or value.device != reference.device:
+                raise ValueError(
+                    f"{name} must use dtype {reference.dtype} and device "
+                    f"{reference.device}."
+                )
+        if means.dtype != reference.dtype or means.device != reference.device:
+            raise ValueError(
+                f"state_means[{appliance}] must use dtype {reference.dtype} and "
+                f"device {reference.device}."
+            )
+        states = int(means.numel())
+        if tuple(initial.shape) != (states,):
+            raise ValueError(
+                f"initial_probabilities[{appliance}] must have shape ({states},)."
+            )
+        _validate_probability_vector(f"initial_probabilities[{appliance}]", initial)
+        _validate_transition_matrix(
+            f"transition_probabilities[{appliance}]", transition, states
+        )
+
+        order = torch.argsort(means, stable=True)
+        canonical_means.append(means[order])
+        canonical_initial.append(initial[order])
+        canonical_transition.append(transition[order][:, order])
+
+    return FactorialHMMParameters(
+        state_means=tuple(canonical_means),
+        initial_probabilities=tuple(canonical_initial),
+        transition_probabilities=tuple(canonical_transition),
+    )
+
+
+def _joint_model(
+    parameters: FactorialHMMParameters,
+    *,
+    max_joint_states: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    if isinstance(max_joint_states, bool) or not isinstance(max_joint_states, int):
+        raise TypeError("max_joint_states must be an integer.")
+    if max_joint_states < 1:
+        raise ValueError("max_joint_states must be positive.")
+    joint_count = math.prod(means.numel() for means in parameters.state_means)
+    if joint_count > max_joint_states:
+        raise ValueError(
+            f"The factorial HMM has {joint_count} joint states, exceeding "
+            f"max_joint_states={max_joint_states}."
+        )
+
+    reference = parameters.state_means[0]
+    ranges = [
+        torch.arange(means.numel(), device=reference.device)
+        for means in parameters.state_means
+    ]
+    joint_states = torch.cartesian_prod(*ranges).reshape(joint_count, -1)
+    joint_means = reference.new_zeros(joint_count)
+    joint_initial = reference.new_zeros(joint_count)
+    joint_transition = reference.new_zeros((joint_count, joint_count))
+    for appliance, (means, initial, transition) in enumerate(
+        zip(
+            parameters.state_means,
+            parameters.initial_probabilities,
+            parameters.transition_probabilities,
+            strict=True,
+        )
+    ):
+        states = joint_states[:, appliance]
+        joint_means = joint_means + means[states]
+        joint_initial = joint_initial + torch.log(initial[states])
+        joint_transition = joint_transition + torch.log(
+            transition[states[:, None], states[None, :]]
+        )
+    return joint_states, joint_means, joint_initial, joint_transition
+
+
+def _validate_observations(
+    observations,
+    parameters: FactorialHMMParameters,
+    noise_std: float,
+) -> torch.Tensor:
+    values = _floating_tensor("observations", observations)
+    if values.ndim != 1 or values.numel() < 1:
+        raise ValueError("observations must be a nonempty one-dimensional tensor.")
+    reference = parameters.state_means[0]
+    if values.dtype != reference.dtype or values.device != reference.device:
+        raise ValueError(
+            f"observations must use dtype {reference.dtype} and device "
+            f"{reference.device}."
+        )
+    if isinstance(noise_std, bool) or not isinstance(noise_std, (int, float)):
+        raise TypeError("noise_std must be a positive finite number.")
+    if not math.isfinite(noise_std) or noise_std <= 0:
+        raise ValueError("noise_std must be a positive finite number.")
+    return values
+
+
+def _emission_scores(
+    observations: torch.Tensor,
+    joint_means: torch.Tensor,
+    noise_std: float,
+) -> torch.Tensor:
+    scale = observations.new_tensor(noise_std)
+    residual = (observations[:, None] - joint_means[None, :]) / scale
+    normalizer = torch.log(scale) + 0.5 * math.log(2.0 * math.pi)
+    return -0.5 * residual.square() - normalizer
+
+
+@torch.no_grad()
+def factorial_hmm_viterbi(
+    observations: torch.Tensor,
+    state_means: Sequence[torch.Tensor],
+    initial_probabilities: Sequence[torch.Tensor],
+    transition_probabilities: Sequence[torch.Tensor],
+    *,
+    noise_std: float,
+    max_joint_states: int = 512,
+) -> FactorialHMMViterbiResult:
+    """Decode the exact maximum-probability joint appliance state path."""
+
+    parameters = canonicalize_factorial_hmm(
+        state_means, initial_probabilities, transition_probabilities
+    )
+    values = _validate_observations(observations, parameters, noise_std)
+    joint_states, joint_means, initial, transition = _joint_model(
+        parameters, max_joint_states=max_joint_states
+    )
+    emissions = _emission_scores(values, joint_means, noise_std)
+
+    time_points, joint_count = emissions.shape
+    scores = emissions.new_empty((time_points, joint_count))
+    backpointers = torch.zeros(
+        (time_points, joint_count), dtype=torch.int64, device=values.device
+    )
+    scores[0] = initial + emissions[0]
+    for time in range(1, time_points):
+        candidates = scores[time - 1][:, None] + transition
+        best_scores, best_sources = torch.max(candidates, dim=0)
+        scores[time] = best_scores + emissions[time]
+        backpointers[time] = best_sources
+
+    final_joint_state = int(torch.argmax(scores[-1]))
+    final_score = scores[-1, final_joint_state]
+    if not bool(torch.isfinite(final_score)):
+        raise ValueError("No valid factorial-HMM path reaches the sequence end.")
+    decoded_joint = torch.empty(time_points, dtype=torch.int64, device=values.device)
+    decoded_joint[-1] = final_joint_state
+    for time in range(time_points - 1, 0, -1):
+        decoded_joint[time - 1] = backpointers[time, decoded_joint[time]]
+
+    state_indices = joint_states[decoded_joint]
+    appliance_power = torch.stack(
+        [
+            means[state_indices[:, appliance]]
+            for appliance, means in enumerate(parameters.state_means)
+        ],
+        dim=1,
+    )
+    aggregate_power = appliance_power.sum(dim=1)
+    return FactorialHMMViterbiResult(
+        state_indices=state_indices,
+        appliance_power=appliance_power,
+        aggregate_power=aggregate_power,
+        score=float(final_score),
+    )
+
+
+def factorial_hmm_path_score(
+    state_indices: torch.Tensor,
+    observations: torch.Tensor,
+    state_means: Sequence[torch.Tensor],
+    initial_probabilities: Sequence[torch.Tensor],
+    transition_probabilities: Sequence[torch.Tensor],
+    *,
+    noise_std: float,
+) -> torch.Tensor:
+    """Return the log score of one labeled per-appliance state path."""
+
+    parameters = canonicalize_factorial_hmm(
+        state_means, initial_probabilities, transition_probabilities
+    )
+    values = _validate_observations(observations, parameters, noise_std)
+    if not isinstance(state_indices, torch.Tensor):
+        raise TypeError("state_indices must be a torch.Tensor.")
+    if state_indices.dtype not in _INTEGER_DTYPES or state_indices.ndim != 2:
+        raise TypeError("state_indices must be a two-dimensional integer tensor.")
+    expected_shape = (values.numel(), len(parameters.state_means))
+    if tuple(state_indices.shape) != expected_shape:
+        raise ValueError(f"state_indices must have shape {expected_shape}.")
+    if state_indices.device != values.device:
+        raise ValueError(f"state_indices must be on {values.device}.")
+    for appliance, means in enumerate(parameters.state_means):
+        states = state_indices[:, appliance]
+        if bool(((states < 0) | (states >= means.numel())).any()):
+            raise ValueError(
+                f"state_indices for appliance {appliance} must be between 0 and "
+                f"{means.numel() - 1}."
+            )
+
+    appliance_power = torch.stack(
+        [
+            means[state_indices[:, appliance]]
+            for appliance, means in enumerate(parameters.state_means)
+        ],
+        dim=1,
+    )
+    scale = values.new_tensor(noise_std)
+    residual = (values - appliance_power.sum(dim=1)) / scale
+    score = (
+        -0.5 * residual.square() - torch.log(scale) - 0.5 * math.log(2.0 * math.pi)
+    ).sum()
+    for appliance, (initial, transition) in enumerate(
+        zip(
+            parameters.initial_probabilities,
+            parameters.transition_probabilities,
+            strict=True,
+        )
+    ):
+        states = state_indices[:, appliance]
+        score = score + torch.log(initial[states[0]])
+        if values.numel() > 1:
+            score = score + torch.log(transition[states[:-1], states[1:]]).sum()
+    if not bool(torch.isfinite(score)):
+        raise ValueError("state_indices describe a path forbidden by the model.")
+    return score
+
+
+__all__ = [
+    "FactorialHMMParameters",
+    "FactorialHMMViterbiResult",
+    "canonicalize_factorial_hmm",
+    "factorial_hmm_path_score",
+    "factorial_hmm_viterbi",
+]

--- a/tests/test_factorial_hmm.py
+++ b/tests/test_factorial_hmm.py
@@ -1,0 +1,450 @@
+from itertools import product
+import inspect
+
+import pytest
+
+
+torch = pytest.importorskip("torch")
+
+from nilmtk_contrib.torch._factorial_hmm import (  # noqa: E402
+    canonicalize_factorial_hmm,
+    factorial_hmm_path_score,
+    factorial_hmm_viterbi,
+)
+
+
+def _parameters(*, dtype=torch.float64, device="cpu"):
+    means = (
+        torch.tensor([0.0, 80.0], dtype=dtype, device=device),
+        torch.tensor([0.0, 30.0], dtype=dtype, device=device),
+    )
+    initial = (
+        torch.tensor([0.9, 0.1], dtype=dtype, device=device),
+        torch.tensor([0.8, 0.2], dtype=dtype, device=device),
+    )
+    transition = (
+        torch.tensor([[0.85, 0.15], [0.2, 0.8]], dtype=dtype, device=device),
+        torch.tensor([[0.75, 0.25], [0.3, 0.7]], dtype=dtype, device=device),
+    )
+    return means, initial, transition
+
+
+def _enumerate_paths(observations, means, initial, transition, *, noise_std):
+    appliance_count = len(means)
+    state_counts = [value.numel() for value in means]
+    joint_states = tuple(product(*(range(count) for count in state_counts)))
+    candidates = []
+    for flattened in product(joint_states, repeat=observations.numel()):
+        path = torch.tensor(
+            flattened,
+            dtype=torch.int64,
+            device=observations.device,
+        ).reshape(observations.numel(), appliance_count)
+        try:
+            score = factorial_hmm_path_score(
+                path,
+                observations,
+                means,
+                initial,
+                transition,
+                noise_std=noise_std,
+            )
+        except ValueError:
+            continue
+        candidates.append((path, float(score)))
+    return candidates
+
+
+def test_canonicalization_sorts_states_and_all_probability_axes_together():
+    means = (torch.tensor([70.0, 0.0, 20.0], dtype=torch.float64),)
+    initial = (torch.tensor([0.1, 0.6, 0.3], dtype=torch.float64),)
+    transition = (
+        torch.tensor(
+            [
+                [0.7, 0.1, 0.2],
+                [0.3, 0.6, 0.1],
+                [0.2, 0.3, 0.5],
+            ],
+            dtype=torch.float64,
+        ),
+    )
+
+    result = canonicalize_factorial_hmm(means, initial, transition)
+
+    assert result.state_means[0].tolist() == [0.0, 20.0, 70.0]
+    assert result.initial_probabilities[0].tolist() == [0.6, 0.3, 0.1]
+    assert result.transition_probabilities[0].tolist() == [
+        [0.6, 0.1, 0.3],
+        [0.3, 0.5, 0.2],
+        [0.1, 0.2, 0.7],
+    ]
+    assert torch.allclose(
+        result.transition_probabilities[0].sum(1),
+        torch.ones(3, dtype=torch.float64),
+    )
+
+
+def test_viterbi_recovers_a_known_two_appliance_path_and_power():
+    means, initial, transition = _parameters()
+    observations = torch.tensor([0.0, 30.0, 110.0, 80.0], dtype=torch.float64)
+
+    result = factorial_hmm_viterbi(
+        observations,
+        means,
+        initial,
+        transition,
+        noise_std=2.0,
+    )
+
+    assert result.state_indices.tolist() == [[0, 0], [0, 1], [1, 1], [1, 0]]
+    assert result.appliance_power.tolist() == [
+        [0.0, 0.0],
+        [0.0, 30.0],
+        [80.0, 30.0],
+        [80.0, 0.0],
+    ]
+    assert torch.equal(result.aggregate_power, result.appliance_power.sum(dim=1))
+    assert result.aggregate_power.tolist() == observations.tolist()
+
+
+@pytest.mark.parametrize("seed", [2, 7, 19])
+def test_viterbi_matches_exhaustive_enumeration_on_small_random_models(seed):
+    generator = torch.Generator().manual_seed(seed)
+    dtype = torch.float64
+    means = (
+        torch.tensor([0.0, 50.0], dtype=dtype),
+        torch.tensor([0.0, 20.0], dtype=dtype),
+    )
+    initial = tuple(
+        torch.softmax(torch.randn(2, generator=generator, dtype=dtype), 0)
+        for _ in means
+    )
+    transition = tuple(
+        torch.softmax(torch.randn(2, 2, generator=generator, dtype=dtype), 1)
+        for _ in means
+    )
+    observations = torch.randn(4, generator=generator, dtype=dtype) * 20 + 35
+    candidates = _enumerate_paths(
+        observations, means, initial, transition, noise_std=8.0
+    )
+    expected_path, expected_score = max(candidates, key=lambda item: item[1])
+
+    result = factorial_hmm_viterbi(
+        observations,
+        means,
+        initial,
+        transition,
+        noise_std=8.0,
+    )
+
+    assert result.score == pytest.approx(expected_score, abs=1e-12)
+    assert torch.equal(result.state_indices, expected_path)
+    actual_score = factorial_hmm_path_score(
+        result.state_indices,
+        observations,
+        means,
+        initial,
+        transition,
+        noise_std=8.0,
+    )
+    assert result.score == pytest.approx(float(actual_score), abs=1e-12)
+
+
+def test_state_label_permutations_cannot_change_decoding_or_score():
+    means, initial, transition = _parameters()
+    observations = torch.tensor([0.0, 30.0, 110.0, 80.0], dtype=torch.float64)
+    expected = factorial_hmm_viterbi(
+        observations, means, initial, transition, noise_std=3.0
+    )
+    orders = (torch.tensor([1, 0]), torch.tensor([1, 0]))
+    permuted_means = tuple(value[order] for value, order in zip(means, orders))
+    permuted_initial = tuple(value[order] for value, order in zip(initial, orders))
+    permuted_transition = tuple(
+        value[order][:, order] for value, order in zip(transition, orders)
+    )
+
+    actual = factorial_hmm_viterbi(
+        observations,
+        permuted_means,
+        permuted_initial,
+        permuted_transition,
+        noise_std=3.0,
+    )
+
+    assert torch.equal(actual.state_indices, expected.state_indices)
+    assert torch.equal(actual.appliance_power, expected.appliance_power)
+    assert actual.score == pytest.approx(expected.score, abs=1e-12)
+
+
+def test_zero_probability_transitions_are_safe_and_forbidden_paths_fail_cleanly():
+    dtype = torch.float64
+    means = (torch.tensor([0.0, 10.0], dtype=dtype),)
+    initial = (torch.tensor([1.0, 0.0], dtype=dtype),)
+    transition = (torch.eye(2, dtype=dtype),)
+    observations = torch.zeros(3, dtype=dtype)
+
+    result = factorial_hmm_viterbi(
+        observations, means, initial, transition, noise_std=1.0
+    )
+
+    assert result.state_indices.flatten().tolist() == [0, 0, 0]
+    assert result.score == pytest.approx(result.score)
+    forbidden = torch.tensor([[0], [1], [1]], dtype=torch.int64)
+    with pytest.raises(ValueError, match="forbidden"):
+        factorial_hmm_path_score(
+            forbidden,
+            observations,
+            means,
+            initial,
+            transition,
+            noise_std=1.0,
+        )
+
+
+def test_joint_state_guard_precedes_quadratic_allocation():
+    dtype = torch.float64
+    means = tuple(torch.arange(4, dtype=dtype) for _ in range(5))
+    initial = tuple(torch.full((4,), 0.25, dtype=dtype) for _ in means)
+    transition = tuple(torch.full((4, 4), 0.25, dtype=dtype) for _ in means)
+
+    with pytest.raises(ValueError, match="1024 joint states"):
+        factorial_hmm_viterbi(
+            torch.zeros(2, dtype=dtype),
+            means,
+            initial,
+            transition,
+            noise_std=1.0,
+            max_joint_states=512,
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutate", "error", "message"),
+    [
+        (lambda m, i, t: ((), i, t), ValueError, "at least one appliance"),
+        (lambda m, i, t: (m, i[:1], t), ValueError, "one entry per appliance"),
+        (lambda m, i, t: (m, i, t[:1]), ValueError, "one entry per appliance"),
+        (
+            lambda m, i, t: (m, (torch.tensor([0.8, 0.8]), i[1]), t),
+            ValueError,
+            "sum to one",
+        ),
+        (
+            lambda m, i, t: (m, i, (torch.tensor([[0.7, 0.2], [0.3, 0.7]]), t[1])),
+            ValueError,
+            "Every row",
+        ),
+        (
+            lambda m, i, t: ((torch.tensor([-1.0, 2.0]), m[1]), i, t),
+            ValueError,
+            "nonnegative",
+        ),
+    ],
+)
+def test_parameter_validation_rejects_invalid_hmms(mutate, error, message):
+    means, initial, transition = _parameters(dtype=torch.float32)
+    arguments = mutate(means, initial, transition)
+
+    with pytest.raises(error, match=message):
+        canonicalize_factorial_hmm(*arguments)
+
+
+def test_parameter_tensor_shape_dtype_and_finiteness_contracts():
+    means, initial, transition = _parameters()
+    cases = [
+        (([0.0, 1.0], means[1]), initial, transition, TypeError, "torch.Tensor"),
+        (
+            (torch.tensor([0, 1]), means[1]),
+            initial,
+            transition,
+            TypeError,
+            "torch.float32 or torch.float64",
+        ),
+        (
+            (torch.tensor([0.0, float("nan")], dtype=torch.float64), means[1]),
+            initial,
+            transition,
+            ValueError,
+            "finite",
+        ),
+        (
+            (torch.tensor([0.0], dtype=torch.float64), means[1]),
+            initial,
+            transition,
+            ValueError,
+            "at least two states",
+        ),
+        (
+            means,
+            (initial[0].reshape(1, 2), initial[1]),
+            transition,
+            ValueError,
+            "shape",
+        ),
+        (
+            means,
+            (torch.tensor([1.1, -0.1], dtype=torch.float64), initial[1]),
+            transition,
+            ValueError,
+            "nonnegative",
+        ),
+        (
+            means,
+            initial,
+            (transition[0][:, :1], transition[1]),
+            ValueError,
+            "shape",
+        ),
+        (
+            means,
+            initial,
+            (
+                torch.tensor([[1.1, -0.1], [0.2, 0.8]], dtype=torch.float64),
+                transition[1],
+            ),
+            ValueError,
+            "nonnegative",
+        ),
+        (
+            (means[0], means[1].float()),
+            initial,
+            transition,
+            ValueError,
+            "dtype",
+        ),
+        (
+            means,
+            (initial[0].float(), initial[1]),
+            transition,
+            ValueError,
+            "dtype",
+        ),
+    ]
+    for case_means, case_initial, case_transition, error, message in cases:
+        with pytest.raises(error, match=message):
+            canonicalize_factorial_hmm(case_means, case_initial, case_transition)
+
+
+@pytest.mark.parametrize(
+    ("maximum", "error", "message"),
+    [
+        (True, TypeError, "integer"),
+        (1.5, TypeError, "integer"),
+        (0, ValueError, "positive"),
+    ],
+)
+def test_joint_state_limit_is_a_positive_integer(maximum, error, message):
+    means, initial, transition = _parameters()
+
+    with pytest.raises(error, match=message):
+        factorial_hmm_viterbi(
+            torch.zeros(2, dtype=torch.float64),
+            means,
+            initial,
+            transition,
+            noise_std=1.0,
+            max_joint_states=maximum,
+        )
+
+
+def test_observation_and_state_path_contracts():
+    means, initial, transition = _parameters()
+    observations = torch.zeros(2, dtype=torch.float64)
+    decode_cases = [
+        (torch.zeros(1, 2, dtype=torch.float64), ValueError, "one-dimensional"),
+        (torch.empty(0, dtype=torch.float64), ValueError, "nonempty"),
+        (torch.zeros(2, dtype=torch.float32), ValueError, "dtype"),
+    ]
+    for values, error, message in decode_cases:
+        with pytest.raises(error, match=message):
+            factorial_hmm_viterbi(values, means, initial, transition, noise_std=1.0)
+    with pytest.raises(TypeError, match="positive finite"):
+        factorial_hmm_viterbi(observations, means, initial, transition, noise_std=True)
+
+    path_cases = [
+        ([[0, 0], [0, 0]], TypeError, "torch.Tensor"),
+        (torch.zeros(2, 2), TypeError, "integer"),
+        (torch.zeros(2, dtype=torch.int64), TypeError, "two-dimensional"),
+        (torch.zeros(1, 2, dtype=torch.int64), ValueError, "shape"),
+        (torch.tensor([[0, 0], [2, 0]]), ValueError, "between 0 and 1"),
+    ]
+    for path, error, message in path_cases:
+        with pytest.raises(error, match=message):
+            factorial_hmm_path_score(
+                path,
+                observations,
+                means,
+                initial,
+                transition,
+                noise_std=1.0,
+            )
+
+
+def test_numerically_impossible_decode_fails_instead_of_returning_infinity():
+    means, initial, transition = _parameters(dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="No valid"):
+        factorial_hmm_viterbi(
+            torch.full((2,), torch.finfo(torch.float32).max),
+            means,
+            initial,
+            transition,
+            noise_std=1e-30,
+        )
+
+
+@pytest.mark.parametrize("noise_std", [0.0, -1.0, float("inf"), float("nan")])
+def test_noise_scale_must_be_positive_and_finite(noise_std):
+    means, initial, transition = _parameters()
+
+    with pytest.raises(ValueError, match="positive finite"):
+        factorial_hmm_viterbi(
+            torch.zeros(2, dtype=torch.float64),
+            means,
+            initial,
+            transition,
+            noise_std=noise_std,
+        )
+
+
+def test_decode_is_deterministic_under_exact_ties():
+    dtype = torch.float64
+    means = (torch.tensor([0.0, 0.0], dtype=dtype),)
+    initial = (torch.tensor([0.5, 0.5], dtype=dtype),)
+    transition = (torch.full((2, 2), 0.5, dtype=dtype),)
+    observations = torch.zeros(3, dtype=dtype)
+
+    first = factorial_hmm_viterbi(
+        observations, means, initial, transition, noise_std=1.0
+    )
+    second = factorial_hmm_viterbi(
+        observations, means, initial, transition, noise_std=1.0
+    )
+
+    assert first.state_indices.tolist() == [[0], [0], [0]]
+    assert torch.equal(first.state_indices, second.state_indices)
+    assert first.score == second.score
+
+
+def test_oracle_has_no_numpy_solver_or_classical_hmm_dependency():
+    import nilmtk_contrib.torch._factorial_hmm as module
+
+    source = inspect.getsource(module)
+
+    for dependency in ("numpy", "pandas", "cvxpy", "hmmlearn", "scipy"):
+        assert dependency not in source
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_cpu_and_cuda_decoding_agree():
+    cpu_parameters = _parameters(dtype=torch.float32)
+    observations = torch.tensor([0.0, 30.0, 110.0, 80.0])
+    cpu = factorial_hmm_viterbi(observations, *cpu_parameters, noise_std=3.0)
+    cuda_parameters = tuple(
+        tuple(value.cuda() for value in group) for group in cpu_parameters
+    )
+    cuda = factorial_hmm_viterbi(observations.cuda(), *cuda_parameters, noise_std=3.0)
+
+    assert torch.equal(cpu.state_indices, cuda.state_indices.cpu())
+    assert torch.allclose(cpu.appliance_power, cuda.appliance_power.cpu())
+    assert cpu.score == pytest.approx(cuda.score, abs=1e-5)


### PR DESCRIPTION
## Summary

- add a private, pure-PyTorch exact joint-state Viterbi oracle for small factorial HMMs
- canonicalize state labels and validate stochastic initial/transition probabilities
- bound the Cartesian state space before its quadratic transition allocation
- add exhaustive, analytic, permutation, zero-probability, determinism, conservation, dependency, and CPU/CUDA parity gates

This PR does not change or retire the existing AFHMM implementations. It establishes a deterministic correctness oracle for a later Torch port.

## Verification

- `pytest -q`: 1,142 passed, 90 skipped
- focused oracle suite: 26 passed, 1 CUDA skip; 99% module coverage
- `ruff check .` and `ruff format --check`: pass
- `uv lock --check`: pass
- wheel and sdist build: pass