### PR TITLE
Share state-space data and strict JSON helpers

### DIFF
--- a/nilmtk_contrib/torch/_hsmm.py
+++ b/nilmtk_contrib/torch/_hsmm.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections import OrderedDict
 from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass, fields
-import json
 from numbers import Integral, Real
 import math
 from pathlib import Path
@@ -17,8 +16,12 @@ import torch
 from nilmtk_contrib.torch._base import TorchStateSpaceDisaggregator
 from nilmtk_contrib.torch._data import power_vector
 from nilmtk_contrib.torch._semi_markov import semi_markov_viterbi
+from nilmtk_contrib.torch._state_space_data import (
+    aligned_power_windows,
+    frame_index,
+)
 from nilmtk_contrib.torch._state_fitting import assign_states, fit_state_means
-from nilmtk_contrib.utils.checkpoints import save_json_atomic
+from nilmtk_contrib.utils.checkpoints import load_json_strict, save_json_atomic
 from nilmtk_contrib.utils.params import get_param, validate_positive_int
 
 
@@ -245,63 +248,6 @@ def _parameters_from_payload(payload, *, num_states, max_duration):
     return parameters
 
 
-def _reject_json_constant(value):
-    raise ValueError(f"Invalid JSON constant {value!r}.")
-
-
-def _unique_json_object(pairs):
-    result = {}
-    for key, value in pairs:
-        if key in result:
-            raise ValueError(f"Duplicate JSON key {key!r}.")
-        result[key] = value
-    return result
-
-
-def _as_power_tensor(frame, label) -> torch.Tensor:
-    values = power_vector(frame, label)
-    if bool((values < 0).any()):
-        raise ValueError(f"{label} must be non-negative.")
-    return torch.as_tensor(values, dtype=torch.float64, device="cpu").clone()
-
-
-def _frame_index(frame, length):
-    index = getattr(frame, "index", None)
-    return index if index is not None else pd.RangeIndex(length)
-
-
-def _aligned_windows(main_frames, target_frames, appliance_name):
-    if len(main_frames) != len(target_frames):
-        raise ValueError(
-            f"{appliance_name!r} has {len(target_frames)} chunks but mains has "
-            f"{len(main_frames)}."
-        )
-    mains = []
-    targets = []
-    for index, (main_frame, target_frame) in enumerate(zip(main_frames, target_frames)):
-        main = _as_power_tensor(main_frame, f"mains chunk {index}")
-        target = _as_power_tensor(
-            target_frame, f"{appliance_name!r} target chunk {index}"
-        )
-        if main.numel() != target.numel():
-            raise ValueError(
-                f"{appliance_name!r} target chunk {index} length does not match mains."
-            )
-        main_index = getattr(main_frame, "index", None)
-        target_index = getattr(target_frame, "index", None)
-        if (
-            main_index is not None
-            and target_index is not None
-            and not main_index.equals(target_index)
-        ):
-            raise ValueError(
-                f"{appliance_name!r} target chunk {index} index does not match mains."
-            )
-        mains.append(main)
-        targets.append(target)
-    return tuple(mains), tuple(targets)
-
-
 def _runs(states: torch.Tensor) -> tuple[tuple[int, int], ...]:
     labels = states.tolist()
     runs = []
@@ -506,15 +452,7 @@ class HSMM(TorchStateSpaceDisaggregator):
         if source is None:
             raise ValueError("HSMM load_model requires a checkpoint directory.")
         artifact_path = Path(source) / _ARTIFACT_FILENAME
