### PR TITLE
Fit observed HMM parameters with PyTorch

### DIFF
--- a/nilmtk_contrib/torch/_hmm_fit.py
+++ b/nilmtk_contrib/torch/_hmm_fit.py
@@ -1,0 +1,180 @@
+"""Deterministic HMM parameter fitting from observed appliance power traces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Sequence
+
+import torch
+
+from nilmtk_contrib.torch._hmm import (
+    GaussianHMMParameters,
+    canonicalize_gaussian_hmm,
+)
+
+
+_FLOAT_DTYPES = frozenset({torch.float32, torch.float64})
+
+
+@dataclass(frozen=True)
+class ObservedGaussianHMMFit:
+    """Fitted parameters, canonical state paths, and convergence diagnostics."""
+
+    parameters: GaussianHMMParameters
+    state_sequences: tuple[torch.Tensor, ...]
+    loss_history: tuple[float, ...]
+    iterations: int
+    converged: bool
+
+
+def _positive_integer(name, value, *, minimum=1):
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be an integer.")
+    if value < minimum:
+        qualifier = "at least two" if minimum == 2 else "positive"
+        raise ValueError(f"{name} must be {qualifier}.")
+    return value
+
+
+def _finite_number(name, value, *, positive):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        qualifier = "positive" if positive else "nonnegative"
+        raise TypeError(f"{name} must be a finite {qualifier} number.")
+    value = float(value)
+    if not math.isfinite(value) or (value <= 0 if positive else value < 0):
+        qualifier = "positive" if positive else "nonnegative"
+        raise ValueError(f"{name} must be a finite {qualifier} number.")
+    return value
+
+
+def _validate_sequences(sequences):
+    if not isinstance(sequences, (tuple, list)) or not sequences:
+        raise ValueError("sequences must contain at least one power trace.")
+    validated = []
+    reference = None
+    for index, values in enumerate(sequences):
+        if not isinstance(values, torch.Tensor):
+            raise TypeError(f"sequences[{index}] must be a torch.Tensor.")
+        if values.dtype not in _FLOAT_DTYPES or values.is_complex():
+            raise TypeError(
+                f"sequences[{index}] must use torch.float32 or torch.float64."
+            )
+        if values.ndim != 1 or values.numel() < 1:
+            raise ValueError(
+                f"sequences[{index}] must be a nonempty one-dimensional tensor."
+            )
+        if not bool(torch.isfinite(values).all()):
+            raise ValueError(f"sequences[{index}] must contain only finite values.")
+        if bool((values < 0).any()):
+            raise ValueError(f"sequences[{index}] must contain nonnegative power.")
+        if reference is None:
+            reference = values
+        elif values.dtype != reference.dtype or values.device != reference.device:
+            raise ValueError(
+                f"sequences[{index}] must use dtype {reference.dtype} and device "
+                f"{reference.device}."
+            )
+        validated.append(values)
+    return tuple(validated)
+
+
+def _assign_states(values, means):
+    distances = (values[:, None] - means[None, :]).square()
+    states = torch.argmin(distances, dim=1)
+    loss = (values - means[states]).square().sum()
+    return states, float(loss)
+
+
+@torch.no_grad()
+def fit_observed_gaussian_hmm(
+    sequences: Sequence[torch.Tensor],
+    *,
+    n_states: int = 2,
+    max_iterations: int = 100,
+    tolerance: float = 1e-6,
+    pseudocount: float = 1.0,
+) -> ObservedGaussianHMMFit:
+    """Fit a discrete-state Gaussian HMM to observed appliance power.
+
+    State means are learned with deterministic one-dimensional Lloyd updates.
+    Initial and transition probabilities are then counted from the inferred
+    paths, preserving every supplied sequence boundary.  Positive additive
+    smoothing keeps all probability vectors and transition rows well-defined.
+    """
+
+    sequences = _validate_sequences(sequences)
+    n_states = _positive_integer("n_states", n_states, minimum=2)
+    max_iterations = _positive_integer("max_iterations", max_iterations)
+    tolerance = _finite_number("tolerance", tolerance, positive=False)
+    pseudocount = _finite_number("pseudocount", pseudocount, positive=True)
+    values = torch.cat(sequences)
+    unique_values = torch.unique(values, sorted=True)
+    if unique_values.numel() < n_states:
+        raise ValueError(
+            f"n_states={n_states} requires at least {n_states} distinct power "
+            f"values; received {unique_values.numel()}."
+        )
+
+    positions = torch.div(
+        torch.arange(n_states, device=values.device)
+        * (unique_values.numel() - 1),
+        n_states - 1,
+        rounding_mode="floor",
+    )
+    means = unique_values[positions]
+    states, loss = _assign_states(values, means)
+    loss_history = [loss]
+    converged = False
+
+    for iteration in range(1, max_iterations + 1):
+        updated_means = means.clone()
+        for state in range(n_states):
+            members = values[states == state]
+            if members.numel():
+                updated_means[state] = members.mean()
+        updated_states, updated_loss = _assign_states(values, updated_means)
+        loss_history.append(updated_loss)
+        improvement = loss - updated_loss
+        threshold = tolerance * max(1.0, abs(loss))
+        unchanged = torch.equal(updated_states, states)
+        means, states, loss = updated_means, updated_states, updated_loss
+        if unchanged or improvement <= threshold:
+            converged = True
+            break
+
+    order = torch.argsort(means, stable=True)
+    inverse_order = torch.empty_like(order)
+    inverse_order[order] = torch.arange(n_states, device=values.device)
+    means = means[order]
+    states = inverse_order[states]
+    lengths = [sequence.numel() for sequence in sequences]
+    state_sequences = tuple(torch.split(states, lengths))
+
+    initial_counts = means.new_full((n_states,), pseudocount)
+    transition_counts = means.new_full((n_states, n_states), pseudocount)
+    for sequence_states in state_sequences:
+        initial_counts[sequence_states[0]] += 1
+        if sequence_states.numel() > 1:
+            transitions = sequence_states[:-1] * n_states + sequence_states[1:]
+            transition_counts += torch.bincount(
+                transitions, minlength=n_states * n_states
+            ).reshape(n_states, n_states).to(means.dtype)
+
+    initial_probabilities = initial_counts / initial_counts.sum()
+    transition_probabilities = transition_counts / transition_counts.sum(
+        dim=1, keepdim=True
+    )
+    parameters = canonicalize_gaussian_hmm(
+        means, initial_probabilities, transition_probabilities
+    )
+    return ObservedGaussianHMMFit(
+        parameters=parameters,
+        state_sequences=state_sequences,
+        loss_history=tuple(loss_history),
+        iterations=iteration,
+        converged=converged,
+    )
+
+
+__all__ = ["ObservedGaussianHMMFit", "fit_observed_gaussian_hmm"]

--- a/tests/test_hmm_fit.py
+++ b/tests/test_hmm_fit.py
@@ -1,0 +1,224 @@
+from itertools import pairwise
+
+import pytest
+
+
+torch = pytest.importorskip("torch")
+
+from nilmtk_contrib.torch._coordinate_factorial_hmm import (  # noqa: E402
+    factorial_hmm_coordinate_viterbi,
+)
+from nilmtk_contrib.torch._hmm_fit import (  # noqa: E402
+    fit_observed_gaussian_hmm,
+)
+
+
+def _two_state_sequences(*, dtype=torch.float64, device="cpu"):
+    return (
+        torch.tensor([0.0, 0.0, 100.0, 100.0], dtype=dtype, device=device),
+        torch.tensor([0.0, 0.0, 100.0, 100.0], dtype=dtype, device=device),
+    )
+
+
+def test_known_states_produce_expected_smoothed_markov_parameters():
+    result = fit_observed_gaussian_hmm(_two_state_sequences(), pseudocount=1.0)
+
+    assert result.converged
+    assert result.parameters.state_means.tolist() == [0.0, 100.0]
+    assert result.parameters.initial_probabilities.tolist() == [0.75, 0.25]
+    assert result.parameters.transition_probabilities.tolist() == [
+        [0.5, 0.5],
+        [0.25, 0.75],
+    ]
+    assert [states.tolist() for states in result.state_sequences] == [
+        [0, 0, 1, 1],
+        [0, 0, 1, 1],
+    ]
+
+
+def test_sequence_boundaries_are_not_counted_as_transitions():
+    sequences = (
+        torch.tensor([0.0, 100.0], dtype=torch.float64),
+        torch.tensor([0.0, 100.0], dtype=torch.float64),
+    )
+
+    result = fit_observed_gaussian_hmm(sequences, pseudocount=1.0)
+
+    assert result.parameters.transition_probabilities.tolist() == [
+        [0.25, 0.75],
+        [0.5, 0.5],
+    ]
+    assert result.parameters.initial_probabilities.tolist() == [0.75, 0.25]
+
+
+def test_three_state_fit_is_canonical_and_loss_is_monotonic():
+    sequences = (
+        torch.tensor(
+            [0.0, 2.0, 1.0, 48.0, 52.0, 50.0, 98.0, 102.0, 100.0],
+            dtype=torch.float64,
+        ),
+    )
+
+    result = fit_observed_gaussian_hmm(sequences, n_states=3)
+
+    assert result.converged
+    assert result.iterations == len(result.loss_history) - 1
+    assert result.parameters.state_means.tolist() == [1.0, 50.0, 100.0]
+    assert all(right <= left for left, right in pairwise(result.loss_history))
+    assert result.state_sequences[0].tolist() == [0, 0, 0, 1, 1, 1, 2, 2, 2]
+
+
+def test_probability_contracts_hold_for_sparse_singleton_sequences():
+    sequences = tuple(
+        torch.tensor([value], dtype=torch.float64) for value in (0.0, 50.0, 100.0)
+    )
+
+    result = fit_observed_gaussian_hmm(
+        sequences, n_states=3, pseudocount=0.25
+    )
+    parameters = result.parameters
+
+    assert torch.all(parameters.initial_probabilities > 0)
+    assert torch.all(parameters.transition_probabilities > 0)
+    assert parameters.initial_probabilities.sum() == pytest.approx(1.0)
+    assert torch.allclose(
+        parameters.transition_probabilities.sum(dim=1),
+        torch.ones(3, dtype=torch.float64),
+    )
+
+
+def test_sequence_order_cannot_change_fitted_parameters():
+    first, second = _two_state_sequences()
+    expected = fit_observed_gaussian_hmm((first, second))
+    actual = fit_observed_gaussian_hmm((second, first))
+
+    assert torch.equal(actual.parameters.state_means, expected.parameters.state_means)
+    assert torch.equal(
+        actual.parameters.initial_probabilities,
+        expected.parameters.initial_probabilities,
+    )
+    assert torch.equal(
+        actual.parameters.transition_probabilities,
+        expected.parameters.transition_probabilities,
+    )
+
+
+def test_fit_is_deterministic_without_random_state():
+    sequences = (
+        torch.tensor([0.0, 1.0, 4.0, 48.0, 51.0, 99.0], dtype=torch.float64),
+    )
+
+    first = fit_observed_gaussian_hmm(sequences, n_states=3)
+    second = fit_observed_gaussian_hmm(sequences, n_states=3)
+
+    assert torch.equal(first.parameters.state_means, second.parameters.state_means)
+    assert torch.equal(first.state_sequences[0], second.state_sequences[0])
+    assert first.loss_history == second.loss_history
+    assert first.iterations == second.iterations
+
+
+def test_fitted_appliance_hmms_compose_with_coordinate_fhmm_inference():
+    dtype = torch.float64
+    appliance_traces = (
+        torch.tensor([0.0, 0.0, 80.0, 80.0], dtype=dtype),
+        torch.tensor([0.0, 30.0, 30.0, 0.0], dtype=dtype),
+    )
+    fits = tuple(
+        fit_observed_gaussian_hmm((trace,)) for trace in appliance_traces
+    )
+    result = factorial_hmm_coordinate_viterbi(
+        appliance_traces[0] + appliance_traces[1],
+        tuple(fit.parameters.state_means for fit in fits),
+        tuple(fit.parameters.initial_probabilities for fit in fits),
+        tuple(fit.parameters.transition_probabilities for fit in fits),
+        noise_std=1.0,
+    )
+
+    assert result.converged
+    assert torch.equal(
+        result.appliance_power,
+        torch.stack(appliance_traces, dim=1),
+    )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error", "message"),
+    [
+        ({"n_states": True}, TypeError, "integer"),
+        ({"n_states": 1}, ValueError, "at least two"),
+        ({"max_iterations": 0}, ValueError, "positive"),
+        ({"max_iterations": 1.5}, TypeError, "integer"),
+        ({"tolerance": True}, TypeError, "nonnegative"),
+        ({"tolerance": -1.0}, ValueError, "nonnegative"),
+        ({"tolerance": float("nan")}, ValueError, "nonnegative"),
+        ({"pseudocount": 0.0}, ValueError, "positive"),
+        ({"pseudocount": float("inf")}, ValueError, "positive"),
+    ],
+)
+def test_hyperparameter_contracts(kwargs, error, message):
+    with pytest.raises(error, match=message):
+        fit_observed_gaussian_hmm(_two_state_sequences(), **kwargs)
+
+
+@pytest.mark.parametrize(
+    ("sequences", "error", "message"),
+    [
+        ((), ValueError, "at least one"),
+        (([0.0, 1.0],), TypeError, "torch.Tensor"),
+        ((torch.tensor([], dtype=torch.float64),), ValueError, "nonempty"),
+        ((torch.zeros(1, 2, dtype=torch.float64),), ValueError, "one-dimensional"),
+        ((torch.tensor([0, 1]),), TypeError, "torch.float32 or torch.float64"),
+        (
+            (torch.tensor([0.0, float("nan")], dtype=torch.float64),),
+            ValueError,
+            "finite",
+        ),
+        (
+            (torch.tensor([-1.0, 0.0], dtype=torch.float64),),
+            ValueError,
+            "nonnegative",
+        ),
+        (
+            (
+                torch.tensor([0.0, 1.0], dtype=torch.float64),
+                torch.tensor([0.0, 1.0], dtype=torch.float32),
+            ),
+            ValueError,
+            "dtype",
+        ),
+    ],
+)
+def test_sequence_contracts(sequences, error, message):
+    with pytest.raises(error, match=message):
+        fit_observed_gaussian_hmm(sequences)
+
+
+def test_insufficient_distinct_power_values_fail_cleanly():
+    sequences = (torch.tensor([0.0, 0.0, 100.0], dtype=torch.float64),)
+
+    with pytest.raises(ValueError, match="requires at least 3 distinct"):
+        fit_observed_gaussian_hmm(sequences, n_states=3)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_cpu_and_cuda_fits_agree_under_strict_determinism():
+    cpu_sequences = _two_state_sequences(dtype=torch.float32)
+    torch.use_deterministic_algorithms(True)
+    try:
+        cpu = fit_observed_gaussian_hmm(cpu_sequences)
+        cuda = fit_observed_gaussian_hmm(
+            tuple(sequence.cuda() for sequence in cpu_sequences)
+        )
+    finally:
+        torch.use_deterministic_algorithms(False)
+
+    assert torch.equal(cpu.parameters.state_means, cuda.parameters.state_means.cpu())
+    assert torch.equal(
+        cpu.parameters.initial_probabilities,
+        cuda.parameters.initial_probabilities.cpu(),
+    )
+    assert torch.equal(
+        cpu.parameters.transition_probabilities,
+        cuda.parameters.transition_probabilities.cpu(),
+    )
+    assert cpu.loss_history == cuda.loss_history


### PR DESCRIPTION
## Summary
- fit Gaussian HMM state means from observed appliance traces with deterministic one-dimensional Lloyd updates
- estimate canonical initial and row-stochastic transition probabilities with positive smoothing
- preserve supplied trace boundaries so separate chunks do not create false transitions
- expose state paths, loss history, iteration count, and convergence status
- use only PyTorch and the shared HMM parameter contracts

This is the training layer for the public Torch AFHMM adapter. It is separate from inference PR #142 so each numerical component can be reviewed and merged independently.

## Property verification
- exact state means and smoothed Markov counts on known traces
- explicit proof that sequence boundaries are not counted as transitions
- monotonically nonincreasing clustering loss and canonical state labels
- valid positive probabilities for sparse singleton traces
- deterministic repeated fitting and sequence-order invariance
- clean failure for insufficient states, invalid power, mixed dtype/device, and invalid hyperparameters
- fitted appliance HMMs compose end-to-end with coordinate FHMM inference

## Verification
- full suite: 1,250 passed, 98 skipped
- HMM/FHMM family: 94 passed, 4 skipped before the final integration test
- focused fit suite: 25 passed, 1 local CUDA skip
- strict deterministic NVIDIA A100: CPU/GPU means and probabilities agree exactly
- full Ruff checks passed
- source distribution and wheel built
- git diff check passed