### PR TITLE
Make exact FHMM compose the shared HMM decoder

### DIFF
--- a/nilmtk_contrib/torch/_factorial_hmm.py
+++ b/nilmtk_contrib/torch/_factorial_hmm.py
@@ -1,9 +1,8 @@
-"""Exact factorial-HMM primitives for small models and correctness tests.
+"""Exact factorial-HMM construction over the shared exact HMM decoder.
 
-This private module is an oracle for the forthcoming PyTorch AFHMM port.  It
-uses exact joint-state Viterbi decoding, so callers must explicitly bound the
-Cartesian state space.  Transition matrices use the conventional
-``[source_state, destination_state]`` orientation.
+This private module is an oracle for a forthcoming PyTorch AFHMM port. It
+constructs the Cartesian product of appliance states and delegates all path
+inference to :mod:`nilmtk_contrib.torch._hmm`.
 """
 
 from __future__ import annotations
@@ -14,8 +13,14 @@ from typing import Sequence
 
 import torch
 
+from nilmtk_contrib.torch._hmm import (
+    canonicalize_gaussian_hmm,
+    gaussian_log_emissions,
+    hmm_path_score,
+    hmm_viterbi,
+)
 
-_FLOAT_DTYPES = frozenset({torch.float32, torch.float64})
+
 _INTEGER_DTYPES = frozenset(
     {torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8}
 )
@@ -40,47 +45,12 @@ class FactorialHMMViterbiResult:
     score: float
 
 
-def _floating_tensor(name: str, value) -> torch.Tensor:
-    if not isinstance(value, torch.Tensor):
-        raise TypeError(f"{name} must be a torch.Tensor.")
-    if value.dtype not in _FLOAT_DTYPES or value.is_complex():
-        raise TypeError(f"{name} must use torch.float32 or torch.float64.")
-    if not bool(torch.isfinite(value).all()):
-        raise ValueError(f"{name} must contain only finite values.")
-    return value
-
-
-def _validate_probability_vector(name: str, value: torch.Tensor) -> None:
-    if bool((value < 0).any()):
-        raise ValueError(f"{name} must be nonnegative.")
-    tolerance = 1e-6 if value.dtype == torch.float32 else 1e-12
-    if not bool(
-        torch.isclose(value.sum(), value.new_tensor(1.0), atol=tolerance, rtol=0)
-    ):
-        raise ValueError(f"{name} must sum to one.")
-
-
-def _validate_transition_matrix(
-    name: str,
-    value: torch.Tensor,
-    states: int,
-) -> None:
-    if tuple(value.shape) != (states, states):
-        raise ValueError(f"{name} must have shape ({states}, {states}).")
-    if bool((value < 0).any()):
-        raise ValueError(f"{name} must be nonnegative.")
-    tolerance = 1e-6 if value.dtype == torch.float32 else 1e-12
-    expected = torch.ones(states, dtype=value.dtype, device=value.device)
-    if not bool(torch.allclose(value.sum(dim=1), expected, atol=tolerance, rtol=0)):
-        raise ValueError(f"Every row of {name} must sum to one.")
-
-
 def canonicalize_factorial_hmm(
     state_means: Sequence[torch.Tensor],
     initial_probabilities: Sequence[torch.Tensor],
     transition_probabilities: Sequence[torch.Tensor],
 ) -> FactorialHMMParameters:
-    """Validate parameters and sort every appliance state by increasing power."""
+    """Validate appliance HMMs and sort their states by increasing power."""
 
     if not isinstance(state_means, (tuple, list)) or not state_means:
         raise ValueError("state_means must contain at least one appliance.")
@@ -90,67 +60,38 @@ def canonicalize_factorial_hmm(
     if len(transition_probabilities) != appliance_count:
         raise ValueError("transition_probabilities must have one entry per appliance.")
 
-    canonical_means = []
-    canonical_initial = []
-    canonical_transition = []
+    canonical = []
     reference = None
-    for appliance, (means_value, initial_value, transition_value) in enumerate(
+    for appliance, values in enumerate(
         zip(state_means, initial_probabilities, transition_probabilities, strict=True)
     ):
-        means = _floating_tensor(f"state_means[{appliance}]", means_value)
-        initial = _floating_tensor(f"initial_probabilities[{appliance}]", initial_value)
-        transition = _floating_tensor(
-            f"transition_probabilities[{appliance}]", transition_value
-        )
-        if means.ndim != 1 or means.numel() < 2:
-            raise ValueError(
-                f"state_means[{appliance}] must contain at least two states."
-            )
-        if bool((means < 0).any()):
+        try:
+            parameters = canonicalize_gaussian_hmm(*values)
+        except (TypeError, ValueError) as exc:
+            raise type(exc)(f"appliance {appliance}: {exc}") from exc
+        if bool((parameters.state_means < 0).any()):
             raise ValueError(f"state_means[{appliance}] must be nonnegative.")
         if reference is None:
-            reference = means
-        for name, value in (
-            (f"initial_probabilities[{appliance}]", initial),
-            (f"transition_probabilities[{appliance}]", transition),
+            reference = parameters.state_means
+        elif (
+            parameters.state_means.dtype != reference.dtype
+            or parameters.state_means.device != reference.device
         ):
-            if value.dtype != reference.dtype or value.device != reference.device:
-                raise ValueError(
-                    f"{name} must use dtype {reference.dtype} and device "
-                    f"{reference.device}."
-                )
-        if means.dtype != reference.dtype or means.device != reference.device:
             raise ValueError(
                 f"state_means[{appliance}] must use dtype {reference.dtype} and "
                 f"device {reference.device}."
             )
-        states = int(means.numel())
-        if tuple(initial.shape) != (states,):
-            raise ValueError(
-                f"initial_probabilities[{appliance}] must have shape ({states},)."
-            )
-        _validate_probability_vector(f"initial_probabilities[{appliance}]", initial)
-        _validate_transition_matrix(
-            f"transition_probabilities[{appliance}]", transition, states
-        )
-
-        order = torch.argsort(means, stable=True)
-        canonical_means.append(means[order])
-        canonical_initial.append(initial[order])
-        canonical_transition.append(transition[order][:, order])
-
+        canonical.append(parameters)
     return FactorialHMMParameters(
-        state_means=tuple(canonical_means),
-        initial_probabilities=tuple(canonical_initial),
-        transition_probabilities=tuple(canonical_transition),
+        state_means=tuple(item.state_means for item in canonical),
+        initial_probabilities=tuple(item.initial_probabilities for item in canonical),
+        transition_probabilities=tuple(
+            item.transition_probabilities for item in canonical
+        ),
     )
 
 
-def _joint_model(
-    parameters: FactorialHMMParameters,
-    *,
-    max_joint_states: int,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+def _joint_model(parameters, *, max_joint_states):
     if isinstance(max_joint_states, bool) or not isinstance(max_joint_states, int):
         raise TypeError("max_joint_states must be an integer.")
     if max_joint_states < 1:
@@ -169,8 +110,8 @@ def _joint_model(
     ]
     joint_states = torch.cartesian_prod(*ranges).reshape(joint_count, -1)
     joint_means = reference.new_zeros(joint_count)
-    joint_initial = reference.new_zeros(joint_count)
-    joint_transition = reference.new_zeros((joint_count, joint_count))
+    initial_scores = reference.new_zeros(joint_count)
+    transition_scores = reference.new_zeros((joint_count, joint_count))
     for appliance, (means, initial, transition) in enumerate(
         zip(
             parameters.state_means,
@@ -181,43 +122,30 @@ def _joint_model(
     ):
         states = joint_states[:, appliance]
         joint_means = joint_means + means[states]
-        joint_initial = joint_initial + torch.log(initial[states])
-        joint_transition = joint_transition + torch.log(
+        initial_scores = initial_scores + torch.log(initial[states])
+        transition_scores = transition_scores + torch.log(
             transition[states[:, None], states[None, :]]
         )
-    return joint_states, joint_means, joint_initial, joint_transition
+    return joint_states, joint_means, initial_scores, transition_scores
 
 
-def _validate_observations(
-    observations,
-    parameters: FactorialHMMParameters,
-    noise_std: float,
-) -> torch.Tensor:
-    values = _floating_tensor("observations", observations)
-    if values.ndim != 1 or values.numel() < 1:
-        raise ValueError("observations must be a nonempty one-dimensional tensor.")
-    reference = parameters.state_means[0]
-    if values.dtype != reference.dtype or values.device != reference.device:
-        raise ValueError(
-            f"observations must use dtype {reference.dtype} and device "
-            f"{reference.device}."
-        )
-    if isinstance(noise_std, bool) or not isinstance(noise_std, (int, float)):
-        raise TypeError("noise_std must be a positive finite number.")
-    if not math.isfinite(noise_std) or noise_std <= 0:
-        raise ValueError("noise_std must be a positive finite number.")
-    return values
-
-
-def _emission_scores(
-    observations: torch.Tensor,
-    joint_means: torch.Tensor,
-    noise_std: float,
-) -> torch.Tensor:
-    scale = observations.new_tensor(noise_std)
-    residual = (observations[:, None] - joint_means[None, :]) / scale
-    normalizer = torch.log(scale) + 0.5 * math.log(2.0 * math.pi)
-    return -0.5 * residual.square() - normalizer
+def _validate_state_indices(state_indices, observations, parameters):
+    if not isinstance(state_indices, torch.Tensor):
+        raise TypeError("state_indices must be a torch.Tensor.")
+    if state_indices.dtype not in _INTEGER_DTYPES or state_indices.ndim != 2:
+        raise TypeError("state_indices must be a two-dimensional integer tensor.")
+    expected_shape = (observations.numel(), len(parameters.state_means))
+    if tuple(state_indices.shape) != expected_shape:
+        raise ValueError(f"state_indices must have shape {expected_shape}.")
+    if state_indices.device != observations.device:
+        raise ValueError(f"state_indices must be on {observations.device}.")
+    for appliance, means in enumerate(parameters.state_means):
+        states = state_indices[:, appliance]
+        if bool(((states < 0) | (states >= means.numel())).any()):
+            raise ValueError(
+                f"state_indices for appliance {appliance} must be between 0 and "
+                f"{means.numel() - 1}."
+            )
 
 
 @torch.no_grad()
@@ -230,39 +158,17 @@ def factorial_hmm_viterbi(
     noise_std: float,
     max_joint_states: int = 512,
 ) -> FactorialHMMViterbiResult:
-    """Decode the exact maximum-probability joint appliance state path."""
+    """Construct the joint HMM and decode its exact maximum-probability path."""
 
     parameters = canonicalize_factorial_hmm(
         state_means, initial_probabilities, transition_probabilities
     )
-    values = _validate_observations(observations, parameters, noise_std)
     joint_states, joint_means, initial, transition = _joint_model(
         parameters, max_joint_states=max_joint_states
     )
-    emissions = _emission_scores(values, joint_means, noise_std)
-
-    time_points, joint_count = emissions.shape
-    scores = emissions.new_empty((time_points, joint_count))
-    backpointers = torch.zeros(
-        (time_points, joint_count), dtype=torch.int64, device=values.device
-    )
-    scores[0] = initial + emissions[0]
-    for time in range(1, time_points):
-        candidates = scores[time - 1][:, None] + transition
-        best_scores, best_sources = torch.max(candidates, dim=0)
-        scores[time] = best_scores + emissions[time]
-        backpointers[time] = best_sources
-
-    final_joint_state = int(torch.argmax(scores[-1]))
-    final_score = scores[-1, final_joint_state]
-    if not bool(torch.isfinite(final_score)):
-        raise ValueError("No valid factorial-HMM path reaches the sequence end.")
-    decoded_joint = torch.empty(time_points, dtype=torch.int64, device=values.device)
-    decoded_joint[-1] = final_joint_state
-    for time in range(time_points - 1, 0, -1):
-        decoded_joint[time - 1] = backpointers[time, decoded_joint[time]]
-
-    state_indices = joint_states[decoded_joint]
+    emissions = gaussian_log_emissions(observations, joint_means, noise_std=noise_std)
+    decoded = hmm_viterbi(emissions, initial, transition)
+    state_indices = joint_states[decoded.states]
     appliance_power = torch.stack(
         [
             means[state_indices[:, appliance]]
@@ -270,12 +176,11 @@ def factorial_hmm_viterbi(
         ],
         dim=1,
     )
-    aggregate_power = appliance_power.sum(dim=1)
     return FactorialHMMViterbiResult(
         state_indices=state_indices,
         appliance_power=appliance_power,
-        aggregate_power=aggregate_power,
-        score=float(final_score),
+        aggregate_power=appliance_power.sum(dim=1),
+        score=decoded.score,
     )
 
 
@@ -287,56 +192,31 @@ def factorial_hmm_path_score(
     transition_probabilities: Sequence[torch.Tensor],
     *,
     noise_std: float,
+    max_joint_states: int = 512,
 ) -> torch.Tensor:
-    """Return the log score of one labeled per-appliance state path."""
+    """Score a labeled appliance path through the constructed joint HMM."""
 
     parameters = canonicalize_factorial_hmm(
         state_means, initial_probabilities, transition_probabilities
     )
-    values = _validate_observations(observations, parameters, noise_std)
-    if not isinstance(state_indices, torch.Tensor):
-        raise TypeError("state_indices must be a torch.Tensor.")
-    if state_indices.dtype not in _INTEGER_DTYPES or state_indices.ndim != 2:
-        raise TypeError("state_indices must be a two-dimensional integer tensor.")
-    expected_shape = (values.numel(), len(parameters.state_means))
-    if tuple(state_indices.shape) != expected_shape:
-        raise ValueError(f"state_indices must have shape {expected_shape}.")
-    if state_indices.device != values.device:
-        raise ValueError(f"state_indices must be on {values.device}.")
-    for appliance, means in enumerate(parameters.state_means):
-        states = state_indices[:, appliance]
-        if bool(((states < 0) | (states >= means.numel())).any()):
-            raise ValueError(
-                f"state_indices for appliance {appliance} must be between 0 and "
-                f"{means.numel() - 1}."
-            )
-
-    appliance_power = torch.stack(
-        [
-            means[state_indices[:, appliance]]
-            for appliance, means in enumerate(parameters.state_means)
-        ],
-        dim=1,
+    _joint_states, joint_means, initial, transition = _joint_model(
+        parameters, max_joint_states=max_joint_states
     )
-    scale = values.new_tensor(noise_std)
-    residual = (values - appliance_power.sum(dim=1)) / scale
-    score = (
-        -0.5 * residual.square() - torch.log(scale) - 0.5 * math.log(2.0 * math.pi)
-    ).sum()
-    for appliance, (initial, transition) in enumerate(
-        zip(
-            parameters.initial_probabilities,
-            parameters.transition_probabilities,
-            strict=True,
-        )
-    ):
-        states = state_indices[:, appliance]
-        score = score + torch.log(initial[states[0]])
-        if values.numel() > 1:
-            score = score + torch.log(transition[states[:-1], states[1:]]).sum()
-    if not bool(torch.isfinite(score)):
-        raise ValueError("state_indices describe a path forbidden by the model.")
-    return score
+    emissions = gaussian_log_emissions(observations, joint_means, noise_std=noise_std)
+    _validate_state_indices(state_indices, observations, parameters)
+    strides = [
+        math.prod(means.numel() for means in parameters.state_means[index + 1 :])
+        for index in range(len(parameters.state_means))
+    ]
+    joint_path = sum(
+        state_indices[:, appliance] * stride for appliance, stride in enumerate(strides)
+    )
+    try:
+        return hmm_path_score(joint_path, emissions, initial, transition)
+    except ValueError as exc:
+        raise ValueError(
+            "state_indices describe a path forbidden by the model."
+        ) from exc
 
 
 __all__ = [

--- a/nilmtk_contrib/torch/_hmm.py
+++ b/nilmtk_contrib/torch/_hmm.py
@@ -1,0 +1,279 @@
+"""Exact log-space HMM primitives shared by NILM state-space models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+
+import torch
+
+
+_FLOAT_DTYPES = frozenset({torch.float32, torch.float64})
+_INTEGER_DTYPES = frozenset(
+    {torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8}
+)
+
+
+@dataclass(frozen=True)
+class HMMViterbiResult:
+    """Highest-scoring state path under supplied log scores."""
+
+    states: torch.Tensor
+    score: float
+
+
+@dataclass(frozen=True)
+class GaussianHMMParameters:
+    """Validated Gaussian HMM parameters ordered by increasing state mean."""
+
+    state_means: torch.Tensor
+    initial_probabilities: torch.Tensor
+    transition_probabilities: torch.Tensor
+
+
+@dataclass(frozen=True)
+class GaussianHMMViterbiResult:
+    """Highest-scoring Gaussian HMM path and reconstructed state means."""
+
+    states: torch.Tensor
+    state_power: torch.Tensor
+    score: float
+
+
+def _floating_tensor(name, value, *, reference=None):
+    if not isinstance(value, torch.Tensor):
+        raise TypeError(f"{name} must be a torch.Tensor.")
+    if value.dtype not in _FLOAT_DTYPES or value.is_complex():
+        raise TypeError(f"{name} must use torch.float32 or torch.float64.")
+    if reference is not None and (
+        value.dtype != reference.dtype or value.device != reference.device
+    ):
+        raise ValueError(
+            f"{name} must use dtype {reference.dtype} and device {reference.device}."
+        )
+    return value
+
+
+def _log_score_tensor(name, value, *, reference=None):
+    value = _floating_tensor(name, value, reference=reference)
+    if bool(torch.isnan(value).any()) or bool(torch.isposinf(value).any()):
+        raise ValueError(f"{name} must not contain NaN or positive infinity.")
+    return value
+
+
+def _validate_log_scores(emission_scores, initial_scores, transition_scores):
+    emissions = _log_score_tensor("emission_scores", emission_scores)
+    if emissions.ndim != 2 or emissions.shape[0] < 1 or emissions.shape[1] < 2:
+        raise ValueError(
+            "emission_scores must have shape (time, states) with time >= 1 "
+            "and states >= 2."
+        )
+    time_points, states = emissions.shape
+    initial = _log_score_tensor("initial_scores", initial_scores, reference=emissions)
+    transition = _log_score_tensor(
+        "transition_scores", transition_scores, reference=emissions
+    )
+    if tuple(initial.shape) != (states,):
+        raise ValueError(f"initial_scores must have shape ({states},).")
+    if tuple(transition.shape) != (states, states):
+        raise ValueError(f"transition_scores must have shape ({states}, {states}).")
+    if not bool(torch.isfinite(initial).any()):
+        raise ValueError("initial_scores must allow at least one state.")
+    return int(time_points), int(states)
+
+
+@torch.no_grad()
+def hmm_viterbi(
+    emission_scores,
+    initial_scores,
+    transition_scores,
+) -> HMMViterbiResult:
+    """Decode an exact first-order HMM from log-domain model scores."""
+
+    time_points, states = _validate_log_scores(
+        emission_scores, initial_scores, transition_scores
+    )
+    scores = emission_scores.new_empty((time_points, states))
+    backpointers = torch.zeros(
+        (time_points, states), dtype=torch.int64, device=emission_scores.device
+    )
+    scores[0] = initial_scores + emission_scores[0]
+    for time in range(1, time_points):
+        candidates = scores[time - 1][:, None] + transition_scores
+        best_scores, best_sources = torch.max(candidates, dim=0)
+        scores[time] = best_scores + emission_scores[time]
+        backpointers[time] = best_sources
+
+    final_state = int(torch.argmax(scores[-1]))
+    final_score = scores[-1, final_state]
+    if not bool(torch.isfinite(final_score)):
+        raise ValueError("No valid HMM path reaches the sequence end.")
+    decoded = torch.empty(time_points, dtype=torch.int64, device=emission_scores.device)
+    decoded[-1] = final_state
+    for time in range(time_points - 1, 0, -1):
+        decoded[time - 1] = backpointers[time, decoded[time]]
+    return HMMViterbiResult(states=decoded, score=float(final_score))
+
+
+def hmm_path_score(states, emission_scores, initial_scores, transition_scores):
+    """Return the log score of one state path under the same HMM convention."""
+
+    time_points, state_count = _validate_log_scores(
+        emission_scores, initial_scores, transition_scores
+    )
+    if not isinstance(states, torch.Tensor):
+        raise TypeError("states must be a torch.Tensor.")
+    if states.dtype not in _INTEGER_DTYPES or states.ndim != 1:
+        raise TypeError("states must be a one-dimensional integer tensor.")
+    if states.device != emission_scores.device:
+        raise ValueError(f"states must be on {emission_scores.device}.")
+    if states.numel() != time_points:
+        raise ValueError(f"states must contain exactly {time_points} labels.")
+    if bool(((states < 0) | (states >= state_count)).any()):
+        raise ValueError(f"states labels must be between 0 and {state_count - 1}.")
+
+    time = torch.arange(time_points, device=emission_scores.device)
+    score = initial_scores[states[0]] + emission_scores[time, states].sum()
+    if time_points > 1:
+        score = score + transition_scores[states[:-1], states[1:]].sum()
+    if not bool(torch.isfinite(score)):
+        raise ValueError("states describe a path forbidden by the HMM scores.")
+    return score
+
+
+def _validate_probability_vector(name, value):
+    if not bool(torch.isfinite(value).all()) or bool((value < 0).any()):
+        raise ValueError(f"{name} must contain finite nonnegative values.")
+    tolerance = 1e-6 if value.dtype == torch.float32 else 1e-12
+    if not bool(
+        torch.isclose(value.sum(), value.new_tensor(1.0), atol=tolerance, rtol=0)
+    ):
+        raise ValueError(f"{name} must sum to one.")
+
+
+def _validate_transition_probabilities(name, value, states):
+    if tuple(value.shape) != (states, states):
+        raise ValueError(f"{name} must have shape ({states}, {states}).")
+    if not bool(torch.isfinite(value).all()) or bool((value < 0).any()):
+        raise ValueError(f"{name} must contain finite nonnegative values.")
+    tolerance = 1e-6 if value.dtype == torch.float32 else 1e-12
+    expected = torch.ones(states, dtype=value.dtype, device=value.device)
+    if not bool(torch.allclose(value.sum(dim=1), expected, atol=tolerance, rtol=0)):
+        raise ValueError(f"Every row of {name} must sum to one.")
+
+
+def canonicalize_gaussian_hmm(
+    state_means,
+    initial_probabilities,
+    transition_probabilities,
+) -> GaussianHMMParameters:
+    """Validate a Gaussian HMM and sort its states by increasing mean."""
+
+    means = _floating_tensor("state_means", state_means)
+    initial = _floating_tensor(
+        "initial_probabilities", initial_probabilities, reference=means
+    )
+    transition = _floating_tensor(
+        "transition_probabilities", transition_probabilities, reference=means
+    )
+    if means.ndim != 1 or means.numel() < 2:
+        raise ValueError("state_means must contain at least two states.")
+    if not bool(torch.isfinite(means).all()):
+        raise ValueError("state_means must contain only finite values.")
+    states = int(means.numel())
+    if tuple(initial.shape) != (states,):
+        raise ValueError(f"initial_probabilities must have shape ({states},).")
+    _validate_probability_vector("initial_probabilities", initial)
+    _validate_transition_probabilities("transition_probabilities", transition, states)
+    order = torch.argsort(means, stable=True)
+    return GaussianHMMParameters(
+        state_means=means[order],
+        initial_probabilities=initial[order],
+        transition_probabilities=transition[order][:, order],
+    )
+
+
+def gaussian_log_emissions(observations, state_means, *, noise_std):
+    """Return Gaussian log-emission scores for observations and state means."""
+
+    means = _floating_tensor("state_means", state_means)
+    values = _floating_tensor("observations", observations, reference=means)
+    if means.ndim != 1 or means.numel() < 2:
+        raise ValueError("state_means must contain at least two states.")
+    if values.ndim != 1 or values.numel() < 1:
+        raise ValueError("observations must be a nonempty one-dimensional tensor.")
+    if not bool(torch.isfinite(means).all()) or not bool(torch.isfinite(values).all()):
+        raise ValueError("observations and state_means must contain finite values.")
+    if isinstance(noise_std, bool) or not isinstance(noise_std, (int, float)):
+        raise TypeError("noise_std must be a positive finite number.")
+    if not math.isfinite(noise_std) or noise_std <= 0:
+        raise ValueError("noise_std must be a positive finite number.")
+    scale = values.new_tensor(noise_std)
+    residual = (values[:, None] - means[None, :]) / scale
+    return -0.5 * residual.square() - torch.log(scale) - 0.5 * math.log(2.0 * math.pi)
+
+
+def gaussian_hmm_viterbi(
+    observations,
+    state_means,
+    initial_probabilities,
+    transition_probabilities,
+    *,
+    noise_std,
+) -> GaussianHMMViterbiResult:
+    """Canonicalize and exactly decode a fixed-variance Gaussian HMM."""
+
+    parameters = canonicalize_gaussian_hmm(
+        state_means, initial_probabilities, transition_probabilities
+    )
+    emissions = gaussian_log_emissions(
+        observations, parameters.state_means, noise_std=noise_std
+    )
+    result = hmm_viterbi(
+        emissions,
+        torch.log(parameters.initial_probabilities),
+        torch.log(parameters.transition_probabilities),
+    )
+    return GaussianHMMViterbiResult(
+        states=result.states,
+        state_power=parameters.state_means[result.states],
+        score=result.score,
+    )
+
+
+def gaussian_hmm_path_score(
+    states,
+    observations,
+    state_means,
+    initial_probabilities,
+    transition_probabilities,
+    *,
+    noise_std,
+):
+    """Score one canonical-state path through a fixed-variance Gaussian HMM."""
+
+    parameters = canonicalize_gaussian_hmm(
+        state_means, initial_probabilities, transition_probabilities
+    )
+    emissions = gaussian_log_emissions(
+        observations, parameters.state_means, noise_std=noise_std
+    )
+    return hmm_path_score(
+        states,
+        emissions,
+        torch.log(parameters.initial_probabilities),
+        torch.log(parameters.transition_probabilities),
+    )
+
+
+__all__ = [
+    "GaussianHMMParameters",
+    "GaussianHMMViterbiResult",
+    "HMMViterbiResult",
+    "canonicalize_gaussian_hmm",
+    "gaussian_hmm_path_score",
+    "gaussian_hmm_viterbi",
+    "gaussian_log_emissions",
+    "hmm_path_score",
+    "hmm_viterbi",
+]

