### PR TITLE
Harden WindowGRU small-chunk training

### DIFF
--- a/nilmtk_contrib/torch/WindowGRU.py
+++ b/nilmtk_contrib/torch/WindowGRU.py
@@ -5,7 +5,13 @@ import numpy as np
 import pandas as pd
 
 from nilmtk_contrib.torch._base import TorchDisaggregator, torch_defaults
-from nilmtk_contrib.utils.model import legacy_print, module_logger, checkpoint_path
+from nilmtk_contrib.utils.checkpoints import (
+    load_torch_state,
+    save_torch_state,
+    temporary_checkpoint,
+)
+from nilmtk_contrib.utils.model import legacy_print, module_logger
+from nilmtk_contrib.utils.validation import train_validation_split
 
 logger = module_logger(__name__)
 _log_print = legacy_print(logger)
@@ -195,65 +201,85 @@ class WindowGRU(TorchDisaggregator):
             model = self.models[app_name]
             mains = train_main.reshape((-1, self.sequence_length, 1))
             app_reading = app_df.reshape((-1, 1))
-            
-            filepath = checkpoint_path(".pt")
-            
+
             # Convert to PyTorch tensors
             mains_tensor = torch.tensor(mains, dtype=torch.float32).permute(0, 2, 1)  # [B, 1, seq]
-            app_tensor = torch.tensor(app_reading, dtype=torch.float32).squeeze()     # [B]
-            
-            # Use validation split like TF (last 15% instead of random split)
-            # This follows the legacy TF validation split fraction.
-            n_total = len(mains_tensor)
-            val_size = max(1, int(0.15 * n_total)) if n_total > 1 else 0
-            train_size = n_total - val_size
-            
-            train_x = mains_tensor[:train_size].to(self.device)
-            val_x = mains_tensor[train_size:].to(self.device)
-            train_y = app_tensor[:train_size].to(self.device)
-            val_y = app_tensor[train_size:].to(self.device)
-            
+            app_tensor = torch.tensor(app_reading, dtype=torch.float32).reshape(-1)
+            split = train_validation_split(
+                mains_tensor,
+                app_tensor,
+                validation_fraction=0.15,
+                strategy="tail",
+                min_train=1,
+                min_val=1,
+                allow_no_validation=True,
+                rounding="floor",
+            )
+            if not split.metadata.should_train:
+                continue
+
+            train_x = split.X_train.to(self.device)
+            train_y = split.y_train.to(self.device)
+            val_x = (
+                split.X_val.to(self.device)
+                if split.metadata.validation_enabled
+                else None
+            )
+            val_y = (
+                split.y_val.to(self.device)
+                if split.metadata.validation_enabled
+                else None
+            )
+
             # Use Adam with TensorFlow-style default parameters.
             optimizer = torch.optim.Adam(model.parameters(), lr=0.001, betas=(0.9, 0.999), eps=1e-07, weight_decay=0.0)
             criterion = nn.MSELoss()
-            
-            best_val_loss = float('inf')
-            
+
             # Create DataLoader for training data with shuffle=True (like TF)
             train_dataset = TensorDataset(train_x, train_y)
             train_loader = DataLoader(train_dataset, batch_size=self.batch_size, shuffle=True)