-        try:
-            with artifact_path.open(encoding="utf-8") as handle:
-                payload = json.load(
-                    handle,
-                    parse_constant=_reject_json_constant,
-                    object_pairs_hook=_unique_json_object,
-                )
-        except (OSError, json.JSONDecodeError, ValueError) as exc:
-            raise ValueError(f"Could not load a valid HSMM artifact: {exc}") from exc
+        payload = load_json_strict(artifact_path, description="HSMM artifact")
         if not isinstance(payload, Mapping) or set(payload) != {
             "schema_version",
             "model_class",
@@ -610,7 +548,9 @@ class HSMM(TorchStateSpaceDisaggregator):
                 raise TypeError(
                     f"Training frames for {appliance_name!r} must be a sequence."
                 )
-            mains, targets = _aligned_windows(main_frames, list(frames), appliance_name)
+            mains, targets = aligned_power_windows(
+                main_frames, list(frames), appliance_name
+            )
             fitted[appliance_name] = _fit_hsmm(
                 mains,
                 targets,
@@ -638,7 +578,7 @@ class HSMM(TorchStateSpaceDisaggregator):
             values = power_vector(frame, f"mains chunk {chunk_index}", allow_empty=True)
             if bool((values < 0).any()):
                 raise ValueError(f"mains chunk {chunk_index} must be non-negative.")
-            output_index = _frame_index(frame, len(values))
+            output_index = frame_index(frame, len(values))
             columns = OrderedDict()
             for appliance_name, fitted in models.items():
                 prediction = (

--- a/nilmtk_contrib/torch/_state_space_data.py
+++ b/nilmtk_contrib/torch/_state_space_data.py
@@ -1,0 +1,63 @@
+"""Shared input contracts for supervised PyTorch state-space models."""
+
+from __future__ import annotations
+
+import pandas as pd
+import torch
+
+from nilmtk_contrib.torch._data import power_vector
+
+
+def as_power_tensor(frame, label) -> torch.Tensor:
+    """Return one finite, nonnegative power channel as an owned CPU tensor."""
+
+    values = power_vector(frame, label)
+    if bool((values < 0).any()):
+        raise ValueError(f"{label} must be non-negative.")
+    return torch.as_tensor(values, dtype=torch.float64, device="cpu").clone()
+
+
+def frame_index(frame, length):
+    """Preserve a frame index or construct a positional fallback."""
+
+    index = getattr(frame, "index", None)
+    return index if index is not None else pd.RangeIndex(length)
+
+
+def aligned_power_windows(main_frames, target_frames, appliance_name):
+    """Validate aligned mains and appliance chunks without joining boundaries."""
+
+    if len(main_frames) != len(target_frames):
+        raise ValueError(
+            f"{appliance_name!r} has {len(target_frames)} chunks but mains has "
+            f"{len(main_frames)}."
+        )
+    mains = []
+    targets = []
+    for index, (main_frame, target_frame) in enumerate(
+        zip(main_frames, target_frames, strict=True)
+    ):
+        main = as_power_tensor(main_frame, f"mains chunk {index}")
+        target = as_power_tensor(
+            target_frame, f"{appliance_name!r} target chunk {index}"
+        )
+        if main.numel() != target.numel():
+            raise ValueError(
+                f"{appliance_name!r} target chunk {index} length does not match mains."
+            )
+        main_index = getattr(main_frame, "index", None)
+        target_index = getattr(target_frame, "index", None)
+        if (
+            main_index is not None
+            and target_index is not None
+            and not main_index.equals(target_index)
+        ):
+            raise ValueError(
+                f"{appliance_name!r} target chunk {index} index does not match mains."
+            )
+        mains.append(main)
+        targets.append(target)
+    return tuple(mains), tuple(targets)
+
+
+__all__ = ["aligned_power_windows", "as_power_tensor", "frame_index"]

--- a/nilmtk_contrib/utils/checkpoints.py
+++ b/nilmtk_contrib/utils/checkpoints.py
@@ -142,6 +142,33 @@ def save_json_atomic(path, payload):
             temporary.unlink(missing_ok=True)
 
 
+def _reject_json_constant(value):
+    raise ValueError(f"Invalid JSON constant {value!r}.")
+
+
+def _unique_json_object(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"Duplicate JSON key {key!r}.")
+        result[key] = value
+    return result
+
+
+def load_json_strict(path, *, description="JSON artifact"):
+    """Load JSON while rejecting duplicate keys and non-standard constants."""
+
+    try:
+        with Path(path).open(encoding="utf-8") as handle:
+            return json.load(
+                handle,
+                parse_constant=_reject_json_constant,
+                object_pairs_hook=_unique_json_object,
+            )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise ValueError(f"Could not load a valid {description}: {exc}") from exc
+
+
 def load_metadata(path, *, expected_model_class=None, expected_backend=None):
     """Load and validate persistence metadata."""
     metadata_path = Path(path) / METADATA_FILENAME

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -7,6 +7,7 @@ from nilmtk_contrib.utils.checkpoints import (
     SCHEMA_VERSION,
     build_metadata,
     collect_dependencies,
+    load_json_strict,
     load_metadata,
     load_torch_state,
     managed_checkpoint_path,
@@ -85,6 +86,37 @@ def test_atomic_json_is_deterministic_host_readable_and_rejects_nan(tmp_path):
     with pytest.raises(ValueError, match="Out of range float values"):
         save_json_atomic(path, {"invalid": float("nan")})
     assert path.read_bytes() == first
+
+
+@pytest.mark.parametrize(
+    ("content", "message"),
+    [
+        ('{"key": 1, "key": 2}', "Duplicate JSON key"),
+        ('{"value": NaN}', "Invalid JSON constant"),
+        ('{"missing":', "Expecting value"),
+    ],
+)
+def test_strict_json_loader_rejects_ambiguous_or_invalid_artifacts(
+    tmp_path, content, message
+):
+    path = tmp_path / "artifact.json"
+    path.write_text(content, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="valid test artifact") as error:
+        load_json_strict(path, description="test artifact")
+
+    assert message in str(error.value)
+
+
+def test_strict_json_loader_returns_valid_content_and_wraps_io_errors(tmp_path):
+    path = tmp_path / "artifact.json"
+    path.write_text('{"value": 3}', encoding="utf-8")
+
+    assert load_json_strict(path) == {"value": 3}
+    with pytest.raises(ValueError, match="valid missing artifact"):
+        load_json_strict(
+            tmp_path / "missing.json", description="missing artifact"
+        )
 
 
 def test_load_metadata_rejects_missing_fields(tmp_path):

--- a/tests/test_state_space_data.py
+++ b/tests/test_state_space_data.py
@@ -1,0 +1,74 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+
+torch = pytest.importorskip("torch")
+
+from nilmtk_contrib.torch._state_space_data import (  # noqa: E402
+    aligned_power_windows,
+    as_power_tensor,
+    frame_index,
+)
+
+
+def test_power_tensor_is_owned_float64_and_nonnegative():
+    values = np.array([0.0, 10.0], dtype=np.float32)
+
+    tensor = as_power_tensor(values, "power")
+    values[1] = 99.0
+
+    assert tensor.dtype == torch.float64
+    assert tensor.device.type == "cpu"
+    assert tensor.tolist() == [0.0, 10.0]
+    with pytest.raises(ValueError, match="non-negative"):
+        as_power_tensor(np.array([0.0, -1.0]), "power")
+
+
+def test_aligned_windows_preserve_chunks_without_aliasing():
+    index = pd.date_range("2026-01-01", periods=3, freq="1min")
+    mains = [pd.DataFrame({"power": [10.0, 20.0, 30.0]}, index=index)]
+    targets = [pd.DataFrame({"power": [0.0, 10.0, 20.0]}, index=index)]
+
+    main_tensors, target_tensors = aligned_power_windows(mains, targets, "fridge")
+    mains[0].iloc[0, 0] = 999.0
+
+    assert len(main_tensors) == len(target_tensors) == 1
+    assert main_tensors[0].tolist() == [10.0, 20.0, 30.0]
+    assert target_tensors[0].tolist() == [0.0, 10.0, 20.0]
+
+
+@pytest.mark.parametrize(
+    ("targets", "message"),
+    [
+        ([], "chunks but mains"),
+        ([pd.DataFrame({"power": [0.0]})], "length does not match"),
+        (
+            [
+                pd.DataFrame(
+                    {"power": [0.0, 10.0]},
+                    index=pd.date_range("2027-01-01", periods=2, freq="1min"),
+                )
+            ],
+            "index does not match",
+        ),
+    ],
+)
+def test_aligned_windows_reject_mismatched_chunk_contracts(targets, message):
+    mains = [
+        pd.DataFrame(
+            {"power": [10.0, 20.0]},
+            index=pd.date_range("2026-01-01", periods=2, freq="1min"),
+        )
+    ]
+
+    with pytest.raises(ValueError, match=message):
+        aligned_power_windows(mains, targets, "fridge")
+
+
+def test_frame_index_preserves_labels_or_builds_range():
+    index = pd.date_range("2026-01-01", periods=2, freq="1min", tz="UTC")
+    frame = pd.DataFrame({"power": [1.0, 2.0]}, index=index)
+
+    assert frame_index(frame, 2).equals(index)
+    assert frame_index(np.array([1.0, 2.0]), 2).equals(pd.RangeIndex(2))


### PR DESCRIPTION
## Summary
- extract aligned mains/target validation, owned power tensors, and index preservation from HSMM into one state-space data module
- centralize strict JSON loading with duplicate-key, NaN/Infinity, malformed-input, and IO error handling
- migrate HSMM to both shared helpers without changing its numerical path or public API
- provide focused contracts for the reusable helpers

This removes the boilerplate that the upcoming Torch AFHMM adapter would otherwise duplicate.

## Parity and robustness verification
- every existing HSMM fitting, inference, persistence, and corrupt-artifact test remains green
- explicit tests cover tensor ownership, float64 conversion, nonnegative power, chunk count/length/index mismatches, and index fallback
- strict JSON tests reject duplicate keys, non-standard constants, malformed syntax, and missing files

## Verification
- full suite: 1,260 passed, 98 skipped
- focused checkpoint/state-space/HSMM suite: 56 passed, 1 skipped
- full Ruff checks passed
- source distribution and wheel built
- git diff check passed