--- a/tests/test_hmm.py
+++ b/tests/test_hmm.py
@@ -1,0 +1,337 @@
+from itertools import product
+import inspect
+
+import pytest
+
+
+torch = pytest.importorskip("torch")
+
+from nilmtk_contrib.torch._hmm import (  # noqa: E402
+    canonicalize_gaussian_hmm,
+    gaussian_hmm_path_score,
+    gaussian_hmm_viterbi,
+    gaussian_log_emissions,
+    hmm_path_score,
+    hmm_viterbi,
+)
+
+
+def _log_scores(*, dtype=torch.float64, device="cpu"):
+    emission = torch.tensor(
+        [[0.7, -0.2], [0.5, 0.1], [-0.4, 0.9], [0.0, 0.8]],
+        dtype=dtype,
+        device=device,
+    )
+    initial = torch.log(torch.tensor([0.8, 0.2], dtype=dtype, device=device))
+    transition = torch.log(
+        torch.tensor([[0.75, 0.25], [0.3, 0.7]], dtype=dtype, device=device)
+    )
+    return emission, initial, transition
+
+
+def _gaussian_parameters(*, dtype=torch.float64, device="cpu"):
+    return (
+        torch.tensor([0.0, 100.0], dtype=dtype, device=device),
+        torch.tensor([0.9, 0.1], dtype=dtype, device=device),
+        torch.tensor([[0.8, 0.2], [0.1, 0.9]], dtype=dtype, device=device),
+    )
+
+
+def test_exact_hmm_matches_exhaustive_path_enumeration():
+    scores = _log_scores()
+    candidates = []
+    for labels in product(range(2), repeat=4):
+        states = torch.tensor(labels, dtype=torch.int64)
+        candidates.append((states, float(hmm_path_score(states, *scores))))
+    expected_states, expected_score = max(candidates, key=lambda item: item[1])
+
+    actual = hmm_viterbi(*scores)
+
+    assert actual.score == pytest.approx(expected_score, abs=1e-12)
+    assert torch.equal(actual.states, expected_states)
+
+
+def test_path_score_has_the_standard_initial_emission_transition_order():
+    emission, initial, transition = _log_scores()
+    states = torch.tensor([0, 0, 1, 1])
+
+    actual = hmm_path_score(states, emission, initial, transition)
+    expected = (
+        initial[0]
+        + emission[0, 0]
+        + transition[0, 0]
+        + emission[1, 0]
+        + transition[0, 1]
+        + emission[2, 1]
+        + transition[1, 1]
+        + emission[3, 1]
+    )
+
+    assert float(actual) == pytest.approx(float(expected), abs=1e-12)
+
+
+def test_path_score_is_differentiable_with_finite_gradients():
+    emission, initial, transition = _log_scores()
+    emission.requires_grad_()
+    initial.requires_grad_()
+    transition.requires_grad_()
+
+    score = hmm_path_score(torch.tensor([0, 0, 1, 1]), emission, initial, transition)
+    (-score).backward()
+
+    for value in (emission, initial, transition):
+        assert value.grad is not None
+        assert torch.isfinite(value.grad).all()
+
+
+def test_gaussian_hmm_recovers_known_state_path_and_power():
+    parameters = _gaussian_parameters()
+    observations = torch.tensor([0.0, 1.0, 99.0, 100.0], dtype=torch.float64)
+
+    result = gaussian_hmm_viterbi(observations, *parameters, noise_std=2.0)
+
+    assert result.states.tolist() == [0, 0, 1, 1]
+    assert result.state_power.tolist() == [0.0, 0.0, 100.0, 100.0]
+    assert result.score == pytest.approx(
+        float(
+            gaussian_hmm_path_score(
+                result.states,
+                observations,
+                *parameters,
+                noise_std=2.0,
+            )
+        ),
+        abs=1e-12,
+    )
+
+
+def test_gaussian_state_label_permutation_cannot_change_decode():
+    means, initial, transition = _gaussian_parameters()
+    observations = torch.tensor([0.0, 1.0, 99.0, 100.0], dtype=torch.float64)
+    expected = gaussian_hmm_viterbi(
+        observations, means, initial, transition, noise_std=2.0
+    )
+    order = torch.tensor([1, 0])
+
+    actual = gaussian_hmm_viterbi(
+        observations,
+        means[order],
+        initial[order],
+        transition[order][:, order],
+        noise_std=2.0,
+    )
+
+    assert torch.equal(actual.states, expected.states)
+    assert torch.equal(actual.state_power, expected.state_power)
+    assert actual.score == pytest.approx(expected.score, abs=1e-12)
+
+
+def test_gaussian_canonicalization_permutates_every_probability_axis():
+    means = torch.tensor([30.0, -2.0, 10.0], dtype=torch.float64)
+    initial = torch.tensor([0.1, 0.6, 0.3], dtype=torch.float64)
+    transition = torch.tensor(
+        [[0.7, 0.1, 0.2], [0.3, 0.6, 0.1], [0.2, 0.3, 0.5]],
+        dtype=torch.float64,
+    )
+
+    actual = canonicalize_gaussian_hmm(means, initial, transition)
+
+    assert actual.state_means.tolist() == [-2.0, 10.0, 30.0]
+    assert actual.initial_probabilities.tolist() == [0.6, 0.3, 0.1]
+    assert actual.transition_probabilities.tolist() == [
+        [0.6, 0.1, 0.3],
+        [0.3, 0.5, 0.2],
+        [0.1, 0.2, 0.7],
+    ]
+
+
+def test_zero_probabilities_are_forbidden_without_nan_scores():
+    dtype = torch.float64
+    emissions = torch.zeros((3, 2), dtype=dtype)
+    initial = torch.tensor([0.0, -torch.inf], dtype=dtype)
+    transition = torch.tensor([[0.0, -torch.inf], [-torch.inf, 0.0]], dtype=dtype)
+
+    result = hmm_viterbi(emissions, initial, transition)
+
+    assert result.states.tolist() == [0, 0, 0]
+    assert result.score == pytest.approx(0.0)
+    with pytest.raises(ValueError, match="forbidden"):
+        hmm_path_score(torch.tensor([0, 1, 1]), emissions, initial, transition)
+
+
+def test_impossible_hmm_fails_instead_of_returning_negative_infinity():
+    emissions = torch.tensor(
+        [[0.0, -torch.inf], [-torch.inf, 0.0]], dtype=torch.float64
+    )
+    initial = torch.tensor([0.0, -torch.inf], dtype=torch.float64)
+    transition = torch.tensor(
+        [[0.0, -torch.inf], [-torch.inf, 0.0]], dtype=torch.float64
+    )
+
+    with pytest.raises(ValueError, match="No valid HMM path"):
+        hmm_viterbi(emissions, initial, transition)
+
+
+def test_exact_ties_have_a_deterministic_first_state_path():
+    scores = (
+        torch.zeros((3, 2), dtype=torch.float64),
+        torch.zeros(2, dtype=torch.float64),
+        torch.zeros((2, 2), dtype=torch.float64),
+    )
+
+    first = hmm_viterbi(*scores)
+    second = hmm_viterbi(*scores)
+
+    assert first.states.tolist() == [0, 0, 0]
+    assert torch.equal(first.states, second.states)
+    assert first.score == second.score
+
+
+@pytest.mark.parametrize(
+    ("mutate", "error", "message"),
+    [
+        (lambda e, i, t: (e.tolist(), i, t), TypeError, "torch.Tensor"),
+        (lambda e, i, t: (e.long(), i, t), TypeError, "float32 or torch.float64"),
+        (lambda e, i, t: (e[0], i, t), ValueError, "shape"),
+        (lambda e, i, t: (e, i[:1], t), ValueError, "initial_scores"),
+        (lambda e, i, t: (e, i, t[:, :1]), ValueError, "transition_scores"),
+        (
+            lambda e, i, t: (e, torch.full_like(i, -torch.inf), t),
+            ValueError,
+            "at least one state",
+        ),
+        (
+            lambda e, i, t: (e.clone().fill_(float("nan")), i, t),
+            ValueError,
+            "NaN",
+        ),
+    ],
+)
+def test_log_score_validation_rejects_malformed_models(mutate, error, message):
+    with pytest.raises(error, match=message):
+        hmm_viterbi(*mutate(*_log_scores()))
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda m, i, t: (m[:1], i, t), "at least two states"),
+        (lambda m, i, t: (m, i.reshape(1, 2), t), "shape"),
+        (lambda m, i, t: (m, torch.tensor([0.8, 0.8]), t), "sum to one"),
+        (
+            lambda m, i, t: (m, torch.tensor([1.1, -0.1]), t),
+            "nonnegative",
+        ),
+        (lambda m, i, t: (m, i, t[:, :1]), "shape"),
+        (
+            lambda m, i, t: (
+                m,
+                i,
+                torch.tensor([[0.8, 0.1], [0.1, 0.9]]),
+            ),
+            "Every row",
+        ),
+    ],
+)
+def test_gaussian_probability_validation_rejects_malformed_models(mutate, message):
+    with pytest.raises(ValueError, match=message):
+        canonicalize_gaussian_hmm(*mutate(*_gaussian_parameters(dtype=torch.float32)))
+
+
+@pytest.mark.parametrize("noise_std", [0.0, -1.0, float("inf"), float("nan")])
+def test_gaussian_noise_scale_must_be_positive_and_finite(noise_std):
+    means, _, _ = _gaussian_parameters()
+
+    with pytest.raises(ValueError, match="positive finite"):
+        gaussian_log_emissions(
+            torch.zeros(2, dtype=torch.float64), means, noise_std=noise_std
+        )
+
+
+def test_gaussian_emission_contract_rejects_bad_shapes_values_and_scale_types():
+    means, _, _ = _gaussian_parameters()
+    cases = [
+        (torch.zeros(2, dtype=torch.float64), means[:1], 1.0, "two states"),
+        (torch.zeros(1, 2, dtype=torch.float64), means, 1.0, "one-dimensional"),
+        (
+            torch.tensor([0.0, float("nan")], dtype=torch.float64),
+            means,
+            1.0,
+            "finite",
+        ),
+    ]
+    for observations, state_means, scale, message in cases:
+        with pytest.raises(ValueError, match=message):
+            gaussian_log_emissions(observations, state_means, noise_std=scale)
+    with pytest.raises(TypeError, match="positive finite"):
+        gaussian_log_emissions(
+            torch.zeros(2, dtype=torch.float64), means, noise_std=True
+        )
+
+
+def test_state_path_contract_rejects_wrong_type_shape_length_and_labels():
+    scores = _log_scores()
+    cases = [
+        ([0, 0, 1, 1], TypeError, "torch.Tensor"),
+        (torch.zeros(4), TypeError, "integer"),
+        (torch.zeros(2, 2, dtype=torch.int64), TypeError, "one-dimensional"),
+        (torch.zeros(3, dtype=torch.int64), ValueError, "exactly 4"),
+        (torch.tensor([0, 0, 1, 2]), ValueError, "between 0 and 1"),
+    ]
+    for states, error, message in cases:
+        with pytest.raises(error, match=message):
+            hmm_path_score(states, *scores)
+
+
+def test_hmm_core_has_no_numpy_solver_or_probabilistic_package_dependency():
+    import nilmtk_contrib.torch._hmm as module
+
+    source = inspect.getsource(module)
+
+    for dependency in (
+        "numpy",
+        "pandas",
+        "cvxpy",
+        "hmmlearn",
+        "pomegranate",
+        "pyro",
+        "scipy",
+    ):
+        assert dependency not in source
+
+
+def test_factorial_hmm_delegates_decoding_to_the_shared_hmm(monkeypatch):
+    import nilmtk_contrib.torch._factorial_hmm as factorial_module
+
+    calls = []
+    exact_decoder = factorial_module.hmm_viterbi
+
+    def recording_decoder(*args):
+        calls.append(tuple(value.shape for value in args))
+        return exact_decoder(*args)
+
+    monkeypatch.setattr(factorial_module, "hmm_viterbi", recording_decoder)
+    means, initial, transition = _gaussian_parameters()
+    result = factorial_module.factorial_hmm_viterbi(
+        torch.tensor([0.0, 100.0], dtype=torch.float64),
+        (means,),
+        (initial,),
+        (transition,),
+        noise_std=2.0,
+    )
+
+    assert result.state_indices.flatten().tolist() == [0, 1]
+    assert calls == [((2, 2), (2,), (2, 2))]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_cpu_and_cuda_gaussian_decoding_agree():
+    observations = torch.tensor([0.0, 1.0, 99.0, 100.0], dtype=torch.float32)
+    parameters = _gaussian_parameters(dtype=torch.float32)
+    cpu = gaussian_hmm_viterbi(observations, *parameters, noise_std=2.0)
+    cuda_parameters = tuple(value.cuda() for value in parameters)
+    cuda = gaussian_hmm_viterbi(observations.cuda(), *cuda_parameters, noise_std=2.0)
+
+    assert torch.equal(cpu.states, cuda.states.cpu())
+    assert torch.allclose(cpu.state_power, cuda.state_power.cpu())
+    assert cpu.score == pytest.approx(cuda.score, abs=1e-5)


### PR DESCRIPTION
## Summary

- add a private exact log-space HMM Viterbi and path-scoring core
- add a validated fixed-variance Gaussian-HMM wrapper with canonical state ordering
- make the factorial-HMM oracle construct joint scores and delegate decoding to the HMM core
- remove the duplicated Viterbi implementation from the factorial layer
- cover exhaustive paths, score convention, zero-probability paths, impossible models, label permutation, gradients, delegation, and CPU/CUDA parity

Pomegranate remains a possible optional parity/fitting backend, not a runtime dependency for this small exact decoder.

## Verification

- focused HMM/FHMM: 56 passed, 2 CUDA skips; 99% combined coverage
- full suite: 1,172 passed, 91 skipped
- Ruff format/lint and uv lock check: pass
- wheel and sdist build: pass