### PR TITLE
Make FeatureMLP deterministic on CUDA

### DIFF
--- a/nilmtk_contrib/torch/_window_features.py
+++ b/nilmtk_contrib/torch/_window_features.py
@@ -143,8 +143,8 @@ class WindowFeatureExtractor(nn.Module):
         centered = values - mean
         differences = values.diff(dim=1)
         absolute_differences = differences.abs()
-        quartiles = torch.quantile(
-            values, values.new_tensor([0.25, 0.75]), dim=1
+        quantiles = torch.quantile(
+            values, values.new_tensor([0.25, 0.5, 0.75]), dim=1
         ).transpose(0, 1)
 
         time = torch.linspace(
@@ -187,8 +187,8 @@ class WindowFeatureExtractor(nn.Module):
                 values.std(dim=1, unbiased=False, keepdim=True),
                 values.amin(dim=1, keepdim=True),
                 values.amax(dim=1, keepdim=True),
-                values.median(dim=1, keepdim=True).values,
-                quartiles[:, 1:] - quartiles[:, :1],
+                quantiles[:, 1:2],
+                quantiles[:, 2:] - quantiles[:, :1],
                 torch.linalg.vector_norm(values, dim=1, keepdim=True)
                 / math.sqrt(self.sequence_length),
                 centered.abs().mean(dim=1, keepdim=True),

--- a/tests/test_feature_mlp.py
+++ b/tests/test_feature_mlp.py
@@ -342,3 +342,23 @@ def test_cpu_and_cuda_feature_extraction_agree():
     assert torch.allclose(cpu, cuda, atol=1e-5, rtol=1e-5)
     with pytest.raises(ValueError, match="model is on cpu"):
         FeatureMLPNetwork(9)(inputs.cuda())
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_cuda_feature_extraction_obeys_strict_determinism():
+    inputs = torch.tensor(
+        [[[4.0, 1.0, 4.0, 2.0, 4.0, 3.0, 2.0, 1.0, 4.0]]],
+        device="cuda",
+    )
+    was_enabled = torch.are_deterministic_algorithms_enabled()
+    was_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+    try:
+        torch.use_deterministic_algorithms(True)
+        first = WindowFeatureExtractor(9).cuda()(inputs)
+        second = WindowFeatureExtractor(9).cuda()(inputs)
+    finally:
+        torch.use_deterministic_algorithms(was_enabled, warn_only=was_warn_only)
+
+    assert torch.equal(first, second)
+    median = PREDICTION_FEATURE_NAMES.index("median")
+    assert first[0, median] == 3.0


### PR DESCRIPTION
## Problem
The first real NILMbench A100 run failed before training because torch.median with indices has no deterministic CUDA implementation. NILMbench correctly enables strict deterministic algorithms.

## Fix
- compute the 25th, 50th, and 75th percentiles in the existing torch.quantile call
- reuse the 50th percentile as the median, avoiding the nondeterministic indexed median kernel and an extra reduction
- add a tied-value CUDA regression that enables strict deterministic algorithms, runs twice, and restores global Torch state

## Verification
- exact patched operation on an A100 80 GB with strict determinism: 21 features, repeated outputs equal, median 3.0
- FeatureMLP tests: 31 passed, 2 local CUDA skips
- full contrib suite: 1,211 passed, 96 skipped
- Ruff clean
- wheel and sdist build

This keeps benchmark determinism strict; it does not downgrade the runner to warning-only mode.