-            
-            for epoch in range(self.n_epochs):
-                # Training phase
-                model.train()
-                train_loss = 0.0
-                num_batches = 0
-                
-                for batch_x, batch_y in train_loader:
-                    optimizer.zero_grad()
-                    outputs = model(batch_x).squeeze(-1)  # Ensure output shape matches target
-                    loss = criterion(outputs, batch_y)
-                    loss.backward()
-                    optimizer.step()
-                    train_loss += loss.item()
-                    num_batches += 1
-                
-                train_loss /= num_batches
-                
-                # Validation phase (evaluate on full validation set at once)
-                model.eval()
-                with torch.no_grad():
-                    val_outputs = model(val_x).squeeze(-1)
-                    val_loss = criterion(val_outputs, val_y).item()
-                
-                # Save best model (like ModelCheckpoint in TF with verbose=1)
-                if val_loss < best_val_loss:
-                    best_val_loss = val_loss
-                    torch.save(model.state_dict(), filepath)
-                    _log_print(f'Epoch {epoch+1}/{self.n_epochs} - loss: {train_loss:.4f} - val_loss: {val_loss:.4f}')
-                
-            # Load best weights (like TF version)
-            model.load_state_dict(torch.load(filepath))
+
+            best_val_loss = float('inf')
+            with temporary_checkpoint(".pt") as filepath:
+                for epoch in range(self.n_epochs):
+                    # Training phase
+                    model.train()
+                    train_loss = 0.0
+                    num_batches = 0
+
+                    for batch_x, batch_y in train_loader:
+                        optimizer.zero_grad()
+                        outputs = model(batch_x).squeeze(-1)  # Ensure output shape matches target
+                        loss = criterion(outputs, batch_y)
+                        loss.backward()
+                        optimizer.step()
+                        train_loss += loss.item()
+                        num_batches += 1
+
+                    train_loss /= num_batches
+
+                    if val_x is None:
+                        save_torch_state(model, filepath)
+                        _log_print(
+                            f'Epoch {epoch+1}/{self.n_epochs} - '
+                            f'loss: {train_loss:.4f}'
+                        )
+                        continue
+
+                    # Validation phase (evaluate on full validation set at once)
+                    model.eval()
+                    with torch.no_grad():
+                        val_outputs = model(val_x).squeeze(-1)
+                        val_loss = criterion(val_outputs, val_y).item()
+
+                    # Save best model (like ModelCheckpoint in TF with verbose=1)
+                    if val_loss < best_val_loss:
+                        best_val_loss = val_loss
+                        save_torch_state(model, filepath)
+                        _log_print(f'Epoch {epoch+1}/{self.n_epochs} - loss: {train_loss:.4f} - val_loss: {val_loss:.4f}')
+
+                if filepath.exists():
+                    load_torch_state(model, filepath, self.device)
     def disaggregate_chunk(self, test_main_list, model=None, do_preprocessing=True):
         self.require_models(model)
 

--- a/nilmtk_contrib/utils/validation.py
+++ b/nilmtk_contrib/utils/validation.py
@@ -85,6 +85,7 @@ def train_validation_split(
     min_train=1,
     min_val=1,
     allow_no_validation=False,
+    rounding="nearest",
 ):
     """Split arrays safely, avoiding empty train or validation sets."""
     if strategy not in {"tail", "random"}:
@@ -95,6 +96,8 @@ def train_validation_split(
         raise ValueError("min_train must be at least 1.")
     if min_val < 1:
         raise ValueError("min_val must be at least 1.")
+    if rounding not in {"nearest", "floor"}:
+        raise ValueError("rounding must be one of 'nearest' or 'floor'.")
 
     num_samples = _length(X)
     if _length(y) != num_samples:
@@ -147,7 +150,13 @@ def train_validation_split(
             metadata,
         )
 
-    validation_size = max(min_val, int(round(num_samples * validation_fraction)))
+    scaled_validation_size = num_samples * validation_fraction
+    validation_size = (
+        int(scaled_validation_size)
+        if rounding == "floor"
+        else int(round(scaled_validation_size))
+    )
+    validation_size = max(min_val, validation_size)
     validation_size = min(validation_size, num_samples - min_train)
     train_size = num_samples - validation_size
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -40,6 +40,25 @@ def test_tail_split_guarantees_validation_sample():
     assert split.y_val.tolist() == [109]
 
 
+def test_split_can_preserve_legacy_floor_rounding():
+    nearest = train_validation_split(
+        np.arange(10),
+        np.arange(10),
+        validation_fraction=0.15,
+    )
+    floored = train_validation_split(
+        np.arange(10),
+        np.arange(10),
+        validation_fraction=0.15,
+        rounding="floor",
+    )
+
+    assert nearest.metadata.validation_size == 2
+    assert floored.metadata.validation_size == 1
+    assert floored.X_train.tolist() == list(range(9))
+    assert floored.X_val.tolist() == [9]
+
+
 def test_tiny_dataset_skips_when_validation_is_required():
     split = train_validation_split(
         np.asarray([1]),
@@ -140,6 +159,7 @@ def test_split_rejects_invalid_arguments():
         {"validation_fraction": 1},
         {"min_train": 0},
         {"min_val": 0},
+        {"rounding": "ceiling"},
     ]
 
     for kwargs in invalid_cases:

--- a/tests/test_window_gru_training.py
+++ b/tests/test_window_gru_training.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+
+import nilmtk_contrib.torch.WindowGRU as window_gru_module
+from nilmtk_contrib.torch.WindowGRU import WindowGRU
+
+
+class TinyPointModel(torch.nn.Module):
+    def __init__(self, sequence_length):
+        super().__init__()
+        self.output = torch.nn.Linear(sequence_length, 1)
+
+    def forward(self, values):
+        return self.output(values.flatten(start_dim=1))
+
+
+def _model(sequence_length=5):
+    model = WindowGRU(
+        {
+            "sequence_length": sequence_length,
+            "n_epochs": 1,
+            "batch_size": 2,
+            "device": "cpu",
+            "seed": 123,
+            "verbose": False,
+        }
+    )
+    model.return_network = lambda: TinyPointModel(sequence_length)
+    return model
+
+
+def _training_data(num_windows, sequence_length=5):
+    mains = pd.DataFrame(
+        np.arange(num_windows * sequence_length, dtype=np.float32).reshape(
+            num_windows, sequence_length
+        )
+    )
+    appliance = pd.DataFrame(
+        np.linspace(1.0, 2.0, num_windows, dtype=np.float32).reshape(-1, 1)
+    )
+    return [mains], [("fridge", [appliance])]
+
+
+def test_single_window_trains_without_an_empty_validation_failure(monkeypatch):
+    model = _model()
+    train_main, train_appliances = _training_data(1)
+    saved_paths = []
+    loaded_paths = []
+    real_save = window_gru_module.save_torch_state
+    real_load = window_gru_module.load_torch_state
+
+    def recording_save(network, path):
+        saved_paths.append(Path(path))
+        real_save(network, path)
+
+    def recording_load(network, path, device):
+        loaded_paths.append((Path(path), device))
+        return real_load(network, path, device)
+
+    monkeypatch.setattr(window_gru_module, "save_torch_state", recording_save)
+    monkeypatch.setattr(window_gru_module, "load_torch_state", recording_load)
+
+    model.partial_fit(train_main, train_appliances, do_preprocessing=False)
+
+    assert list(model.models) == ["fridge"]
+    assert saved_paths
+    assert loaded_paths == [(saved_paths[-1], torch.device("cpu"))]
+    assert not saved_paths[-1].exists()
+    assert all(torch.isfinite(value).all() for value in model.models["fridge"].parameters())
+
+
+def test_tail_validation_still_trains_and_restores_the_best_weights():
+    model = _model()
+    train_main, train_appliances = _training_data(4)
+
+    model.partial_fit(train_main, train_appliances, do_preprocessing=False)
+
+    predictions = model.disaggregate_chunk(
+        train_main,
+        do_preprocessing=False,
+    )
+    assert len(predictions) == 1
+    assert predictions[0].shape == (4, 1)
+    assert np.isfinite(predictions[0].to_numpy()).all()


### PR DESCRIPTION
## Summary
- train a single WindowGRU window without creating an empty validation evaluation or a scalar target
- use the shared safe split and temporary checkpoint primitives
- preserve the legacy floor-based 15% tail split exactly for normal training chunks
- restore weights onto the configured device with tensor-only loading
- delete best-weight checkpoints immediately after training

## Verification
- 1,327 unit tests passed; 101 optional tests skipped
- 97 focused WindowGRU, split, and inference-alignment tests
- real WindowGRU architecture synthetic train/disaggregate smoke
- explicit one-window regression and checkpoint cleanup tests
- validation rounding/parity tests
- Ruff and git diff --check
- frozen lockfile, documentation contracts, sdist, and wheel